### PR TITLE
feat: revert "feat: remove .metadata.image from schema (#2606)"

### DIFF
--- a/src/types/package.go
+++ b/src/types/package.go
@@ -47,6 +47,7 @@ type ZarfMetadata struct {
 	Description       string `json:"description,omitempty" jsonschema:"description=Additional information about this package"`
 	Version           string `json:"version,omitempty" jsonschema:"description=Generic string set by a package author to track the package version (Note: ZarfInitConfigs will always be versioned to the CLIVersion they were created with)"`
 	URL               string `json:"url,omitempty" jsonschema:"description=Link to package information when online"`
+	Image             string `json:"image,omitempty" jsonschema:"description=An image URL to embed in this package (Reserved for future use in Zarf UI)"`
 	Uncompressed      bool   `json:"uncompressed,omitempty" jsonschema:"description=Disable compression of this package"`
 	Architecture      string `json:"architecture,omitempty" jsonschema:"description=The target cluster architecture for this package,example=arm64,example=amd64"`
 	YOLO              bool   `json:"yolo,omitempty" jsonschema:"description=Yaml OnLy Online (YOLO): True enables deploying a Zarf package without first running zarf init against the cluster. This is ideal for connected environments where you want to use existing VCS and container registries."`

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -1018,6 +1018,10 @@
           "type": "string",
           "description": "Link to package information when online"
         },
+        "image": {
+          "type": "string",
+          "description": "An image URL to embed in this package (Reserved for future use in Zarf UI)"
+        },
         "uncompressed": {
           "type": "boolean",
           "description": "Disable compression of this package"


### PR DESCRIPTION
This reverts commit ed2f876dc0ff2fed647b64d62f5a0843d41eed75.

## Description

We received feedback that people do have uses for the .metadata.images field. Adding it back

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
