### PR TITLE
chore: update permissions for eks & ecr nightly tests

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -2,7 +2,6 @@ name: Test ECR Publishing
 on:
   schedule:
    - cron: '0 7 * * * ' ## Every day at 0700 UTC
-
   workflow_dispatch: ## Give us the ability to run this manually
 
 
@@ -28,11 +27,13 @@ jobs:
       - name: Build the Zarf binary
         run: make build-cli-linux-amd
 
-      - name: Configure AWS Credentials
+      - name: Auth with AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.AWS_NIGHTLY_ROLE }}
+          role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: us-east-1
+          role-duration-seconds: 3600
 
       # NOTE: The aws cli will need to be explicitly installed on self-hosted runners
       - name: Login to the ECR Registry

--- a/.github/workflows/nightly-eks.yml
+++ b/.github/workflows/nightly-eks.yml
@@ -2,7 +2,6 @@ name: Test EKS Cluster
 on:
   schedule:
    - cron: '0 7 * * *' ## Every day at 0700 UTC
-
   workflow_dispatch: ## Give us the ability to run this manually
     inputs:
       cluster_name:
@@ -33,8 +32,8 @@ jobs:
       - name: Setup golang
         uses: ./.github/actions/golang
 
-      - name: Build Zarf
-        run: make
+      - name: Build binary and zarf packages
+        uses: ./.github/actions/packages
 
       - name: Auth with AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
@@ -56,7 +55,7 @@ jobs:
             --confirm
 
       - name: Run tests
-        run: make test-e2e ARCH=amd64
+        run: make test-e2e-with-cluster ARCH=amd64
 
       - name: Teardown the cluster
         if: always()
@@ -70,9 +69,8 @@ jobs:
         if: always()
         uses: ./.github/actions/save-logs
 
-      # UNCOMMENT BEFORE MERGE
-      # - name: Send trigger to Slack on workflow failure
-      #   if: failure()
-      #   uses: ./.github/actions/slack
-      #   with:
-      #     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Send trigger to Slack on workflow failure
+        if: failure()
+        uses: ./.github/actions/slack
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-eks.yml
+++ b/.github/workflows/nightly-eks.yml
@@ -70,8 +70,9 @@ jobs:
         if: always()
         uses: ./.github/actions/save-logs
 
-      - name: Send trigger to Slack on workflow failure
-        if: failure()
-        uses: ./.github/actions/slack
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # UNCOMMENT BEFORE MERGE
+      # - name: Send trigger to Slack on workflow failure
+      #   if: failure()
+      #   uses: ./.github/actions/slack
+      #   with:
+      #     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-eks.yml
+++ b/.github/workflows/nightly-eks.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Setup golang
         uses: ./.github/actions/golang
 
-      - name: Build binary and zarf packages
-        uses: ./.github/actions/packages
+      - name: Build Zarf
+        run: make
 
       - name: Auth with AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/.github/workflows/nightly-eks.yml
+++ b/.github/workflows/nightly-eks.yml
@@ -36,12 +36,13 @@ jobs:
       - name: Build binary and zarf packages
         uses: ./.github/actions/packages
 
-      - name: Configure AWS Credentials
+      - name: Auth with AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.AWS_NIGHTLY_ROLE }}
+          role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: us-east-1
-          role-duration-seconds: 14400
+          role-duration-seconds: 3600
 
       - name: Build the eks package
         run: ./build/zarf package create packages/distros/eks -o build --confirm

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -17,6 +17,7 @@ addons:
     version: "###ZARF_VAR_EBS_DRIVER_VERSION###"
     attachPolicyARNs:
       - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    permissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
     tags:
       PermissionsBoundary: "zarf_dev_base_policy"
 

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -8,6 +8,7 @@ metadata:
 
 iam:
   withOIDC: true
+  # serviceRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
 
 addons:
   - name: aws-ebs-csi-driver

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -8,7 +8,7 @@ metadata:
 
 iam:
   withOIDC: true
-  # serviceRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+  serviceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
 
 addons:
   - name: aws-ebs-csi-driver

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -5,6 +5,8 @@ metadata:
   name: ###ZARF_VAR_EKS_CLUSTER_NAME###
   region: ###ZARF_VAR_EKS_CLUSTER_REGION###
   version: "###ZARF_VAR_EKS_CLUSTER_VERSION###"
+  tags:
+    PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
 
 iam:
   withOIDC: true
@@ -15,6 +17,15 @@ addons:
     version: "###ZARF_VAR_EBS_DRIVER_VERSION###"
     attachPolicyARNs:
       - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    tags:
+      PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+
+  # - name: vpc-cni
+  #   attachPolicyARNs:
+  #     - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+  #   permissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+  #   tags:
+  #     PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
 
 managedNodeGroups:
 - instanceType: ###ZARF_VAR_EKS_INSTANCE_TYPE###
@@ -22,5 +33,7 @@ managedNodeGroups:
   minSize: 3
   maxSize: 6
   spot: true
