### PR TITLE
feat: expose root cmd

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -101,6 +101,11 @@ func Execute(ctx context.Context) {
 	os.Exit(1)
 }
 
+// NewRootCmd returns the root command.
+func NewRootCmd() *cobra.Command {
+	return rootCmd
+}
+
 func init() {
 	// Add the tools commands
 	tools.Include(rootCmd)


### PR DESCRIPTION
## Description

Closes https://github.com/zarf-dev/zarf/issues/2765

Expose `rootCmd` so that Zarf can be properly embedded in other CLIs.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
