### PR TITLE
refactor: add error handling to view SBOM files

### DIFF
--- a/src/internal/packager/sbom/tools.go
+++ b/src/internal/packager/sbom/tools.go
@@ -14,26 +14,31 @@ import (
 )
 
 // ViewSBOMFiles opens a browser to view the SBOM files and pauses for user input.
-func ViewSBOMFiles(directory string) {
-	sbomViewFiles, _ := filepath.Glob(filepath.Join(directory, "sbom-viewer-*"))
-
-	if len(sbomViewFiles) > 0 {
-		link := sbomViewFiles[0]
-		msg := fmt.Sprintf("This package has %d images with software bill-of-materials (SBOM) included. If your browser did not open automatically you can copy and paste this file location into your browser address bar to view them: %s\n\n", len(sbomViewFiles), link)
-		message.Note(msg)
-
-		if err := exec.LaunchURL(link); err != nil {
-			message.Debug(err)
-		}
-
-		// Use survey.Input to hang until user input
-		var value string
-		prompt := &survey.Input{
-			Message: "Hit the 'enter' key when you are done viewing the SBOM files",
-			Default: "",
-		}
-		_ = survey.AskOne(prompt, &value)
-	} else {
-		message.Note("There were no images with software bill-of-materials (SBOM) included.")
+func ViewSBOMFiles(directory string) error {
+	sbomViewFiles, err := filepath.Glob(filepath.Join(directory, "sbom-viewer-*"))
+	if err != nil {
+		return err
 	}
+
+	if len(sbomViewFiles) == 0 {
+		message.Note("There were no images with software bill-of-materials (SBOM) included.")
+		return nil
+	}
+
+	link := sbomViewFiles[0]
+	msg := fmt.Sprintf("This package has %d images with software bill-of-materials (SBOM) included. If your browser did not open automatically you can copy and paste this file location into your browser address bar to view them: %s\n\n", len(sbomViewFiles), link)
+	message.Note(msg)
+	if err := exec.LaunchURL(link); err != nil {
+		return err
+	}
+	var value string
+	prompt := &survey.Input{
+		Message: "Hit the 'enter' key when you are done viewing the SBOM files",
+		Default: "",
+	}
+	err = survey.AskOne(prompt, &value)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -321,7 +321,10 @@ func (pc *PackageCreator) Output(ctx context.Context, dst *layout.PackagePaths, 
 		}
 
 		if pc.createOpts.ViewSBOM {
-			sbom.ViewSBOMFiles(sbomDir)
+			err := sbom.ViewSBOMFiles(sbomDir)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -47,7 +47,10 @@ func (p *Packager) Inspect(ctx context.Context) (err error) {
 	}
 
 	if p.cfg.InspectOpts.ViewSBOM {
-		sbom.ViewSBOMFiles(sbomDir)
+		err := sbom.ViewSBOMFiles(sbomDir)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This refactors ViewSBOMFiles to handle errors properly. This was initially done to stop debug logging the single error, but it felt wrong to not fix the other errors while I was at it.

## Related Issue

Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
