### PR TITLE
refactor: rename image references

### DIFF
--- a/.github/workflows/publish-application-packages.yml
+++ b/.github/workflows/publish-application-packages.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.inputs.branchName }}
 
       - name: Install The Latest Release Version of Zarf
-        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
+        uses: defenseunicorns/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
 
       - name: "Login to GHCR"
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
@@ -39,11 +39,11 @@ jobs:
           zarf package create -o build -a arm64 examples/dos-games --signing-key=awskms:///${{ secrets.COSIGN_AWS_KMS_KEY }} --confirm
 
           # Publish a the signed dos-games package
-          zarf package publish ./build/zarf-package-dos-games-amd64-1.0.0.tar.zst oci://ghcr.io/defenseunicorns/packages --key=https://zarf.dev/cosign.pub
-          zarf package publish ./build/zarf-package-dos-games-arm64-1.0.0.tar.zst oci://ghcr.io/defenseunicorns/packages --key=https://zarf.dev/cosign.pub
+          zarf package publish ./build/zarf-package-dos-games-amd64-1.0.0.tar.zst oci://ghcr.io/zarf-dev/packages --key=https://zarf.dev/cosign.pub
+          zarf package publish ./build/zarf-package-dos-games-arm64-1.0.0.tar.zst oci://ghcr.io/zarf-dev/packages --key=https://zarf.dev/cosign.pub
 
           # Publish a skeleton of the dos-games package
-          zarf package publish examples/dos-games oci://ghcr.io/defenseunicorns/packages
+          zarf package publish examples/dos-games oci://ghcr.io/zarf-dev/packages
         env:
           AWS_REGION: ${{ secrets.COSIGN_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.COSIGN_AWS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
         run: |
           cp build/zarf build/zarf-linux-amd64
           cp build/zarf-arm build/zarf-linux-arm64
-          docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/zarf/agent:$GITHUB_REF_NAME .
+          docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/zarf-dev/zarf/agent:$GITHUB_REF_NAME .
           rm build/zarf-linux-amd64
           rm build/zarf-linux-arm64
-          echo ZARF_AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect ghcr.io/defenseunicorns/zarf/agent:$GITHUB_REF_NAME --format '{{ json . }}' | jq -r .manifest.digest) >> $GITHUB_ENV
+          echo ZARF_AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect ghcr.io/zarf-dev/zarf/agent:$GITHUB_REF_NAME --format '{{ json . }}' | jq -r .manifest.digest) >> $GITHUB_ENV
 
       - name: "Zarf Agent: Sign the Image"
-        run: cosign sign --key awskms:///${{ secrets.COSIGN_AWS_KMS_KEY }} -a release-engineer=https://github.com/${{ github.actor }} -a version=$GITHUB_REF_NAME ghcr.io/defenseunicorns/zarf/agent@$ZARF_AGENT_IMAGE_DIGEST -y
+        run: cosign sign --key awskms:///${{ secrets.COSIGN_AWS_KMS_KEY }} -a release-engineer=https://github.com/${{ github.actor }} -a version=$GITHUB_REF_NAME ghcr.io/zarf-dev/zarf/agent@$ZARF_AGENT_IMAGE_DIGEST -y
         env:
           COSIGN_EXPERIMENTAL: 1
           AWS_REGION: ${{ secrets.COSIGN_AWS_REGION }}
@@ -63,8 +63,8 @@ jobs:
 
       - name: Publish Init Package as OCI and Skeleton
         run: |
-          make publish-init-package ARCH=amd64 REPOSITORY_URL=ghcr.io/defenseunicorns/packages
-          make publish-init-package ARCH=arm64 REPOSITORY_URL=ghcr.io/defenseunicorns/packages
+          make publish-init-package ARCH=amd64 REPOSITORY_URL=ghcr.io/zerf-dev/packages
+          make publish-init-package ARCH=arm64 REPOSITORY_URL=ghcr.io/zarf-dev/packages
 
       # Create a CVE report based on this build
       - name: Create release time CVE report

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -73,7 +73,7 @@ jobs:
           chmod +x build/zarf
 
       - name: Install release version of Zarf
