### PR TITLE
ci: run label check during merge group

### DIFF
--- a/.github/workflows/scan-labels.yml
+++ b/.github/workflows/scan-labels.yml
@@ -1,7 +1,8 @@
 name: Validate Labels
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, opened, edited, synchronize]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/scan-labels.yml
+++ b/.github/workflows/scan-labels.yml
@@ -1,7 +1,7 @@
 name: Validate Labels
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

For some reason the label check is required to be run on merge group push, but doesn't unless specified

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
