### PR TITLE
test: e2e waits

### DIFF
--- a/src/test/external/common.go
+++ b/src/test/external/common.go
@@ -5,12 +5,9 @@
 package external
 
 import (
-	"context"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/defenseunicorns/zarf/src/test"
@@ -30,31 +27,4 @@ func createPodInfoPackageWithInsecureSources(t *testing.T, temp string) {
 	err = exec.CmdWithPrint(zarfBinPath, "tools", "yq", "eval", ".spec.insecure = true", "-i", filepath.Join(temp, "oci", "podinfo-source.yaml"))
 	require.NoError(t, err, "unable to yq edit oci source")
 	exec.CmdWithPrint(zarfBinPath, "package", "create", temp, "--confirm", "--output", temp)
-}
-
-func verifyWaitSuccess(t *testing.T, timeoutMinutes time.Duration, cmd string, args []string, condition string, onTimeout string) bool {
-	timeout := time.After(timeoutMinutes * time.Minute)
-	for {
-		// delay check 3 seconds
-		time.Sleep(3 * time.Second)
-		select {
-		// on timeout abort
-		case <-timeout:
-			t.Error(onTimeout)
-
-			return false
-
-			// after delay, try running
-		default:
-			// Check information from the given command
-			stdOut, _, err := exec.CmdWithContext(context.TODO(), exec.PrintCfg(), cmd, args...)
-			// Log error
-			if err != nil {
-				t.Log(string(stdOut), err)
-			}
-			if strings.Contains(string(stdOut), condition) {
-				return true
-			}
-		}
-	}
 }

--- a/src/test/external/docker-compose.yml
+++ b/src/test/external/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   server:
     image: gitea/gitea:1.18.1

--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -75,7 +75,7 @@ func (suite *ExtInClusterTestSuite) SetupSuite() {
 			Name:      "gitea-0",
 		},
 	}
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer waitCancel()
 	err = pkgkubernetes.WaitForReady(waitCtx, c.Watcher, objs)
 	suite.NoError(err)


### PR DESCRIPTION
## Description

Using the built in --wait flag for docker compose rather than waiting ourselves. Additionally extending the wait time to be closer to what it was before changing to pkgWaits. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
