### PR TITLE
chore: move public test repo

### DIFF
--- a/.github/workflows/build-rust-injector.yml
+++ b/.github/workflows/build-rust-injector.yml
@@ -2,6 +2,7 @@ name: Zarf Injector Rust Binaries
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dummy-dco.yaml
+++ b/.github/workflows/dummy-dco.yaml
@@ -1,0 +1,12 @@
+name: DCO
+on:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"

--- a/examples/git-data/zarf.yaml
+++ b/examples/git-data/zarf.yaml
@@ -8,30 +8,30 @@ components:
   - name: full-repo
     repos:
       # The following performs a full Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git
+      - https://github.com/zarf-dev/zarf-public-test.git
       # The following performs a full Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test
 
   - name: specific-tag
     repos:
       # The following performs a tag Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@v0.0.1
+      - https://github.com/zarf-dev/zarf-public-test.git@v0.0.1
       # The following performs a refspec tag Git Repo Mirror with `go-git`
-      - https://github.com/defenseunicorns/zarf-public-test.git@refs/tags/v0.0.1
+      - https://github.com/zarf-dev/zarf-public-test.git@refs/tags/v0.0.1
       # The following performs a tag Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1
 
   - name: specific-branch
     repos:
       # The following performs a branch Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@refs/heads/dragons
+      - https://github.com/zarf-dev/zarf-public-test.git@refs/heads/dragons
       # The following performs a branch Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@refs/heads/dragons
 
   - name: specific-hash
     repos:
       # The following performs a SHA Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@01a23218923f24194133b5eb11268cf8d73ff1bb
+      - https://github.com/zarf-dev/zarf-public-test.git@01a23218923f24194133b5eb11268cf8d73ff1bb
       # The following performs a SHA Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@01a23218923f24194133b5eb11268cf8d73ff1bb
 

