### PR TITLE
chore: stop releasing to s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,14 +139,6 @@ jobs:
           name: build-artifacts
           path: build/
 
-      # Set up AWS credentials for GoReleaser to upload backups of artifacts to S3
-      - name: Set AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_GOV_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_GOV_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
       - name: Make zarf executable and skip brew latest for pre-release tags
         run: |
           chmod +x build/zarf

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -107,10 +107,3 @@ brews:
     commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
     homepage: "https://zarf.dev/"
     description: "DevSecOps for Air Gap"
-
-# Upload artifact backups to s3
-blobs:
-  - provider: s3
-    region: us-gov-west-1
-    bucket: zarf-public
-    directory: "release/{{.Version}}"


### PR DESCRIPTION
## Description

We are releasing to s3, but no one uses it. Let's stop. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
