### PR TITLE
refactor: move package generation to a local variable

### DIFF
--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -54,14 +54,17 @@ func (c *Cluster) GetDeployedZarfPackages(ctx context.Context) ([]types.Deployed
 
 // GetDeployedPackage gets the metadata information about the package name provided (if it exists in the cluster).
 // We determine what packages have been deployed to the cluster by looking for specific secrets in the Zarf namespace.
-func (c *Cluster) GetDeployedPackage(ctx context.Context, packageName string) (deployedPackage *types.DeployedPackage, err error) {
-	// Get the secret that describes the deployed package
+func (c *Cluster) GetDeployedPackage(ctx context.Context, packageName string) (*types.DeployedPackage, error) {
 	secret, err := c.Clientset.CoreV1().Secrets(ZarfNamespaceName).Get(ctx, config.ZarfPackagePrefix+packageName, metav1.GetOptions{})
 	if err != nil {
-		return deployedPackage, err
+		return nil, err
 	}
-
-	return deployedPackage, json.Unmarshal(secret.Data["data"], &deployedPackage)
+	deployedPackage := &types.DeployedPackage{}
+	err = json.Unmarshal(secret.Data["data"], deployedPackage)
+	if err != nil {
+		return nil, err
+	}
+	return deployedPackage, nil
 }
 
 // StripZarfLabelsAndSecretsFromNamespaces removes metadata and secrets from existing namespaces no longer manged by Zarf.

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -38,7 +38,6 @@ type Packager struct {
 	hpaModified    bool
 	connectStrings types.ConnectStrings
 	source         sources.PackageSource
-	generation     int
 }
 
 // Modifier is a function that modifies the packager.
@@ -154,12 +153,6 @@ func (p *Packager) isConnectedToCluster() bool {
 func (p *Packager) attemptClusterChecks(ctx context.Context) (err error) {
 	spinner := message.NewProgressSpinner("Gathering additional cluster information (if available)")
 	defer spinner.Stop()
-
-	// Check if the package has already been deployed and get its generation
-	if existingDeployedPackage, _ := p.cluster.GetDeployedPackage(ctx, p.cfg.Pkg.Metadata.Name); existingDeployedPackage != nil {
-		// If this package has been deployed before, increment the package generation within the secret
-		p.generation = existingDeployedPackage.Generation + 1
-	}
 
 	// Check the clusters architecture matches the package spec
 	if err := p.validatePackageArchitecture(ctx); err != nil {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -138,20 +138,10 @@ func (p *Packager) Deploy(ctx context.Context) error {
 
 // deployComponents loops through a list of ZarfComponents and deploys them.
 func (p *Packager) deployComponents(ctx context.Context) (deployedComponents []types.DeployedComponent, err error) {
-	// Check if this package has been deployed before and grab relevant information about already deployed components
-	if p.generation == 0 {
-		p.generation = 1 // If this is the first deployment, set the generation to 1
-	}
-
 	// Process all the components we are deploying
 	for _, component := range p.cfg.Pkg.Components {
-		deployedComponent := types.DeployedComponent{
-			Name:               component.Name,
-			Status:             types.ComponentStatusDeploying,
-			ObservedGeneration: p.generation,
-		}
-
-		// If this component requires a cluster, connect to one
+		// Connect to cluster if a component requires it.
+		packageGeneration := 1
 		if component.RequiresCluster() {
 			timeout := cluster.DefaultTimeout
 			if p.cfg.Pkg.IsInitConfig() {
@@ -160,8 +150,19 @@ func (p *Packager) deployComponents(ctx context.Context) (deployedComponents []t
 			connectCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 			if err := p.connectToCluster(connectCtx); err != nil {
-				return deployedComponents, fmt.Errorf("unable to connect to the Kubernetes cluster: %w", err)
+				return nil, fmt.Errorf("unable to connect to the Kubernetes cluster: %w", err)
 			}
+
+			// If this package has been deployed before, increment the package generation within the secret
+			if existingDeployedPackage, _ := p.cluster.GetDeployedPackage(ctx, p.cfg.Pkg.Metadata.Name); existingDeployedPackage != nil {
+				packageGeneration = existingDeployedPackage.Generation + 1
+			}
+		}
+
+		deployedComponent := types.DeployedComponent{
+			Name:               component.Name,
+			Status:             types.ComponentStatusDeploying,
+			ObservedGeneration: packageGeneration,
 		}
 
 		// Ensure we don't overwrite any installedCharts data when updating the package secret
@@ -177,7 +178,7 @@ func (p *Packager) deployComponents(ctx context.Context) (deployedComponents []t
 
 		// Update the package secret to indicate that we are attempting to deploy this component
 		if p.isConnectedToCluster() {
-			if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, p.generation, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
+			if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, packageGeneration, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
 				message.Debugf("Unable to record package deployment for component %s: this will affect features like `zarf package remove`: %s", component.Name, err.Error())
 			}
 		}
@@ -205,7 +206,7 @@ func (p *Packager) deployComponents(ctx context.Context) (deployedComponents []t
 			// Update the package secret to indicate that we failed to deploy this component
 			deployedComponents[idx].Status = types.ComponentStatusFailed
 			if p.isConnectedToCluster() {
-				if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, p.generation, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
+				if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, packageGeneration, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
 					message.Debugf("Unable to record package deployment for component %q: this will affect features like `zarf package remove`: %s", component.Name, err.Error())
 				}
 			}
@@ -217,7 +218,7 @@ func (p *Packager) deployComponents(ctx context.Context) (deployedComponents []t
 		deployedComponents[idx].InstalledCharts = charts
 		deployedComponents[idx].Status = types.ComponentStatusSucceeded
 		if p.isConnectedToCluster() {
-			if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, p.generation, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
+			if _, err := p.cluster.RecordPackageDeploymentAndWait(ctx, p.cfg.Pkg, deployedComponents, p.connectStrings, packageGeneration, component, p.cfg.DeployOpts.SkipWebhooks); err != nil {
 				message.Debugf("Unable to record package deployment for component %q: this will affect features like `zarf package remove`: %s", component.Name, err.Error())
 			}
 		}


### PR DESCRIPTION
## Description

This change moves generation from a struct property in packager to the only place where it is needed.

## Related Issue

Relates to #2709 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