--- a/src/pkg/packager/lint/lint_test.go
+++ b/src/pkg/packager/lint/lint_test.go
@@ -196,7 +196,7 @@ func TestValidateComponent(t *testing.T) {
 
 	t.Run("Unpinnned repo warning", func(t *testing.T) {
 		t.Parallel()
-		unpinnedRepo := "https://github.com/defenseunicorns/zarf-public-test.git"
+		unpinnedRepo := "https://github.com/zarf-dev/zarf-public-test.git"
 		component := types.ZarfComponent{Repos: []string{
 			unpinnedRepo,
 			"https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1",

--- a/src/test/e2e/07_create_git_test.go
+++ b/src/test/e2e/07_create_git_test.go
@@ -26,7 +26,7 @@ func TestCreateGit(t *testing.T) {
 	defer e2e.CleanFiles(extractDir)
 
 	// Verify the full-repo component
-	gitDir := fmt.Sprintf("%s/components/full-repo/repos/zarf-public-test-1143224168/.git", extractDir)
+	gitDir := fmt.Sprintf("%s/components/full-repo/repos/zarf-public-test-2395699829/.git", extractDir)
 	verifyGitRepo(t, gitDir,
 		"0a6b587", "(HEAD -> main, online-upstream/main)", "Adjust dragon spacing",
 		"v0.0.1\n", "  dragons\n* main\n")
@@ -38,13 +38,13 @@ func TestCreateGit(t *testing.T) {
 		"v0.0.1\n", "  dragons\n* main\n")
 
 	// Verify specific tag component shorthand tag
-	gitDir = fmt.Sprintf("%s/components/specific-tag/repos/zarf-public-test-443792367/.git", extractDir)
+	gitDir = fmt.Sprintf("%s/components/specific-tag/repos/zarf-public-test-470731282/.git", extractDir)
 	verifyGitRepo(t, gitDir,
 		"5249809", "(HEAD -> zarf-ref-v0.0.1, tag: v0.0.1)", "Added README.md",
 		"v0.0.1\n", "* zarf-ref-v0.0.1\n")
 
 	// Verify specific tag component refspec tag
-	gitDir = fmt.Sprintf("%s/components/specific-tag/repos/zarf-public-test-1981411475/.git", extractDir)
+	gitDir = fmt.Sprintf("%s/components/specific-tag/repos/zarf-public-test-482869567/.git", extractDir)
 	verifyGitRepo(t, gitDir,
 		"5249809", "(HEAD -> zarf-ref-v0.0.1, tag: v0.0.1)", "Added README.md",
 		"v0.0.1\n", "* zarf-ref-v0.0.1\n")
@@ -56,7 +56,7 @@ func TestCreateGit(t *testing.T) {
 		"v0.0.1\n", "* zarf-ref-v0.0.1\n")
 
 	// Verify specific branch component
-	gitDir = fmt.Sprintf("%s/components/specific-branch/repos/zarf-public-test-1670574289/.git", extractDir)
+	gitDir = fmt.Sprintf("%s/components/specific-branch/repos/zarf-public-test-2265377406/.git", extractDir)
 	verifyGitRepo(t, gitDir,
 		"01a2321", "(HEAD -> dragons, online-upstream/dragons)", "Explain what this repo does",
 		"", "* dragons\n")
@@ -68,7 +68,7 @@ func TestCreateGit(t *testing.T) {
 		"", "* dragons\n")
 
 	// Verify specific hash component
-	gitDir = fmt.Sprintf("%s/components/specific-hash/repos/zarf-public-test-2357350897/.git", extractDir)
+	gitDir = fmt.Sprintf("%s/components/specific-hash/repos/zarf-public-test-3231174532/.git", extractDir)
 	verifyGitRepo(t, gitDir,
 		"01a2321", "(HEAD -> zarf-ref-01a23218923f24194133b5eb11268cf8d73ff1bb, online-upstream/dragons)", "Explain what this repo does",
 		"v0.0.1\n", "  main\n* zarf-ref-01a23218923f24194133b5eb11268cf8d73ff1bb\n")

--- a/src/test/e2e/09_component_compose_test.go
+++ b/src/test/e2e/09_component_compose_test.go
@@ -139,8 +139,8 @@ func (suite *CompositionSuite) Test_1_FullComposability() {
   - ghcr.io/stefanprodan/podinfo:6.4.0
   - ghcr.io/stefanprodan/podinfo:6.4.1
   repos:
-  - https://github.com/defenseunicorns/zarf-public-test.git
-  - https://github.com/defenseunicorns/zarf-public-test.git@refs/heads/dragons
+  - https://github.com/zarf-dev/zarf-public-test.git
+  - https://github.com/zarf-dev/zarf-public-test.git@refs/heads/dragons
 `)
 
 	// Check dataInjections

--- a/src/test/e2e/22_git_and_gitops_test.go
+++ b/src/test/e2e/22_git_and_gitops_test.go
@@ -77,7 +77,7 @@ func testGitServerReadOnly(ctx context.Context, t *testing.T, gitURL string) {
 	gitCfg := git.New(zarfState.GitServer)
 
 	// Get the repo as the readonly user
-	repoName := "zarf-public-test-2469062884"
+	repoName := "zarf-public-test-2363058019"
 	getRepoRequest, _ := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/repos/%s/%s", gitURL, zarfState.GitServer.PushUsername, repoName), nil)
 	getRepoResponseBody, _, err := gitCfg.DoHTTPThings(getRepoRequest, types.ZarfGitReadUser, zarfState.GitServer.PullPassword)
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func testGitServerTagAndHash(ctx context.Context, t *testing.T, gitURL string) {
 	// Init the state variable
 	zarfState, err := c.LoadZarfState(ctx)
 	require.NoError(t, err, "Failed to load Zarf state")
-	repoName := "zarf-public-test-2469062884"
+	repoName := "zarf-public-test-2363058019"
 
 	gitCfg := git.New(zarfState.GitServer)
 

--- a/src/test/packages/09-composable-packages/sub-package/zarf.yaml
+++ b/src/test/packages/09-composable-packages/sub-package/zarf.yaml
@@ -26,7 +26,7 @@ components:
     images:
       - ghcr.io/stefanprodan/podinfo:6.4.0
     repos:
-      - https://github.com/defenseunicorns/zarf-public-test.git
+      - https://github.com/zarf-dev/zarf-public-test.git
     files:
       - source: ../files/coffee-ipsum.txt
         target: coffee-ipsum.txt

--- a/src/test/packages/09-composable-packages/zarf.yaml
+++ b/src/test/packages/09-composable-packages/zarf.yaml
@@ -40,7 +40,7 @@ components:
     images:
       - ghcr.io/stefanprodan/podinfo:6.4.1
     repos:
-      - https://github.com/defenseunicorns/zarf-public-test.git@refs/heads/dragons
+      - https://github.com/zarf-dev/zarf-public-test.git@refs/heads/dragons
     files:
       - source: files/coffee-ipsum.txt
         target: coffee-ipsum.txt

--- a/src/test/packages/12-lint/zarf.yaml
+++ b/src/test/packages/12-lint/zarf.yaml
@@ -14,7 +14,7 @@ components:
 
   - name: full-repo
     repos:
-    - https://github.com/defenseunicorns/zarf-public-test.git
+    - https://github.com/zarf-dev/zarf-public-test.git
     - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1
     - https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads
     images:

--- a/src/test/packages/22-git-data/zarf.yaml
+++ b/src/test/packages/22-git-data/zarf.yaml
@@ -9,7 +9,7 @@ components:
     required: true
     repos:
       # Do a full Git Repo Mirror
-      - https://github.com/defenseunicorns/zarf-public-test.git
+      - https://github.com/zarf-dev/zarf-public-test.git
       # The following performs a full Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test
       # Perform a full repo mirror of a simple repository with a single branch - (this causes an "already up to date" error in go-git)
@@ -19,9 +19,9 @@ components:
     required: true
     repos:
       # The following performs a tag Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@v0.0.1
+      - https://github.com/zarf-dev/zarf-public-test.git@v0.0.1
       # The following performs a refspec tag Git Repo Mirror with `go-git`
-      - https://github.com/defenseunicorns/zarf-public-test.git@refs/tags/v0.0.1
+      - https://github.com/zarf-dev/zarf-public-test.git@refs/tags/v0.0.1
       # The following performs a tag Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1
     actions:
@@ -36,7 +36,7 @@ components:
     required: true
     repos:
       # The following performs a branch Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@refs/heads/dragons
+      - https://github.com/zarf-dev/zarf-public-test.git@refs/heads/dragons
       # The following performs a branch Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@refs/heads/dragons
     actions:
@@ -51,7 +51,7 @@ components:
     required: true
     repos:
       # The following performs a SHA Git Repo Mirror with `go-git` (internal to Zarf)
-      - https://github.com/defenseunicorns/zarf-public-test.git@01a23218923f24194133b5eb11268cf8d73ff1bb
+      - https://github.com/zarf-dev/zarf-public-test.git@01a23218923f24194133b5eb11268cf8d73ff1bb
       # The following performs a SHA Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@01a23218923f24194133b5eb11268cf8d73ff1bb
     actions:

--- a/src/test/packages/22-git-data/zarf.yaml
+++ b/src/test/packages/22-git-data/zarf.yaml
@@ -12,8 +12,6 @@ components:
       - https://github.com/zarf-dev/zarf-public-test.git
       # The following performs a full Git Repo Mirror forcing a fallback to host `git`
       - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test
-      # Perform a full repo mirror of a simple repository with a single branch - (this causes an "already up to date" error in go-git)
-      - https://github.com/defenseunicorns/golang-tekton-hello-world.git
 
   - name: specific-tag
     required: true


### PR DESCRIPTION
## Description

old link was archived, this should be owned by the zarf-dev org anyway.

The numbers changing in this pr are crc hashes that are changing because the repo name changed. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
