### PR TITLE
feat: add nodeselector, tolerations for zarf registry deployment using --set during `zarf init`

### DIFF
--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -34,6 +34,14 @@ spec:
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
+      {{ - with .Values.nodeSelector }}
+      nodeSelector:
+        {{ - toYaml . | nindent 12 }}
+      {{ - end }}
+      {{ - with .Values.tolerations }}
+      tolerations:
+        {{ - toYaml . | nindent 12 }}
+      {{ - end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -44,3 +44,9 @@ caBundle: ###ZARF_VAR_REGISTRY_CA_BUNDLE###
 
 extraEnvVars:
   ###ZARF_VAR_REGISTRY_EXTRA_ENVS###
+
+nodeSelector:
+  ###ZARF_VAR_REGISTRY_NODE_SELECTOR###
+
+tolerations:
+  ###ZARF_VAR_REGISTRY_TOLERATIONS###

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -58,6 +58,16 @@ variables:
     default: ""
     autoIndent: true
 
+  - name: REGISTRY_TOLERATIONS
+    description: Array of tolerations for the registry pod
+    default: ""
+    autoIndent: true
+
+  - name: REGISTRY_NODE_SELECTOR
+    description: Key value pairs of node selectors for the registry pod
+    default: ""
+    autoIndent: true
+
 constants:
   - name: REGISTRY_IMAGE
     value: "###ZARF_PKG_TMPL_REGISTRY_IMAGE###"


### PR DESCRIPTION
## Description

Allow setting nodeselector and tolerations for the zarf registry chart using `--set` while running `zarf init`

## Related Issue

Relates to #2176

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
