### PR TITLE
refactor: remove use of os.Chdir

### DIFF
--- a/src/pkg/packager/creator/creator_test.go
+++ b/src/pkg/packager/creator/creator_test.go
@@ -26,13 +26,13 @@ func TestLoadPackageDefinition(t *testing.T) {
 			name:        "valid package definition",
 			testDir:     "valid",
 			expectedErr: "",
-			creator:     NewPackageCreator(types.ZarfCreateOptions{}, ""),
+			creator:     NewPackageCreator(types.ZarfCreateOptions{}),
 		},
 		{
 			name:        "invalid package definition",
 			testDir:     "invalid",
 			expectedErr: "package must have at least 1 component",
-			creator:     NewPackageCreator(types.ZarfCreateOptions{}, ""),
+			creator:     NewPackageCreator(types.ZarfCreateOptions{}),
 		},
 		{
 			name:        "valid package definition",

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -55,8 +55,7 @@ func updateRelativeDifferentialPackagePath(path string, cwd string) string {
 }
 
 // NewPackageCreator returns a new PackageCreator.
-func NewPackageCreator(createOpts types.ZarfCreateOptions, cwd string) *PackageCreator {
-	createOpts.DifferentialPackagePath = updateRelativeDifferentialPackagePath(createOpts.DifferentialPackagePath, cwd)
+func NewPackageCreator(createOpts types.ZarfCreateOptions) *PackageCreator {
 	return &PackageCreator{createOpts}
 }
 

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -39,36 +39,18 @@ type imageMap map[string]bool
 
 // FindImages iterates over a Zarf.yaml and attempts to parse any images.
 func (p *Packager) FindImages(ctx context.Context) (imgMap map[string][]string, err error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		// Return to the original working directory
-		if err := os.Chdir(cwd); err != nil {
-			message.Warnf("Unable to return to the original working directory: %s", err.Error())
-		}
-	}()
-	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
-		return nil, fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
-	}
 	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
-
-	c := creator.NewPackageCreator(p.cfg.CreateOpts, cwd)
-
-	if err := helpers.CreatePathAndCopy(layout.ZarfYAML, p.layout.ZarfYAML); err != nil {
+	c := creator.NewPackageCreator(p.cfg.CreateOpts)
+	if err := helpers.CreatePathAndCopy(filepath.Join(p.cfg.CreateOpts.BaseDir, layout.ZarfYAML), p.layout.ZarfYAML); err != nil {
 		return nil, err
 	}
-
 	p.cfg.Pkg, p.warnings, err = c.LoadPackageDefinition(ctx, p.layout)
 	if err != nil {
 		return nil, err
 	}
-
 	for _, warning := range p.warnings {
 		message.Warn(warning)
 	}
-
 	return p.findImages()
 }
 

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -7,7 +7,7 @@ package packager
 import (
 	"context"
 	"fmt"
-	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -48,13 +48,9 @@ func (p *Packager) Publish(ctx context.Context) (err error) {
 	}
 
 	if p.cfg.CreateOpts.IsSkeleton {
-		if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
-			return fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
-		}
-
 		sc := creator.NewSkeletonCreator(p.cfg.CreateOpts, p.cfg.PublishOpts)
-
-		if err := helpers.CreatePathAndCopy(layout.ZarfYAML, p.layout.ZarfYAML); err != nil {
+		err := helpers.CreatePathAndCopy(filepath.Join(p.cfg.CreateOpts.BaseDir, layout.ZarfYAML), p.layout.ZarfYAML)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Description

This change removes use of os.Chdir from exported code.

## Related Issue

Fixes #2682 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
