### PR TITLE
refactor: replace debug logs with returning errors

### DIFF
--- a/src/cmd/connect.go
+++ b/src/cmd/connect.go
@@ -65,7 +65,7 @@ var connectCmd = &cobra.Command{
 		} else {
 			spinner.Updatef(lang.CmdConnectEstablishedWeb, tunnel.FullURL())
 			if err := exec.LaunchURL(tunnel.FullURL()); err != nil {
-				message.Debug(err)
+				return err
 			}
 		}
 

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -407,7 +407,7 @@ func (p *Packager) processComponentFiles(component types.ZarfComponent, pkgLocat
 			// Check if the file looks like a text file
 			isText, err := helpers.IsTextFile(subFile)
 			if err != nil {
-				message.Debugf("unable to determine if file %s is a text file: %s", subFile, err)
+				return err
 			}
 
 			// If the file is a text file, template it


### PR DESCRIPTION
## Description

This change replaces more debug logs with returning errors instead.

## Related Issue

Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