-        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
+        uses: defenseunicorns/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
         with:
           download-init-package: true
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build-local-agent-image: ## Build the Zarf agent image to be used in a locally b
 	@ if [ "$(ARCH)" = "amd64" ]; then cp build/zarf build/zarf-linux-amd64; fi
 	@ if [ "$(ARCH)" = "arm64" ] && [ ! -s ./build/zarf-arm ]; then $(MAKE) build-cli-linux-arm; fi
 	@ if [ "$(ARCH)" = "arm64" ]; then cp build/zarf-arm build/zarf-linux-arm64; fi
-	docker buildx build --load --platform linux/$(ARCH) --tag ghcr.io/defenseunicorns/zarf/agent:local .
+	docker buildx build --load --platform linux/$(ARCH) --tag ghcr.io/zarf-dev/zarf/agent:local .
 	@ if [ "$(ARCH)" = "amd64" ]; then rm build/zarf-linux-amd64; fi
 	@ if [ "$(ARCH)" = "arm64" ]; then rm build/zarf-linux-arm64; fi
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -17,7 +17,7 @@ import (
 
 // Zarf Global Configuration Constants.
 const (
-	GithubProject = "defenseunicorns/zarf"
+	GithubProject = "zarf-dev/zarf"
 
 	ZarfAgentHost = "agent-hook.zarf.svc"
 

--- a/src/pkg/zoci/utils.go
+++ b/src/pkg/zoci/utils.go
@@ -43,5 +43,5 @@ func ReferenceFromMetadata(registryLocation string, metadata *types.ZarfMetadata
 
 // GetInitPackageURL returns the URL for the init package for the given version.
 func GetInitPackageURL(version string) string {
-	return fmt.Sprintf("ghcr.io/defenseunicorns/packages/init:%s", version)
+	return fmt.Sprintf("ghcr.io/zarf-dev/packages/init:%s", version)
 }

--- a/src/test/e2e/08_create_differential_test.go
+++ b/src/test/e2e/08_create_differential_test.go
@@ -73,7 +73,7 @@ func TestCreateDifferential(t *testing.T) {
 	/* Validate we have ONLY the images we expect to have */
 	expectedImages := []string{
 		"ghcr.io/stefanprodan/podinfo:latest",
-		"ghcr.io/defenseunicorns/zarf/agent:v0.26.0",
+		"ghcr.io/zarf-dev/zarf/agent:v0.26.0",
 	}
 	require.Len(t, actualImages, 2, "zarf.yaml from the differential package does not contain the correct number of images")
 	for _, expectedImage := range expectedImages {

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -42,7 +42,7 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	out := fmt.Sprintf("zarf-package-dos-games-%s-1.0.0.tar.zst", e2e.Arch)
 
 	// Build the fully qualified reference.
-	ref := fmt.Sprintf("oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0-%s", e2e.Arch)
+	ref := fmt.Sprintf("oci://ghcr.io/zarf-dev/packages/dos-games:1.0.0-%s", e2e.Arch)
 
 	// Pull the package via OCI.
 	stdOut, stdErr, err := e2e.Zarf("package", "pull", ref)
@@ -74,7 +74,7 @@ func (suite *PullInspectTestSuite) Test_1_Remote_Inspect() {
 
 	// Test inspect on a public package.
 	// NOTE: This also makes sure that Zarf does not attempt auth when inspecting a public package.
-	ref := fmt.Sprintf("oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0-%s", e2e.Arch)
+	ref := fmt.Sprintf("oci://ghcr.io/zarf-dev/packages/dos-games:1.0.0-%s", e2e.Arch)
 	_, stdErr, err = e2e.Zarf("package", "inspect", ref)
 	suite.NoError(err, stdErr)
 }

--- a/src/test/e2e/13_find_images_test.go
+++ b/src/test/e2e/13_find_images_test.go
@@ -53,7 +53,7 @@ func TestFindImages(t *testing.T) {
 
 		stdOut, _, err := e2e.Zarf("prepare", "find-images", ".", "--registry-url", registry, "--create-set", fmt.Sprintf("agent_image_tag=%s", agentTag))
 		require.NoError(t, err)
-		internalRegistryImage := fmt.Sprintf("%s/%s:%s", registry, "defenseunicorns/zarf/agent", agentTag)
+		internalRegistryImage := fmt.Sprintf("%s/%s:%s", registry, "zarf-dev/zarf/agent", agentTag)
 		require.Contains(t, stdOut, internalRegistryImage, "registry image should be found with registry url")
 		require.Contains(t, stdOut, "busybox:latest", "Busybox image should be found as long as helm chart doesn't error")
 

--- a/src/test/e2e/14_create_sha_index_test.go
+++ b/src/test/e2e/14_create_sha_index_test.go
@@ -21,7 +21,7 @@ func TestCreateIndexShaErrors(t *testing.T) {
 		{
 			name:                  "Image Index",
 			packagePath:           "src/test/packages/14-index-sha/image-index",
-			expectedImageInStderr: "ghcr.io/defenseunicorns/zarf/agent:v0.32.6@sha256:b3fabdc7d4ecd0f396016ef78da19002c39e3ace352ea0ae4baa2ce9d5958376",
+			expectedImageInStderr: "ghcr.io/zarf-dev/zarf/agent:v0.32.6@sha256:b3fabdc7d4ecd0f396016ef78da19002c39e3ace352ea0ae4baa2ce9d5958376",
 		},
 		{
 			name:                  "Manifest List",

--- a/src/test/e2e/21_connect_creds_test.go
+++ b/src/test/e2e/21_connect_creds_test.go
@@ -88,7 +88,7 @@ func connectToZarfServices(ctx context.Context, t *testing.T) {
 	// We assert greater than or equal to since the base init has 8 images
 	// HOWEVER during an upgrade we could have mismatched versions/names resulting in more images
 	require.GreaterOrEqual(t, len(registryList), 3)
-	require.Contains(t, stdOut, "defenseunicorns/zarf/agent")
+	require.Contains(t, stdOut, "zarf-dev/zarf/agent")
 	require.Contains(t, stdOut, "gitea/gitea")
 	require.Contains(t, stdOut, "library/registry")
 

--- a/src/test/packages/00-remote-pull-fail/zarf.yaml
+++ b/src/test/packages/00-remote-pull-fail/zarf.yaml
@@ -5,4 +5,4 @@ components:
   - name: doesnotexist-docker
     required: true
     images:
-      - ghcr.io/defenseunicorns/doesnotexist:1.3.3.7
+      - ghcr.io/zarf-dev/doesnotexist:1.3.3.7

--- a/src/test/packages/08-differential-package/zarf.yaml
+++ b/src/test/packages/08-differential-package/zarf.yaml
@@ -9,7 +9,7 @@ components:
     required: true
     images:
       - ghcr.io/stefanprodan/podinfo:6.0.0
-      - ghcr.io/defenseunicorns/zarf/agent:###ZARF_PKG_TMPL_PACKAGE_VERSION###
+      - ghcr.io/zarf-dev/zarf/agent:###ZARF_PKG_TMPL_PACKAGE_VERSION###
     repos:
       - https://github.com/defenseunicorns/zarf.git@c74e2e9626da0400e0a41e78319b3054c53a5d4e
       - https://github.com/defenseunicorns/zarf.git@refs/tags/###ZARF_PKG_TMPL_PACKAGE_VERSION###

--- a/src/test/packages/14-index-sha/image-index/zarf.yaml
+++ b/src/test/packages/14-index-sha/image-index/zarf.yaml
@@ -6,4 +6,4 @@ components:
   - name: baseline
     required: true
     images:
-      - ghcr.io/defenseunicorns/zarf/agent:v0.32.6@sha256:05a82656df5466ce17c3e364c16792ae21ce68438bfe06eeab309d0520c16b48
+      - ghcr.io/zarf-dev/zarf/agent:v0.32.6@sha256:05a82656df5466ce17c3e364c16792ae21ce68438bfe06eeab309d0520c16b48

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -1,7 +1,7 @@
 [package.create.set]
 # The image reference to use for the Zarf agent, defaults to a locally built image
 agent_image_domain = 'ghcr.io/'
-agent_image = 'defenseunicorns/zarf/agent'
+agent_image = 'zarf-dev/zarf/agent'
 agent_image_tag = 'local'
 
 # Tag for the zarf injector binary to use


### PR DESCRIPTION
## Description

This change renames the image references to the new Zarf Dev.

## Related Issue

Relates to #2732

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