+  tags:
+    PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
   iam:
     instanceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -22,5 +22,5 @@ managedNodeGroups:
   minSize: 3
   maxSize: 6
   spot: true
-  # iam:
-  #   instanceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+  iam:
+    instanceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -20,12 +20,12 @@ addons:
     tags:
       PermissionsBoundary: "zarf_dev_base_policy"
 
-  # - name: vpc-cni
-  #   attachPolicyARNs:
-  #     - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-  #   permissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
-  #   tags:
-  #     PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+  - name: vpc-cni
+    attachPolicyARNs:
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    permissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+    tags:
+      PermissionsBoundary: "zarf_dev_base_policy"
 
 managedNodeGroups:
 - instanceType: ###ZARF_VAR_EKS_INSTANCE_TYPE###

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -6,7 +6,7 @@ metadata:
   region: ###ZARF_VAR_EKS_CLUSTER_REGION###
   version: "###ZARF_VAR_EKS_CLUSTER_VERSION###"
   tags:
-    PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+    PermissionsBoundary: "zarf_dev_base_policy"
 
 iam:
   withOIDC: true
@@ -18,7 +18,7 @@ addons:
     attachPolicyARNs:
       - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
     tags:
-      PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+      PermissionsBoundary: "zarf_dev_base_policy"
 
   # - name: vpc-cni
   #   attachPolicyARNs:
@@ -34,6 +34,6 @@ managedNodeGroups:
   maxSize: 6
   spot: true
   tags:
-    PermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"
+    PermissionsBoundary: "zarf_dev_base_policy"
   iam:
     instanceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"

--- a/packages/distros/eks/eks.yaml
+++ b/packages/distros/eks/eks.yaml
@@ -22,3 +22,5 @@ managedNodeGroups:
   minSize: 3
   maxSize: 6
   spot: true
+  # iam:
+  #   instanceRolePermissionsBoundary: "arn:aws:iam::173911864621:policy/zarf_dev_base_policy"

--- a/packages/distros/eks/zarf.yaml
+++ b/packages/distros/eks/zarf.yaml
@@ -52,9 +52,9 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster --dry-run -f eks.yaml
+          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster --dry-run -f eks.yaml -v 5
           - cmd: sleep 15
-          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster -f eks.yaml
+          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster -f eks.yaml -v 5
           - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) utils write-kubeconfig -c ${ZARF_VAR_EKS_CLUSTER_NAME}
 
   - name: teardown-eks-cluster

--- a/packages/distros/eks/zarf.yaml
+++ b/packages/distros/eks/zarf.yaml
@@ -52,9 +52,9 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster --dry-run -f eks.yaml -v 5
+          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster --dry-run -f eks.yaml
           - cmd: sleep 15
-          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster -f eks.yaml -v 5
+          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) create cluster -f eks.yaml
           - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) utils write-kubeconfig -c ${ZARF_VAR_EKS_CLUSTER_NAME}
 
   - name: teardown-eks-cluster

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -45,7 +45,7 @@ func TestECRPublishing(t *testing.T) {
 	testPackageVersion := "0.0.1"
 	testPackageFileName := fmt.Sprintf("zarf-package-%s-%s-%s.tar.zst", testPackageName, e2e.Arch, testPackageVersion)
 	testPackageLocation := filepath.Join(tmpDir, testPackageFileName)
-	registryURL := "oci://public.ecr.aws/t8y5r5z5/zarf-nightly"
+	registryURL := "oci://public.ecr.aws/z6q5p6f7/zarf-nightly"
 	upstreamPackageURL := fmt.Sprintf("%s/%s:%s-%s", registryURL, testPackageName, testPackageVersion, e2e.Arch)
 	keyFlag := fmt.Sprintf("--key=%s", "./src/test/packages/zarf-test.pub")
 

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -46,7 +46,7 @@ func TestECRPublishing(t *testing.T) {
 	testPackageFileName := fmt.Sprintf("zarf-package-%s-%s-%s.tar.zst", testPackageName, e2e.Arch, testPackageVersion)
 	testPackageLocation := filepath.Join(tmpDir, testPackageFileName)
 	registryURL := "oci://public.ecr.aws/z6q5p6f7/zarf-nightly"
-	upstreamPackageURL := fmt.Sprintf("%s/%s:%s-%s", registryURL, testPackageName, testPackageVersion, e2e.Arch)
+	upstreamPackageURL := fmt.Sprintf("%s/%s:%s", registryURL, testPackageName, testPackageVersion)
 	keyFlag := fmt.Sprintf("--key=%s", "./src/test/packages/zarf-test.pub")
 
 	// Build the package with our test signature


### PR DESCRIPTION
## Description
Nightly jobs are currently broken, this moves them off of a personal AWS account to a defense unicorns supported account. Also only running cluster tests on eks as the non cluster tests don't care about the distro

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
