### PR TITLE
refactor: add error to packager set paths

### DIFF
--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -268,18 +268,22 @@ func (pp *PackagePaths) AddSBOMs() *PackagePaths {
 }
 
 // SetFromLayers maps layers to package paths.
-func (pp *PackagePaths) SetFromLayers(layers []ocispec.Descriptor) {
+func (pp *PackagePaths) SetFromLayers(layers []ocispec.Descriptor) error {
 	paths := []string{}
 	for _, layer := range layers {
 		if layer.Annotations[ocispec.AnnotationTitle] != "" {
 			paths = append(paths, layer.Annotations[ocispec.AnnotationTitle])
 		}
 	}
-	pp.SetFromPaths(paths)
+	err := pp.SetFromPaths(paths)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetFromPaths maps paths to package paths.
-func (pp *PackagePaths) SetFromPaths(paths []string) {
+func (pp *PackagePaths) SetFromPaths(paths []string) error {
 	for _, rel := range paths {
 		// Convert from the standard '/' to the OS path separator for Windows support
 		switch path := filepath.FromSlash(rel); {
@@ -310,9 +314,10 @@ func (pp *PackagePaths) SetFromPaths(paths []string) {
 			}
 			pp.Components.Tarballs[componentName] = filepath.Join(pp.Base, path)
 		default:
-			message.Debug("ignoring path", path)
+			return fmt.Errorf("unknown path %s", path)
 		}
 	}
+	return nil
 }
 
 // Files returns a map of all the files in the package.

--- a/src/pkg/layout/package_test.go
+++ b/src/pkg/layout/package_test.go
@@ -115,7 +115,8 @@ func TestPackageFiles(t *testing.T) {
 			normalizePath("images/oci-layout"),
 			normalizePath("images/blobs/sha256/" + strings.Repeat("1", 64)),
 		}
-		pp.SetFromPaths(paths)
+		err := pp.SetFromPaths(paths)
+		require.NoError(t, err)
 
 		files := pp.Files()
 		expected := map[string]string{
@@ -150,7 +151,8 @@ func TestPackageFiles(t *testing.T) {
 			},
 		}
 		pp.AddImages()
-		pp.SetFromLayers(descs)
+		err := pp.SetFromLayers(descs)
+		require.NoError(t, err)
 
 		files := pp.Files()
 		expected := map[string]string{
@@ -163,6 +165,17 @@ func TestPackageFiles(t *testing.T) {
 		}
 		require.Equal(t, expected, files)
 	})
+}
+
+func TestInvalidSetPaths(t *testing.T) {
+	t.Parallel()
+
+	pp := New("test")
+	paths := []string{
+		"foo",
+	}
+	err := pp.SetFromPaths(paths)
+	require.EqualError(t, err, "unknown path foo")
 }
 
 // normalizePath ensures that the filepaths being generated are normalized to the host OS.

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -64,7 +64,10 @@ func (s *OCISource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, f
 	if err != nil {
 		return pkg, nil, fmt.Errorf("unable to pull the package: %w", err)
 	}
-	dst.SetFromLayers(layersFetched)
+	err = dst.SetFromLayers(layersFetched)
+	if err != nil {
+		return types.ZarfPackage{}, nil, err
+	}
 
 	if err := dst.MigrateLegacy(); err != nil {
 		return pkg, nil, err
@@ -119,7 +122,10 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 	if err != nil {
 		return pkg, nil, err
 	}
-	dst.SetFromLayers(layersFetched)
+	err = dst.SetFromLayers(layersFetched)
+	if err != nil {
+		return types.ZarfPackage{}, nil, err
+	}
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {
@@ -174,7 +180,10 @@ func (s *OCISource) Collect(ctx context.Context, dir string) (string, error) {
 	}
 
 	loaded := layout.New(tmp)
-	loaded.SetFromLayers(fetched)
+	err = loaded.SetFromLayers(fetched)
+	if err != nil {
+		return "", err
+	}
 
 	var pkg types.ZarfPackage
 

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -81,7 +81,10 @@ func (s *TarballSource) LoadPackage(_ context.Context, dst *layout.PackagePaths,
 		return pkg, nil, err
 	}
 
-	dst.SetFromPaths(pathsExtracted)
+	err = dst.SetFromPaths(pathsExtracted)
+	if err != nil {
+		return types.ZarfPackage{}, nil, err
+	}
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {
@@ -161,7 +164,10 @@ func (s *TarballSource) LoadPackageMetadata(_ context.Context, dst *layout.Packa
 		}
 	}
 
-	dst.SetFromPaths(pathsExtracted)
+	err = dst.SetFromPaths(pathsExtracted)
+	if err != nil {
+		return types.ZarfPackage{}, nil, err
+	}
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {


### PR DESCRIPTION
## Description

This change removes the debug log and replaces it with an error  when a package path is of unknown format.

## Related Issue

Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
