### PR TITLE
chore: turn down codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,20 @@
+# To validate:
+#   cat codecov.yml | curl --data-binary @- https://codecov.io/validate
+
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  status:
+    patch: false
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        enabled: no # disable patch since it is noisy and not correct
+        if_not_found: success


### PR DESCRIPTION
This should turn off annotations and set success threshold to 1%