### PR TITLE
chore: update obsolete versions

### DIFF
--- a/examples/podinfo-flux/git/podinfo-kustomization.yaml
+++ b/examples/podinfo-flux/git/podinfo-kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: podinfo-git

--- a/examples/podinfo-flux/git/podinfo-source.yaml
+++ b/examples/podinfo-flux/git/podinfo-source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/src/test/external/docker-compose.yml
+++ b/src/test/external/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   server:
     image: gitea/gitea:1.18.1


### PR DESCRIPTION
## Description

We were getting warnings that we should update to v1 with flux git repos and that the docker compose version key is obsolete 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
