### PR TITLE
refactor: remove hpa modified from packager

### DIFF
--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -250,6 +250,10 @@ func (c *Cluster) RecordPackageDeployment(ctx context.Context, pkg types.ZarfPac
 // EnableRegHPAScaleDown enables the HPA scale down for the Zarf Registry.
 func (c *Cluster) EnableRegHPAScaleDown(ctx context.Context) error {
 	hpa, err := c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(ZarfNamespaceName).Get(ctx, "zarf-docker-registry", metav1.GetOptions{})
+	// Ignore not found error when HPA is disabled.
+	if kerrors.IsNotFound(err) {
+		return err
+	}
 	if err != nil {
 		return err
 	}
@@ -265,6 +269,10 @@ func (c *Cluster) EnableRegHPAScaleDown(ctx context.Context) error {
 // DisableRegHPAScaleDown disables the HPA scale down for the Zarf Registry.
 func (c *Cluster) DisableRegHPAScaleDown(ctx context.Context) error {
 	hpa, err := c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(ZarfNamespaceName).Get(ctx, "zarf-docker-registry", metav1.GetOptions{})
+	// Ignore not found error when HPA is disabled.
+	if kerrors.IsNotFound(err) {
+		return err
+	}
 	if err != nil {
 		return err
 	}

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -35,7 +35,6 @@ type Packager struct {
 	state          *types.ZarfState
 	cluster        *cluster.Cluster
 	layout         *layout.PackagePaths
-	hpaModified    bool
 	connectStrings types.ConnectStrings
 	sbomViewFiles  []string
 	source         sources.PackageSource

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -39,10 +39,12 @@ import (
 )
 
 func (p *Packager) resetRegistryHPA(ctx context.Context) {
-	if p.isConnectedToCluster() && p.hpaModified {
-		if err := p.cluster.EnableRegHPAScaleDown(ctx); err != nil {
-			message.Debugf("unable to reenable the registry HPA scale down: %s", err.Error())
-		}
+	if !p.isConnectedToCluster() {
+		return
+	}
+	err := p.cluster.EnableRegHPAScaleDown(ctx)
+	if err != nil {
+		message.Debugf("unable to reenable the registry HPA scale down: %s", err.Error())
 	}
 }
 
@@ -106,7 +108,6 @@ func (p *Packager) Deploy(ctx context.Context) error {
 		}
 	}
 
-	p.hpaModified = false
 	p.connectStrings = make(types.ConnectStrings)
 	// Reset registry HPA scale down whether an error occurs or not
 	defer p.resetRegistryHPA(ctx)
@@ -249,11 +250,6 @@ func (p *Packager) deployInitComponent(ctx context.Context, component types.Zarf
 		return nil, nil
 	}
 
-	if isRegistry {
-		// If we are deploying the registry then mark the HPA as "modified" to set it to Min later
-		p.hpaModified = true
-	}
-
 	// Before deploying the seed registry, start the injector
 	if isSeedRegistry {
 		err := p.cluster.StartInjection(ctx, p.layout.Base, p.layout.Images.Base, component.Images)
@@ -304,11 +300,10 @@ func (p *Packager) deployComponent(ctx context.Context, component types.ZarfComp
 		}
 
 		// Disable the registry HPA scale down if we are deploying images and it is not already disabled
-		if hasImages && !p.hpaModified && p.state.RegistryInfo.InternalRegistry {
-			if err := p.cluster.DisableRegHPAScaleDown(ctx); err != nil {
-				message.Debugf("unable to disable the registry HPA scale down: %s", err.Error())
-			} else {
-				p.hpaModified = true
+		if hasImages && p.state.RegistryInfo.InternalRegistry {
+			err := p.cluster.DisableRegHPAScaleDown(ctx)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -85,7 +85,6 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 	if !p.cfg.CreateOpts.NoYOLO {
 		p.cfg.Pkg.Metadata.YOLO = true
 	} else {
-		p.hpaModified = false
 		// Reset registry HPA scale down whether an error occurs or not
 		defer p.resetRegistryHPA(ctx)
 	}


### PR DESCRIPTION
## Description

This change removes the hpa modified property from packager. Instead it will always set the registry to the expected scale policy no matter if it has been modified or not. The additional API calls are worth the reduction in complexity.

A note for the future is that the purpose for disabling scale down of the registry has to be documented. It is not totally clear why this is done.

## Related Issue

Relates to #2694 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/.github/CONTRIBUTING.md#developer-workflow) followed
