### PR TITLE
refactor: move package state to local variable

### DIFF
--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -113,7 +113,7 @@ func (h *Helm) UpdateZarfAgentValues(ctx context.Context) error {
 					Value: agentImage.Tag,
 				},
 			})
-			applicationTemplates, err := template.GetZarfTemplates("zarf-agent", h.state)
+			applicationTemplates, err := template.GetZarfTemplates("zarf-agent", h.state.RegistryInfo, h.state.GitServer, h.state.AgentTLS, h.state.StorageClass)
 			if err != nil {
 				return fmt.Errorf("error setting up the templates: %w", err)
 			}

--- a/src/pkg/cluster/state_test.go
+++ b/src/pkg/cluster/state_test.go
@@ -202,7 +202,7 @@ func TestInitZarfState(t *testing.T) {
 				}
 			}()
 
-			err := c.InitZarfState(ctx, tt.initOpts)
+			_, err := c.InitZarfState(ctx, tt.initOpts)
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 				return

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -32,7 +32,6 @@ import (
 type Packager struct {
 	cfg            *types.PackagerConfig
 	variableConfig *variables.VariableConfig
-	state          *types.ZarfState
 	cluster        *cluster.Cluster
 	layout         *layout.PackagePaths
 	hpaModified    bool

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 // Mirror pulls resources from a package (images, git repositories, etc) and pushes them to remotes in the air gap without deploying them
@@ -40,40 +39,24 @@ func (p *Packager) Mirror(ctx context.Context) error {
 		return fmt.Errorf("mirror cancelled")
 	}
 
-	p.state = &types.ZarfState{
-		RegistryInfo: p.cfg.InitOpts.RegistryInfo,
-		GitServer:    p.cfg.InitOpts.GitServer,
-	}
-
 	for _, component := range p.cfg.Pkg.Components {
-		if err := p.mirrorComponent(ctx, component); err != nil {
-			return err
+		componentPaths := p.layout.Components.Dirs[component.Name]
+
+		// All components now require a name
+		message.HeaderInfof("📦 %s COMPONENT", strings.ToUpper(component.Name))
+
+		if len(component.Images) > 0 {
+			err := p.pushImagesToRegistry(ctx, p.cfg.InitOpts.RegistryInfo, component.Images, p.cfg.MirrorOpts.NoImgChecksum)
+			if err != nil {
+				return fmt.Errorf("unable to push images to the registry: %w", err)
+			}
+		}
+		if len(component.Repos) > 0 {
+			err := p.pushReposToRepository(ctx, p.cfg.InitOpts.GitServer, componentPaths.Repos, component.Repos)
+			if err != nil {
+				return fmt.Errorf("unable to push the repos to the repository: %w", err)
+			}
 		}
 	}
-	return nil
-}
-
-// mirrorComponent mirrors a Zarf Component.
-func (p *Packager) mirrorComponent(ctx context.Context, component types.ZarfComponent) error {
-	componentPaths := p.layout.Components.Dirs[component.Name]
-
-	// All components now require a name
-	message.HeaderInfof("📦 %s COMPONENT", strings.ToUpper(component.Name))
-
-	hasImages := len(component.Images) > 0
-	hasRepos := len(component.Repos) > 0
-
-	if hasImages {
-		if err := p.pushImagesToRegistry(ctx, component.Images, p.cfg.MirrorOpts.NoImgChecksum); err != nil {
-			return fmt.Errorf("unable to push images to the registry: %w", err)
-		}
-	}
-
-	if hasRepos {
-		if err := p.pushReposToRepository(ctx, componentPaths.Repos, component.Repos); err != nil {
-			return fmt.Errorf("unable to push the repos to the repository: %w", err)
-		}
-	}
-
 	return nil
 }

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -109,13 +109,6 @@ func (p *Packager) findImages(ctx context.Context) (imgMap map[string][]string, 
 	if err != nil {
 		return nil, err
 	}
-	artifactServer := types.ArtifactServerInfo{}
-	artifactServer.FillInEmptyValues()
-	p.state = &types.ZarfState{
-		RegistryInfo:   registryInfo,
-		GitServer:      gitServer,
-		ArtifactServer: artifactServer,
-	}
 
 	for _, component := range p.cfg.Pkg.Components {
 		if len(component.Charts)+len(component.Manifests)+len(component.Repos) < 1 {
@@ -156,7 +149,7 @@ func (p *Packager) findImages(ctx context.Context) (imgMap map[string][]string, 
 		if err != nil {
 			return nil, err
 		}
-		err = p.populateComponentAndStateTemplates(component.Name)
+		err = p.populateComponentAndStateTemplates(component.Name, registryInfo, gitServer, types.GeneratedPKI{}, "")
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -12,11 +12,12 @@ import (
 	"runtime"
 	"slices"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/defenseunicorns/pkg/helpers/v2"
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
@@ -182,7 +183,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 	for _, chart := range helpers.Reverse(deployedComponent.InstalledCharts) {
 		spinner.Updatef("Uninstalling chart '%s' from the '%s' component", chart.ChartName, deployedComponent.Name)
 
-		helmCfg := helm.NewClusterOnly(p.cfg, p.variableConfig, p.state, p.cluster)
+		helmCfg := helm.NewClusterOnly(p.cfg, p.variableConfig, nil, p.cluster)
 		if err := helmCfg.RemoveChart(chart.Namespace, chart.ChartName, spinner); err != nil {
 			if !errors.Is(err, driver.ErrReleaseNotFound) {
 				onFailure()


### PR DESCRIPTION
## Description

This removes the Zarf state as a property in the packager struct. Instead it is loaded in functions that needs it and passed as a argument. 

## Related Issue

Relates to #2709 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
