### PR TITLE
refactor: move and test HasImages

### DIFF
--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -149,16 +149,6 @@ func (p *Packager) isConnectedToCluster() bool {
 	return p.cluster != nil
 }
 
-// hasImages returns whether the current package contains images
-func (p *Packager) hasImages() bool {
-	for _, component := range p.cfg.Pkg.Components {
-		if len(component.Images) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // attemptClusterChecks attempts to connect to the cluster and check for useful metadata and config mismatches.
 // NOTE: attemptClusterChecks should only return an error if there is a problem significant enough to halt a deployment, otherwise it should return nil and print a warning message.
 func (p *Packager) attemptClusterChecks(ctx context.Context) (err error) {
@@ -197,7 +187,7 @@ func (p *Packager) attemptClusterChecks(ctx context.Context) (err error) {
 // validatePackageArchitecture validates that the package architecture matches the target cluster architecture.
 func (p *Packager) validatePackageArchitecture(ctx context.Context) error {
 	// Ignore this check if we don't have a cluster connection, or the package contains no images
-	if !p.isConnectedToCluster() || !p.hasImages() {
+	if !p.isConnectedToCluster() || !p.cfg.Pkg.HasImages() {
 		return nil
 	}
 

--- a/src/types/package.go
+++ b/src/types/package.go
@@ -37,6 +37,16 @@ func (pkg ZarfPackage) IsInitConfig() bool {
 	return pkg.Kind == ZarfInitConfig
 }
 
+// HasImages returns true if one of the components contains an image.
+func (pkg ZarfPackage) HasImages() bool {
+	for _, component := range pkg.Components {
+		if len(component.Images) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // IsSBOMAble checks if a package has contents that an SBOM can be created on (i.e. images, files, or data injections).
 func (pkg ZarfPackage) IsSBOMAble() bool {
 	for _, c := range pkg.Components {

--- a/src/types/package_test.go
+++ b/src/types/package_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZarfPackageIsInitPackage(t *testing.T) {
+	t.Parallel()
+
+	pkg := ZarfPackage{
+		Kind: ZarfInitConfig,
+	}
+	require.True(t, pkg.IsInitConfig())
+	pkg = ZarfPackage{
+		Kind: ZarfPackageConfig,
+	}
+	require.False(t, pkg.IsInitConfig())
+}
+
+func TestZarfPackageHasImages(t *testing.T) {
+	t.Parallel()
+
+	pkg := ZarfPackage{
+		Components: []ZarfComponent{
+			{
+				Name: "without images",
+			},
+		},
+	}
+	require.False(t, pkg.HasImages())
+	pkg = ZarfPackage{
+		Components: []ZarfComponent{
+			{
+				Name:   "with images",
+				Images: []string{"docker.io/library/alpine:latest"},
+			},
+		},
+	}
+	require.True(t, pkg.HasImages())
+}
+
+func TestZarfPackageIsSBOMable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		images         []string
+		files          []ZarfFile
+		dataInjections []ZarfDataInjection
+		expected       bool
+	}{
+		{
+			name:     "empty component",
+			expected: false,
+		},
+		{
+			name:     "only images",
+			images:   []string{""},
+			expected: true,
+		},
+		{
+			name:     "only files",
+			files:    []ZarfFile{{}},
+			expected: true,
+		},
+		{
+			name:           "only data injections",
+			dataInjections: []ZarfDataInjection{{}},
+			expected:       true,
+		},
+		{
+			name:           "all three set",
+			images:         []string{""},
+			files:          []ZarfFile{{}},
+			dataInjections: []ZarfDataInjection{{}},
+			expected:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := ZarfPackage{
+				Components: []ZarfComponent{
+					{
+						Name:           "without images",
+						Images:         tt.images,
+						Files:          tt.files,
+						DataInjections: tt.dataInjections,
+					},
+				},
+			}
+			require.Equal(t, tt.expected, pkg.IsSBOMAble())
+		})
+	}
+}


### PR DESCRIPTION
## Description

This change moves `HasImages` to the Zarf package struct. It also adds tests for some of the packages methods.

## Related Issue

Relates to #2709 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
