### PR TITLE
chore: move context.TODO to context.Background() (3)

### DIFF
--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -107,7 +107,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c type
 
 	// Template the chart so we can see what GitRepositories are being referenced in the
 	// manifests created with the provided Helm.
-	template, _, err := helmCfg.TemplateChart()
+	template, _, err := helmCfg.TemplateChart(ctx)
 	if err != nil {
 		return c, fmt.Errorf("unable to template Big Bang Chart: %w", err)
 	}

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -5,6 +5,7 @@
 package helm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -30,7 +31,7 @@ import (
 )
 
 // InstallOrUpgradeChart performs a helm install of the given chart.
-func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {
+func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings, string, error) {
 	fromMessage := h.chart.URL
 	if fromMessage == "" {
 		fromMessage = "Zarf-generated helm chart"
@@ -52,7 +53,7 @@ func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {
 		return nil, "", fmt.Errorf("unable to initialize the K8s client: %w", err)
 	}
 
-	postRender, err := h.newRenderer()
+	postRender, err := h.newRenderer(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to create helm renderer: %w", err)
 	}
@@ -126,7 +127,7 @@ func (h *Helm) InstallOrUpgradeChart() (types.ConnectStrings, string, error) {
 }
 
 // TemplateChart generates a helm template from a given chart.
-func (h *Helm) TemplateChart() (manifest string, chartValues chartutil.Values, err error) {
+func (h *Helm) TemplateChart(ctx context.Context) (manifest string, chartValues chartutil.Values, err error) {
 	message.Debugf("helm.TemplateChart()")
 	spinner := message.NewProgressSpinner("Templating helm chart %s", h.chart.Name)
 	defer spinner.Stop()
@@ -170,7 +171,7 @@ func (h *Helm) TemplateChart() (manifest string, chartValues chartutil.Values, e
 		return "", nil, fmt.Errorf("unable to load chart data: %w", err)
 	}
 
-	client.PostRenderer, err = h.newRenderer()
+	client.PostRenderer, err = h.newRenderer(ctx)
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to create helm renderer: %w", err)
 	}
@@ -204,7 +205,7 @@ func (h *Helm) RemoveChart(namespace string, name string, spinner *message.Spinn
 
 // UpdateReleaseValues updates values for a given chart release
 // (note: this only works on single-deep charts, charts with dependencies (like loki-stack) will not work)
-func (h *Helm) UpdateReleaseValues(updatedValues map[string]interface{}) error {
+func (h *Helm) UpdateReleaseValues(ctx context.Context, updatedValues map[string]interface{}) error {
 	spinner := message.NewProgressSpinner("Updating values for helm release %s", h.chart.ReleaseName)
 	defer spinner.Stop()
 
@@ -213,7 +214,7 @@ func (h *Helm) UpdateReleaseValues(updatedValues map[string]interface{}) error {
 		return fmt.Errorf("unable to initialize the K8s client: %w", err)
 	}
 
-	postRender, err := h.newRenderer()
+	postRender, err := h.newRenderer(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to create helm renderer: %w", err)
 	}

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -37,7 +37,7 @@ type renderer struct {
 	namespaces     map[string]*corev1.Namespace
 }
 
-func (h *Helm) newRenderer() (*renderer, error) {
+func (h *Helm) newRenderer(ctx context.Context) (*renderer, error) {
 	message.Debugf("helm.NewRenderer()")
 
 	rend := &renderer{
@@ -49,7 +49,7 @@ func (h *Helm) newRenderer() (*renderer, error) {
 		return rend, nil
 	}
 
-	namespace, err := h.cluster.Clientset.CoreV1().Namespaces().Get(context.TODO(), h.chart.Namespace, metav1.GetOptions{})
+	namespace, err := h.cluster.Clientset.CoreV1().Namespaces().Get(ctx, h.chart.Namespace, metav1.GetOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return nil, fmt.Errorf("unable to check for existing namespace %q in cluster: %w", h.chart.Namespace, err)
 	}

--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -45,7 +45,7 @@ func (h *Helm) UpdateZarfRegistryValues(ctx context.Context) error {
 		Namespace:   "zarf",
 		ReleaseName: "zarf-docker-registry",
 	}
-	err = h.UpdateReleaseValues(registryValues)
+	err = h.UpdateReleaseValues(ctx, registryValues)
 	if err != nil {
 		return fmt.Errorf("error updating the release values: %w", err)
 	}
@@ -119,7 +119,7 @@ func (h *Helm) UpdateZarfAgentValues(ctx context.Context) error {
 			}
 			h.variableConfig.SetApplicationTemplates(applicationTemplates)
 
-			err = h.UpdateReleaseValues(map[string]interface{}{})
+			err = h.UpdateReleaseValues(ctx, map[string]interface{}{})
 			if err != nil {
 				return fmt.Errorf("error updating the release values: %w", err)
 			}

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -352,7 +352,7 @@ func (p *Packager) deployComponent(ctx context.Context, component types.ZarfComp
 	}
 
 	if hasCharts || hasManifests {
-		if charts, err = p.installChartAndManifests(componentPath, component); err != nil {
+		if charts, err = p.installChartAndManifests(ctx, componentPath, component); err != nil {
 			return charts, err
 		}
 	}
@@ -610,7 +610,7 @@ func (p *Packager) generateValuesOverrides(chart types.ZarfChart, componentName 
 }
 
 // Install all Helm charts and raw k8s manifests into the k8s cluster.
-func (p *Packager) installChartAndManifests(componentPaths *layout.ComponentPaths, component types.ZarfComponent) (installedCharts []types.InstalledChart, err error) {
+func (p *Packager) installChartAndManifests(ctx context.Context, componentPaths *layout.ComponentPaths, component types.ZarfComponent) (installedCharts []types.InstalledChart, err error) {
 	for _, chart := range component.Charts {
 		// Do not wait for the chart to be ready if data injections are present.
 		if len(component.DataInjections) > 0 {
@@ -646,7 +646,7 @@ func (p *Packager) installChartAndManifests(componentPaths *layout.ComponentPath
 				p.cfg.PkgOpts.Retries),
 		)
 
-		addedConnectStrings, installedChartName, err := helmCfg.InstallOrUpgradeChart()
+		addedConnectStrings, installedChartName, err := helmCfg.InstallOrUpgradeChart(ctx)
 		if err != nil {
 			return installedCharts, err
 		}
@@ -699,7 +699,7 @@ func (p *Packager) installChartAndManifests(componentPaths *layout.ComponentPath
 		}
 
 		// Install the chart.
-		addedConnectStrings, installedChartName, err := helmCfg.InstallOrUpgradeChart()
+		addedConnectStrings, installedChartName, err := helmCfg.InstallOrUpgradeChart(ctx)
 		if err != nil {
 			return installedCharts, err
 		}

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -185,7 +185,7 @@ func (p *Packager) findImages(ctx context.Context) (imgMap map[string][]string, 
 			}
 
 			// Generate helm templates for this chart
-			chartTemplate, chartValues, err := helmCfg.TemplateChart()
+			chartTemplate, chartValues, err := helmCfg.TemplateChart(ctx)
 			if err != nil {
 				message.WarnErrf(err, "Problem rendering the helm template for %s: %s", chart.Name, err.Error())
 				erroredCharts = append(erroredCharts, chart.Name)


### PR DESCRIPTION
Relies on #2746 before merging 

This messes with some public functions, I ran them through UDS-CLI to make sure we aren't breaking anything. 