### PR TITLE
refactor: replace message.Warn with context logger 

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -23,7 +23,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -97,7 +97,7 @@ var devTransformGitLinksCmd = &cobra.Command{
 	Aliases: []string{"p"},
 	Short:   lang.CmdDevPatchGitShort,
 	Args:    cobra.ExactArgs(2),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		host, fileName := args[0], args[1]
 
 		// Read the contents of the given file
@@ -110,7 +110,7 @@ var devTransformGitLinksCmd = &cobra.Command{
 
 		// Perform git url transformation via regex
 		text := string(content)
-		processedText := transform.MutateGitURLsInText(message.Warnf, pkgConfig.InitOpts.GitServer.Address, text, pkgConfig.InitOpts.GitServer.PushUsername)
+		processedText := transform.MutateGitURLsInText(cmd.Context(), pkgConfig.InitOpts.GitServer.Address, text, pkgConfig.InitOpts.GitServer.PushUsername)
 
 		// Print the differences
 		dmp := diffmatchpatch.New()
@@ -153,7 +153,7 @@ var devSha256SumCmd = &cobra.Command{
 		var err error
 
 		if helpers.IsURL(fileName) {
-			message.Warn(lang.CmdDevSha256sumRemoteWarning)
+			logging.FromContextOrDiscard(cmd.Context()).Warn("This is a remote source. If a published checksum is available you should use that rather than calculating it directly from the remote link.")
 
 			fileBase, err := helpers.ExtractBasePathFromURL(fileName)
 			if err != nil {

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -53,7 +53,7 @@ var devDeployCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ var devGenerateCmd = &cobra.Command{
 		pkgConfig.CreateOpts.BaseDir = "."
 		pkgConfig.FindImagesOpts.RepoHelmChartPath = pkgConfig.GenerateOpts.GitPath
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -229,7 +229,7 @@ var devFindImagesCmd = &cobra.Command{
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ var devLintCmd = &cobra.Command{
 		pkgConfig.CreateOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -63,7 +63,7 @@ var initCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig, packager.WithSource(src))
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig, packager.WithSource(src))
 		if err != nil {
 			return err
 		}

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent"
 	"github.com/zarf-dev/zarf/src/internal/gitea"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -336,7 +337,7 @@ var updateGiteaPVC = &cobra.Command{
 		// There is a possibility that the pvc does not yet exist and Gitea helm chart should create it
 		helmShouldCreate, err := c.UpdateGiteaPVC(ctx, pvcName, rollback)
 		if err != nil {
-			message.WarnErr(err, lang.CmdInternalUpdateGiteaPVCErr)
+			logging.FromContextOrDiscard(ctx).Warn("Unable to update the existing Gitea persistent volume claim.", "error", err)
 		}
 		fmt.Print(helmShouldCreate)
 		return nil

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -47,7 +47,7 @@ var packageCreateCmd = &cobra.Command{
 
 		var isCleanPathRegex = regexp.MustCompile(`^[a-zA-Z0-9\_\-\/\.\~\\:]+$`)
 		if !isCleanPathRegex.MatchString(config.CommonOptions.CachePath) {
-			message.Warnf(lang.CmdPackageCreateCleanPathErr, config.ZarfDefaultCachePath)
+			logging.FromContextOrDiscard(cmd.Context()).Warn("Invalid characters in the Zarf cache path, defaulting to path", "default", config.ZarfDefaultCachePath)
 			config.CommonOptions.CachePath = config.ZarfDefaultCachePath
 		}
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -87,6 +89,10 @@ var rootCmd = &cobra.Command{
 
 // Execute is the entrypoint for the CLI.
 func Execute(ctx context.Context) {
+	handler := logging.NewPtermHandler()
+	log := slog.New(handler)
+	ctx = logging.NewContext(ctx, log)
+
 	cmd, err := rootCmd.ExecuteContextC(ctx)
 	if err == nil {
 		return

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -76,12 +76,13 @@ var rootCmd = &cobra.Command{
 		_, _ = fmt.Fprintln(os.Stderr, zarfLogo)
 		cmd.Help()
 
+		log := logging.FromContextOrDiscard(cmd.Context())
 		if len(args) > 0 {
 			if strings.Contains(args[0], config.ZarfPackagePrefix) || strings.Contains(args[0], "zarf-init") {
-				message.Warnf(lang.RootCmdDeprecatedDeploy, args[0])
+				log.Warn("Deprecated: Please use \"zarf package deploy\" to deploy this package.  This warning will be removed in Zarf v1.0.0.")
 			}
 			if args[0] == layout.ZarfYAML {
-				message.Warn(lang.RootCmdDeprecatedCreate)
+				log.Warn("Deprecated: Please use \"zarf package create\" to create this package.  This warning will be removed in Zarf v1.0.0.")
 			}
 		}
 	},

--- a/src/cmd/tools/crane.go
+++ b/src/cmd/tools/crane.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/packager/images"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
@@ -176,7 +177,7 @@ func zarfCraneInternalWrapper(commandToWrap func(*[]crane.Option) *cobra.Command
 
 		zarfState, err := c.LoadZarfState(ctx)
 		if err != nil {
-			message.Warnf("could not get Zarf state from Kubernetes cluster, continuing without state information %s", err.Error())
+			logging.FromContextOrDiscard(cmd.Context()).Warn("could not get Zarf state from Kubernetes cluster, continuing without state information", "error", err)
 			return originalListFn(cmd, args)
 		}
 

--- a/src/cmd/tools/wait.go
+++ b/src/cmd/tools/wait.go
@@ -29,7 +29,7 @@ var waitForCmd = &cobra.Command{
 	Long:    lang.CmdToolsWaitForLong,
 	Example: lang.CmdToolsWaitForExample,
 	Args:    cobra.MinimumNArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse the timeout string
 		timeout, err := time.ParseDuration(waitTimeout)
 		if err != nil {
@@ -51,7 +51,7 @@ var waitForCmd = &cobra.Command{
 		}
 
 		// Execute the wait command.
-		if err := utils.ExecuteWait(waitTimeout, waitNamespace, condition, kind, identifier, timeout); err != nil {
+		if err := utils.ExecuteWait(cmd.Context(), waitTimeout, waitNamespace, condition, kind, identifier, timeout); err != nil {
 			return err
 		}
 		return err

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
@@ -40,8 +41,8 @@ var deprecatedGetGitCredsCmd = &cobra.Command{
 	Hidden: true,
 	Short:  lang.CmdToolsGetGitPasswdShort,
 	Long:   lang.CmdToolsGetGitPasswdLong,
-	Run: func(_ *cobra.Command, _ []string) {
-		message.Warn(lang.CmdToolsGetGitPasswdDeprecation)
+	Run: func(cmd *cobra.Command, _ []string) {
+		logging.FromContextOrDiscard(cmd.Context()).Warn("Deprecated: This command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0.")
 		getCredsCmd.Run(getCredsCmd, []string{"git"})
 	},
 }
@@ -101,6 +102,7 @@ var updateCredsCmd = &cobra.Command{
 		}
 
 		ctx := cmd.Context()
+		log := logging.FromContextOrDiscard(ctx)
 
 		timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
 		defer cancel()
@@ -179,7 +181,7 @@ var updateCredsCmd = &cobra.Command{
 				err = h.UpdateZarfRegistryValues(ctx)
 				if err != nil {
 					// Warn if we couldn't actually update the registry (it might not be installed and we should try to continue)
-					message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateRegistry, err.Error())
+					log.Warn("Unable to update Zarf Registry values", "error", err)
 				}
 			}
 			if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
@@ -192,7 +194,7 @@ var updateCredsCmd = &cobra.Command{
 				err = h.UpdateZarfAgentValues(ctx)
 				if err != nil {
 					// Warn if we couldn't actually update the agent (it might not be installed and we should try to continue)
-					message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateAgent, err.Error())
+					log.Warn("Unable to update Zarf Agent TLS secrets", "error", err)
 				}
 			}
 		}

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -54,9 +54,6 @@ const (
 	RootCmdFlagTempDir     = "Specify the temporary directory to use for intermediate files"
 	RootCmdFlagInsecure    = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."
 
-	RootCmdDeprecatedDeploy = "Deprecated: Please use \"zarf package deploy %s\" to deploy this package.  This warning will be removed in Zarf v1.0.0."
-	RootCmdDeprecatedCreate = "Deprecated: Please use \"zarf package create\" to create this package.  This warning will be removed in Zarf v1.0.0."
-
 	// zarf connect
 	CmdConnectShort = "Accesses services or pods deployed in the cluster"
 	CmdConnectLong  = "Uses a k8s port-forward to connect to resources within the cluster referenced by your kube-context.\n" +
@@ -100,8 +97,6 @@ const (
 
 	CmdDestroyFlagConfirm          = "REQUIRED. Confirm the destroy action to prevent accidental deletions"
 	CmdDestroyFlagRemoveComponents = "Also remove any installed components outside the zarf namespace"
-
-	CmdDestroyErrScriptPermissionDenied = "Received 'permission denied' when trying to execute the script (%s). Please double-check you have the correct kube-context."
 
 	// zarf init
 	CmdInitShort = "Prepares a k8s cluster for the deployment of Zarf packages"
@@ -202,7 +197,6 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInternalUpdateGiteaPVCShort = "Updates an existing Gitea persistent volume claim"
 	CmdInternalUpdateGiteaPVCLong  = "Updates an existing Gitea persistent volume claim by assessing if claim is a custom user provided claim or default." +
 		"This is called internally by the supported Gitea package component."
-	CmdInternalUpdateGiteaPVCErr          = "Unable to update the existing Gitea persistent volume claim."
 	CmdInternalFlagUpdateGiteaPVCRollback = "Roll back previous Gitea persistent volume claim updates."
 
 	CmdInternalIsValidHostnameShort = "Checks if the current machine's hostname is RFC1123 compliant"
@@ -267,7 +261,6 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageCreateFlagDifferential          = "[beta] Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package"
 	CmdPackageCreateFlagRegistryOverride      = "Specify a map of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)"
 	CmdPackageCreateFlagFlavor                = "The flavor of components to include in the resulting package (i.e. have a matching or empty \"only.flavor\" key)"
-	CmdPackageCreateCleanPathErr              = "Invalid characters in Zarf cache path, defaulting to %s"
 
 	CmdPackageDeployFlagConfirm                        = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdPackageDeployFlagAdoptExistingResources         = "Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover."
@@ -332,8 +325,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 		"This should only be used for manifests that are not mutated by the Zarf Agent Mutating Webhook."
 	CmdDevPatchGitOverwritePrompt = "Overwrite the file %s with these changes?"
 
-	CmdDevSha256sumShort         = "Generates a SHA256SUM for the given file"
-	CmdDevSha256sumRemoteWarning = "This is a remote source. If a published checksum is available you should use that rather than calculating it directly from the remote link."
+	CmdDevSha256sumShort = "Generates a SHA256SUM for the given file"
 
 	CmdDevFindImagesShort = "Evaluates components in a Zarf file to identify images specified in their helm charts and manifests"
 	CmdDevFindImagesLong  = "Evaluates components in a Zarf file to identify images specified in their helm charts and manifests.\n\n" +
@@ -429,10 +421,9 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 	CmdToolsRegistryFlagNonDist  = "Allow pushing non-distributable (foreign) layers"
 	CmdToolsRegistryFlagPlatform = "Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64)."
 
-	CmdToolsGetGitPasswdShort       = "[Deprecated] Returns the push user's password for the Git server"
-	CmdToolsGetGitPasswdLong        = "[Deprecated] Reads the password for a user with push access to the configured Git server in Zarf State. Note that this command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0."
-	CmdToolsGetGitPasswdDeprecation = "Deprecated: This command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0."
-	CmdToolsYqExample               = `
+	CmdToolsGetGitPasswdShort = "[Deprecated] Returns the push user's password for the Git server"
+	CmdToolsGetGitPasswdLong  = "[Deprecated] Reads the password for a user with push access to the configured Git server in Zarf State. Note that this command has been replaced by 'zarf tools get-creds git' and will be removed in Zarf v1.0.0."
+	CmdToolsYqExample         = `
 # yq defaults to 'eval' command if no command is specified. See "zarf tools yq eval --help" for more examples.
 
 # read the "stuff" node from "myfile.yml"
@@ -622,9 +613,4 @@ var (
 	ErrInitNotFound        = errors.New("this command requires a zarf-init package, but one was not found on the local system. Re-run the last command again without '--confirm' to download the package")
 	ErrUnableToCheckArch   = errors.New("unable to get the configured cluster's architecture")
 	ErrUnableToGetPackages = errors.New("unable to load the Zarf Package data from the cluster")
-)
-
-// Collection of reusable warn messages.
-var (
-	WarnSGetDeprecation = "Using sget to download resources is being deprecated and will removed in the v1.0.0 release of Zarf. Please publish the packages as OCI artifacts instead."
 )

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -315,9 +315,8 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a ar
 $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a skeleton`
 	CmdPackagePullFlagOutputDirectory = "Specify the output directory for the pulled Zarf package"
 
-	CmdPackageChoose                = "Choose or type the package file"
-	CmdPackageClusterSourceFallback = "%q does not satisfy any current sources, assuming it is a package deployed to a cluster"
-	CmdPackageInvalidSource         = "Unable to identify source from %q: %s"
+	CmdPackageChoose        = "Choose or type the package file"
+	CmdPackageInvalidSource = "Unable to identify source from %q: %s"
 
 	// zarf dev (prepare is an alias for dev)
 	CmdDevShort = "Commands useful for developing packages"

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
@@ -64,8 +63,6 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 	if err != nil {
 		return nil, err
 	}
-
-	message.Debugf("Using the url of (%s) to mutate the ArgoCD Application", state.GitServer.Address)
 
 	app := Application{}
 	if err = json.Unmarshal(r.Object.Raw, &app); err != nil {
@@ -125,7 +122,6 @@ func getPatchedRepoURL(repoURL string, gs types.GitServerInfo, r *v1.AdmissionRe
 			return "", fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original repoURL of (%s) got mutated to (%s)", repoURL, patchedURL)
 	}
 
 	return patchedURL, nil

--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,13 +32,14 @@ func createArgoAppAdmissionRequest(t *testing.T, op v1.Operation, argoApp *Appli
 func TestArgoAppWebhook(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
+
 	state := &types.ZarfState{GitServer: types.GitServerInfo{
 		Address:      "https://git-server.com",
 		PushUsername: "a-push-user",
 	}}
 	c := createTestClientWithZarfState(ctx, t, state)
-	handler := admission.NewHandler().Serve(NewApplicationMutationHook(ctx, c))
+	handler := admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c))
 
 	tests := []admissionTest{
 		{

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -91,7 +91,6 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 			return nil, fmt.Errorf("unable the git url: %w", err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original url of (%s) got mutated to (%s)", repoCreds.URL, patchedURL)
 	}
 
 	patches := populateArgoRepositoryPatchOperations(patchedURL, state.GitServer)

--- a/src/internal/agent/hooks/argocd-repository_test.go
+++ b/src/internal/agent/hooks/argocd-repository_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	b64 "encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +35,8 @@ func createArgoRepoAdmissionRequest(t *testing.T, op v1.Operation, argoRepo *cor
 func TestArgoRepoWebhook(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
+
 	state := &types.ZarfState{GitServer: types.GitServerInfo{
 		Address:      "https://git-server.com",
 		PushUsername: "a-push-user",
@@ -43,7 +44,7 @@ func TestArgoRepoWebhook(t *testing.T) {
 		PullUsername: "a-pull-user",
 	}}
 	c := createTestClientWithZarfState(ctx, t, state)
-	handler := admission.NewHandler().Serve(NewRepositorySecretMutationHook(ctx, c))
+	handler := admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c))
 
 	tests := []admissionTest{
 		{

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -16,7 +16,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	v1 "k8s.io/api/admission/v1"
 )
@@ -51,8 +50,6 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		return nil, err
 	}
 
-	message.Debugf("Using the url of (%s) to mutate the flux repository", state.GitServer.Address)
-
 	repo := flux.GitRepository{}
 	if err = json.Unmarshal(r.Object.Raw, &repo); err != nil {
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
@@ -78,7 +75,6 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 			return nil, fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original git URL of (%s) got mutated to (%s)", repo.Spec.URL, patchedURL)
 	}
 
 	// Patch updates of the repo spec

--- a/src/internal/agent/hooks/flux-gitrepo_test.go
+++ b/src/internal/agent/hooks/flux-gitrepo_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,13 +36,14 @@ func createFluxGitRepoAdmissionRequest(t *testing.T, op v1.Operation, fluxGitRep
 func TestFluxMutationWebhook(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
+
 	state := &types.ZarfState{GitServer: types.GitServerInfo{
 		Address:      "https://git-server.com",
 		PushUsername: "a-push-user",
 	}}
 	c := createTestClientWithZarfState(ctx, t, state)
-	handler := admission.NewHandler().Serve(NewGitRepositoryMutationHook(ctx, c))
+	handler := admission.NewHandler().Serve(ctx, NewGitRepositoryMutationHook(ctx, c))
 
 	tests := []admissionTest{
 		{

--- a/src/internal/agent/hooks/flux-helmrepo.go
+++ b/src/internal/agent/hooks/flux-helmrepo.go
@@ -13,13 +13,14 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/fluxcd/pkg/apis/meta"
 	flux "github.com/fluxcd/source-controller/api/v1"
+	v1 "k8s.io/api/admission/v1"
+
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
-	v1 "k8s.io/api/admission/v1"
 )
 
 // NewHelmRepositoryMutationHook creates a new instance of the helm repo mutation hook.
@@ -43,7 +44,7 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 
 	// If we see a type of helm repo other than OCI we should flag a warning and return
 	if strings.ToLower(src.Spec.Type) != "oci" {
-		message.Warnf(lang.AgentWarnNotOCIType, src.Spec.Type)
+		logging.FromContextOrDiscard(ctx).Warn("Skipping HelmRepo mutation because the type is not OCI", "type", src.Spec.Type)
 		return &operations.Result{Allowed: true}, nil
 	}
 

--- a/src/internal/agent/hooks/flux-helmrepo.go
+++ b/src/internal/agent/hooks/flux-helmrepo.go
@@ -65,8 +65,6 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 		return nil, err
 	}
 
-	message.Debugf("Using the url of (%s) to mutate the flux HelmRepository", registryAddress)
-
 	patchedSrc, err := transform.ImageTransformHost(registryAddress, src.Spec.URL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to transform the HelmRepo URL: %w", err)
@@ -77,8 +75,6 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 		return nil, fmt.Errorf("unable to parse the HelmRepo URL: %w", err)
 	}
 	patchedURL := helpers.OCIURLPrefix + patchedRefInfo.Name
-
-	message.Debugf("original HelmRepo URL of (%s) got mutated to (%s)", src.Spec.URL, patchedURL)
 
 	patches := populateHelmRepoPatchOperations(patchedURL, zarfState.RegistryInfo.IsInternal())
 

--- a/src/internal/agent/hooks/flux-helmrepo_test.go
+++ b/src/internal/agent/hooks/flux-helmrepo_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +37,8 @@ func createFluxHelmRepoAdmissionRequest(t *testing.T, op v1.Operation, fluxHelmR
 func TestFluxHelmMutationWebhook(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
+
 	state := &types.ZarfState{RegistryInfo: types.RegistryInfo{Address: "127.0.0.1:31999"}}
 
 	tests := []admissionTest{
@@ -167,7 +168,7 @@ func TestFluxHelmMutationWebhook(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := createTestClientWithZarfState(ctx, t, state)
-			handler := admission.NewHandler().Serve(NewHelmRepositoryMutationHook(ctx, c))
+			handler := admission.NewHandler().Serve(ctx, NewHelmRepositoryMutationHook(ctx, c))
 			if tt.svc != nil {
 				_, err := c.Clientset.CoreV1().Services("zarf").Create(ctx, tt.svc, metav1.CreateOptions{})
 				require.NoError(t, err)

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -12,13 +12,14 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/fluxcd/pkg/apis/meta"
 	flux "github.com/fluxcd/source-controller/api/v1beta2"
+	v1 "k8s.io/api/admission/v1"
+
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
-	v1 "k8s.io/api/admission/v1"
 )
 
 // NewOCIRepositoryMutationHook creates a new instance of the oci repo mutation hook.
@@ -47,7 +48,7 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	// If we have a semver we want to continue since we will still have the upstream tag
 	// but should warn that we can't guarantee there won't be collisions
 	if src.Spec.Reference.SemVer != "" {
-		message.Warnf(lang.AgentWarnSemVerRef, src.Spec.Reference.SemVer)
+		logging.FromContextOrDiscard(ctx).Warn("Detected a smever OCI ref, continuing but will be unable to guarantee against collisions if multiple OCI artifacts with the same name are broudt in from different registries", "semver", src.Spec.Reference.SemVer)
 	}
 
 	if src.Labels != nil && src.Labels["zarf-agent"] == "patched" {

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -44,7 +44,7 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		src.Spec.Reference = &flux.OCIRepositoryRef{}
 	}
 
-	// If we have a semver we want to continue since we wil still have the upstream tag
+	// If we have a semver we want to continue since we will still have the upstream tag
 	// but should warn that we can't guarantee there won't be collisions
 	if src.Spec.Reference.SemVer != "" {
 		message.Warnf(lang.AgentWarnSemVerRef, src.Spec.Reference.SemVer)
@@ -69,8 +69,6 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	}
 
 	// For the internal registry this will be the ip & port of the service, it may look like 10.43.36.151:5000
-	message.Debugf("Using the url of (%s) to mutate the flux OCIRepository", registryAddress)
-
 	ref := src.Spec.URL
 	if src.Spec.Reference.Digest != "" {
 		ref = fmt.Sprintf("%s@%s", ref, src.Spec.Reference.Digest)
@@ -96,8 +94,6 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	} else if patchedRefInfo.Tag != "" {
 		patchedRef.Tag = patchedRefInfo.Tag
 	}
-
-	message.Debugf("original OCIRepo URL of (%s) got mutated to (%s)", src.Spec.URL, patchedURL)
 
 	patches := populateOCIRepoPatchOperations(patchedURL, zarfState.RegistryInfo.IsInternal(), patchedRef)
 

--- a/src/internal/agent/hooks/flux-ocirepo_test.go
+++ b/src/internal/agent/hooks/flux-ocirepo_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -189,14 +189,14 @@ func TestFluxOCIMutationWebhook(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
 	state := &types.ZarfState{RegistryInfo: types.RegistryInfo{Address: "127.0.0.1:31999"}}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := createTestClientWithZarfState(ctx, t, state)
-			handler := admission.NewHandler().Serve(NewOCIRepositoryMutationHook(ctx, c))
+			handler := admission.NewHandler().Serve(ctx, NewOCIRepositoryMutationHook(ctx, c))
 			if tt.svc != nil {
 				_, err := c.Clientset.CoreV1().Services("zarf").Create(ctx, tt.svc, metav1.CreateOptions{})
 				require.NoError(t, err)

--- a/src/internal/agent/hooks/pods_test.go
+++ b/src/internal/agent/hooks/pods_test.go
@@ -4,7 +4,6 @@
 package hooks
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,11 +35,11 @@ func createPodAdmissionRequest(t *testing.T, op v1.Operation, pod *corev1.Pod) *
 func TestPodMutationWebhook(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testutil.TestContext(t)
 
 	state := &types.ZarfState{RegistryInfo: types.RegistryInfo{Address: "127.0.0.1:31999"}}
 	c := createTestClientWithZarfState(ctx, t, state)
-	handler := admission.NewHandler().Serve(NewPodMutationHook(ctx, c))
+	handler := admission.NewHandler().Serve(ctx, NewPodMutationHook(ctx, c))
 
 	tests := []admissionTest{
 		{

--- a/src/internal/agent/http/admission/handler.go
+++ b/src/internal/agent/http/admission/handler.go
@@ -7,6 +7,7 @@
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	corev1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +36,9 @@ func NewHandler() *Handler {
 }
 
 // Serve returns an http.HandlerFunc for an admission webhook.
-func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
+func (h *Handler) Serve(ctx context.Context, hook operations.Hook) http.HandlerFunc {
+	log := logging.FromContextOrDiscard(ctx)
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method != http.MethodPost {
@@ -70,7 +74,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 			Kind:       "AdmissionReview",
 		}
 		if err != nil {
-			message.Warnf("%s: %s", lang.AgentErrBindHandler, err.Error())
+			log.Warn("Unable to bind the webhook handler", "error", err)
 			admissionResponse := corev1.AdmissionReview{
 				TypeMeta: admissionMeta,
 				Response: &corev1.AdmissionResponse{
@@ -79,7 +83,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 			}
 			jsonResponse, err := json.Marshal(admissionResponse)
 			if err != nil {
-				message.WarnErr(err, lang.AgentErrMarshalResponse)
+				log.Warn(lang.AgentErrMarshalResponse, "error", err)
 				http.Error(w, lang.AgentErrMarshalResponse, http.StatusInternalServerError)
 				return
 			}
@@ -103,7 +107,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 			jsonPatchType := corev1.PatchTypeJSONPatch
 			patchBytes, err := json.Marshal(result.PatchOps)
 			if err != nil {
-				message.WarnErr(err, lang.AgentErrMarshallJSONPatch)
+				log.Warn(lang.AgentErrMarshallJSONPatch, "error", err)
 				http.Error(w, lang.AgentErrMarshallJSONPatch, http.StatusInternalServerError)
 			}
 			admissionResponse.Response.Patch = patchBytes
@@ -112,7 +116,7 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 
 		jsonResponse, err := json.Marshal(admissionResponse)
 		if err != nil {
-			message.WarnErr(err, lang.AgentErrMarshalResponse)
+			log.Warn(lang.AgentErrMarshalResponse, "error", err)
 			http.Error(w, lang.AgentErrMarshalResponse, http.StatusInternalServerError)
 			return
 		}

--- a/src/internal/agent/http/proxy.go
+++ b/src/internal/agent/http/proxy.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -14,17 +15,19 @@ import (
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
 // ProxyHandler constructs a new httputil.ReverseProxy and returns an http handler.
-func ProxyHandler(cluster *cluster.Cluster) http.HandlerFunc {
+func ProxyHandler(ctx context.Context, cluster *cluster.Cluster) http.HandlerFunc {
+	log := logging.FromContextOrDiscard(ctx)
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		state, err := cluster.LoadZarfState(r.Context())
 		if err != nil {
-			message.Debugf("%#v", err)
+			log.Debug("load zarf state failed", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			//nolint: errcheck // ignore
 			w.Write([]byte("unable to load Zarf state, see the Zarf HTTP proxy logs for more details"))
@@ -32,7 +35,7 @@ func ProxyHandler(cluster *cluster.Cluster) http.HandlerFunc {
 		}
 		err = proxyRequestTransform(r, state)
 		if err != nil {
-			message.Debugf("%#v", err)
+			log.Debug("proxy request transporm failed", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			//nolint: errcheck // ignore
 			w.Write([]byte("unable to transform the provided request, see the Zarf HTTP proxy logs for more details"))

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -58,7 +58,7 @@ func StartWebhook(ctx context.Context, cluster *cluster.Cluster) error {
 // StartHTTPProxy launches the zarf agent proxy in the cluster.
 func StartHTTPProxy(ctx context.Context, cluster *cluster.Cluster) error {
 	mux := http.NewServeMux()
-	mux.Handle("/", agentHttp.ProxyHandler(cluster))
+	mux.Handle("/", agentHttp.ProxyHandler(ctx, cluster))
 	return startServer(ctx, httpPort, mux)
 }
 

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -45,12 +45,12 @@ func StartWebhook(ctx context.Context, cluster *cluster.Cluster) error {
 
 	// Routers
 	mux := http.NewServeMux()
-	mux.Handle("/mutate/pod", admissionHandler.Serve(podsMutation))
-	mux.Handle("/mutate/flux-gitrepository", admissionHandler.Serve(fluxGitRepositoryMutation))
-	mux.Handle("/mutate/flux-helmrepository", admissionHandler.Serve(fluxHelmRepositoryMutation))
-	mux.Handle("/mutate/flux-ocirepository", admissionHandler.Serve(fluxOCIRepositoryMutation))
-	mux.Handle("/mutate/argocd-application", admissionHandler.Serve(argocdApplicationMutation))
-	mux.Handle("/mutate/argocd-repository", admissionHandler.Serve(argocdRepositoryMutation))
+	mux.Handle("/mutate/pod", admissionHandler.Serve(ctx, podsMutation))
+	mux.Handle("/mutate/flux-gitrepository", admissionHandler.Serve(ctx, fluxGitRepositoryMutation))
+	mux.Handle("/mutate/flux-helmrepository", admissionHandler.Serve(ctx, fluxHelmRepositoryMutation))
+	mux.Handle("/mutate/flux-ocirepository", admissionHandler.Serve(ctx, fluxOCIRepositoryMutation))
+	mux.Handle("/mutate/argocd-application", admissionHandler.Serve(ctx, argocdApplicationMutation))
+	mux.Handle("/mutate/argocd-repository", admissionHandler.Serve(ctx, argocdRepositoryMutation))
 
 	return startServer(ctx, httpPort, mux)
 }

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -193,8 +193,7 @@ func (h *Helm) RemoveChart(namespace string, name string, spinner *message.Spinn
 	// Establish a new actionConfig for the namespace.
 	_ = h.createActionConfig(namespace, spinner)
 	// Perform the uninstall.
-	response, err := h.uninstallChart(name)
-	message.Debug(response)
+	_, err := h.uninstallChart(name)
 	return err
 }
 

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -6,7 +6,6 @@ package helm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -307,19 +306,8 @@ func (h *Helm) buildChartDependencies() error {
 
 	// Build the deps from the helm chart
 	err = man.Build()
-	var notFoundErr *downloader.ErrRepoNotFound
-	if errors.As(err, &notFoundErr) {
-		// If we encounter a repo not found error point the user to `zarf tools helm repo add`
-		message.Warnf("%s. Please add the missing repo(s) via the following:", notFoundErr.Error())
-		for _, repository := range notFoundErr.Repos {
-			message.ZarfCommand(fmt.Sprintf("tools helm repo add <your-repo-name> %s", repository))
-		}
-		return err
-	}
 	if err != nil {
-		message.ZarfCommand("tools helm dependency build --verify")
-		message.Warnf("Unable to perform a rebuild of Helm dependencies: %s", err.Error())
-		return err
+		return fmt.Errorf("Unable to perform rebuild of Helm dependencies: %w", err)
 	}
 	return nil
 }

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/git"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -39,7 +40,7 @@ func (h *Helm) PackageChart(ctx context.Context, cosignKeyPath string) error {
 		// check if the chart is a git url with a ref (if an error is returned url will be empty)
 		isGitURL := strings.HasSuffix(url, ".git")
 		if err != nil {
-			message.Debugf("unable to parse the url, continuing with %s", h.chart.URL)
+			logging.FromContextOrDiscard(ctx).Debug("continuing with original url as the url could not be parsed", "url", h.chart.URL, "error", err)
 		}
 
 		if isGitURL {
@@ -147,7 +148,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 
 	// Not returning the error here since the repo file is only needed if we are pulling from a repo that requires authentication
 	if err != nil {
-		message.Debugf("Unable to load the repo file at %q: %s", pull.Settings.RepositoryConfig, err.Error())
+		logging.FromContextOrDiscard(ctx).Debug("unable to load the repository file", "path", pull.Settings.RepositoryConfig, "error", err)
 	}
 
 	var username string

--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -112,7 +112,7 @@ func (h *Helm) UpdateZarfAgentValues(ctx context.Context) error {
 					Value: agentImage.Tag,
 				},
 			})
-			applicationTemplates, err := template.GetZarfTemplates("zarf-agent", h.state)
+			applicationTemplates, err := template.GetZarfTemplates(ctx, "zarf-agent", h.state)
 			if err != nil {
 				return fmt.Errorf("error setting up the templates: %w", err)
 			}

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -225,7 +225,7 @@ func Pull(ctx context.Context, cfg PullConfig) (map[transform.Image]v1.Image, er
 
 	doneSaving := make(chan error)
 	updateText := fmt.Sprintf("Pulling %d images", imageCount)
-	go utils.RenderProgressBarForLocalDirWrite(cfg.DestinationDirectory, totalBytes.Load(), doneSaving, updateText, updateText)
+	go utils.RenderProgressBarForLocalDirWrite(ctx, cfg.DestinationDirectory, totalBytes.Load(), doneSaving, updateText, updateText)
 
 	toPull := maps.Clone(fetched)
 

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -115,8 +115,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 				return err
 			}
 
-			message.Debugf("push %s -> %s)", refInfo.Reference, offlineName)
-
 			if err = pushImage(img, offlineName); err != nil {
 				return err
 			}

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -5,6 +5,7 @@
 package sbom
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"os"
@@ -27,6 +28,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -48,7 +50,7 @@ var transformRegex = regexp.MustCompile(`(?m)[^a-zA-Z0-9\.\-]`)
 var componentPrefix = "zarf-component-"
 
 // Catalog catalogs the given components and images to create an SBOM.
-func Catalog(componentSBOMs map[string]*layout.ComponentSBOM, imageList []transform.Image, paths *layout.PackagePaths) error {
+func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBOM, imageList []transform.Image, paths *layout.PackagePaths) error {
 	imageCount := len(imageList)
 	componentCount := len(componentSBOMs)
 	builder := Builder{
@@ -103,7 +105,7 @@ func Catalog(componentSBOMs map[string]*layout.ComponentSBOM, imageList []transf
 		builder.spinner.Updatef("Creating component file SBOMs (%d of %d): %s", currComponent, componentCount, component)
 
 		if componentSBOMs[component] == nil {
-			message.Debugf("Component %s has invalid SBOM, skipping", component)
+			logging.FromContextOrDiscard(ctx).Debug("component has invalid SBOM, skipping", "component", component)
 			continue
 		}
 

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -5,6 +5,7 @@
 package template
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
@@ -41,7 +43,7 @@ func GetZarfVariableConfig() *variables.VariableConfig {
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.
-func GetZarfTemplates(componentName string, state *types.ZarfState) (templateMap map[string]*variables.TextTemplate, err error) {
+func GetZarfTemplates(ctx context.Context, componentName string, state *types.ZarfState) (templateMap map[string]*variables.TextTemplate, err error) {
 	templateMap = make(map[string]*variables.TextTemplate)
 
 	if state != nil {
@@ -100,7 +102,7 @@ func GetZarfTemplates(componentName string, state *types.ZarfState) (templateMap
 		}
 	}
 
-	debugPrintTemplateMap(templateMap)
+	debugPrintTemplateMap(ctx, templateMap)
 
 	return templateMap, nil
 }
@@ -125,7 +127,7 @@ func generateHtpasswd(regInfo *types.RegistryInfo) (string, error) {
 	return "", nil
 }
 
-func debugPrintTemplateMap(templateMap map[string]*variables.TextTemplate) {
+func debugPrintTemplateMap(ctx context.Context, templateMap map[string]*variables.TextTemplate) {
 	debugText := "templateMap = { "
 
 	for key, template := range templateMap {
@@ -137,6 +139,5 @@ func debugPrintTemplateMap(templateMap map[string]*variables.TextTemplate) {
 	}
 
 	debugText += " }"
-
-	message.Debug(debugText)
+	logging.FromContextOrDiscard(ctx).Debug(debugText)
 }

--- a/src/pkg/cluster/data.go
+++ b/src/pkg/cluster/data.go
@@ -25,7 +25,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logging"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 )
@@ -92,7 +91,7 @@ func (c *Cluster) HandleDataInjection(ctx context.Context, data v1alpha1.ZarfDat
 		zarfCommand, err := utils.GetFinalExecutableCommand()
 		kubectlBinPath := "kubectl"
 		if err != nil {
-			message.Warnf("Unable to get the zarf executable path, falling back to host kubectl: %s", err)
+			log.Warn("unable to get the zarf executable path falling back to host kubectl", "error", err)
 		} else {
 			kubectlBinPath = fmt.Sprintf("%s tools kubectl", zarfCommand)
 		}

--- a/src/pkg/cluster/secrets.go
+++ b/src/pkg/cluster/secrets.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -198,7 +199,7 @@ func (c *Cluster) GetServiceInfoFromRegistryAddress(ctx context.Context, stateRe
 	// If this is an internal service then we need to look it up and
 	svc, port, err := serviceInfoFromNodePortURL(serviceList.Items, stateRegistryAddress)
 	if err != nil {
-		message.Debugf("registry appears to not be a nodeport service, using original address %q", stateRegistryAddress)
+		logging.FromContextOrDiscard(ctx).Debug("registry appears to not be a node port service, using original address", "address", stateRegistryAddress)
 		return stateRegistryAddress, nil
 	}
 

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -37,6 +37,8 @@ const (
 
 // InitZarfState initializes the Zarf state with the given temporary directory and init configs.
 func (c *Cluster) InitZarfState(ctx context.Context, initOptions types.ZarfInitOptions) error {
+	log := logging.FromContextOrDiscard(ctx)
+
 	spinner := message.NewProgressSpinner("Gathering cluster state information")
 	defer spinner.Stop()
 
@@ -155,16 +157,13 @@ func (c *Cluster) InitZarfState(ctx context.Context, initOptions types.ZarfInitO
 		state.ArtifactServer = initOptions.ArtifactServer
 	} else {
 		if helpers.IsNotZeroAndNotEqual(initOptions.GitServer, state.GitServer) {
-			message.Warn("Detected a change in Git Server init options on a re-init. Ignoring... To update run:")
-			message.ZarfCommand("tools update-creds git")
+			log.Warn("Detected a change in Git Server init options on a re-init. Ignoring... To update run: zarf tools update-creds git")
 		}
 		if helpers.IsNotZeroAndNotEqual(initOptions.RegistryInfo, state.RegistryInfo) {
-			message.Warn("Detected a change in Image Registry init options on a re-init. Ignoring... To update run:")
-			message.ZarfCommand("tools update-creds registry")
+			log.Warn("Detected a change in Image Registry init options on a re-init. Ignoring... To update run: zarf tools update-creds registry")
 		}
 		if helpers.IsNotZeroAndNotEqual(initOptions.ArtifactServer, state.ArtifactServer) {
-			message.Warn("Detected a change in Artifact Server init options on a re-init. Ignoring... To update run:")
-			message.ZarfCommand("tools update-creds artifact")
+			log.Warn("Detected a change in Artifact Server init options on a re-init. Ignoring... To update run: zarf tools update-creds artifact")
 		}
 	}
 

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/types"
@@ -203,7 +204,7 @@ func (c *Cluster) LoadZarfState(ctx context.Context) (state *types.ZarfState, er
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 	return state, nil
 }
 
@@ -228,7 +229,7 @@ func (c *Cluster) sanitizeZarfState(state *types.ZarfState) *types.ZarfState {
 	return state
 }
 
-func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
+func (c *Cluster) debugPrintZarfState(ctx context.Context, state *types.ZarfState) {
 	if state == nil {
 		return
 	}
@@ -239,12 +240,12 @@ func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
 	if err != nil {
 		return
 	}
-	message.Debugf("ZarfState - %s", string(b))
+	logging.FromContextOrDiscard(ctx).Debug("ZarfState", "state", string(b))
 }
 
 // SaveZarfState takes a given state and persists it to the Zarf/zarf-state secret.
 func (c *Cluster) SaveZarfState(ctx context.Context, state *types.ZarfState) error {
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 
 	data, err := json.Marshal(&state)
 	if err != nil {

--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -12,15 +12,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/gitea"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -181,7 +182,7 @@ func (c *Cluster) RecordPackageDeployment(ctx context.Context, pkg v1alpha1.Zarf
 	var componentWebhooks map[string]map[string]types.Webhook
 	existingPackageSecret, err := c.GetDeployedPackage(ctx, packageName)
 	if err != nil {
-		message.Debugf("Unable to fetch existing secret for package '%s': %s", packageName, err.Error())
+		logging.FromContextOrDiscard(ctx).Debug("unable to fetch existing secret for package", "package", packageName, "error", err)
 	}
 	if existingPackageSecret != nil {
 		componentWebhooks = existingPackageSecret.ComponentWebhooks

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/mholt/archiver/v3"
+
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // ComponentPaths contains paths for a component.
@@ -58,7 +58,6 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 	}
 	if size > 0 {
 		tb := fmt.Sprintf("%s.tar", base)
-		message.Debugf("Archiving %q", name)
 		if err := helpers.CreateReproducibleTarballFromDir(base, name, tb); err != nil {
 			return err
 		}
@@ -66,8 +65,6 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 			c.Tarballs = make(map[string]string)
 		}
 		c.Tarballs[name] = tb
-	} else {
-		message.Debugf("Component %q is empty, skipping archiving", name)
 	}
 
 	delete(c.Dirs, name)
@@ -126,11 +123,9 @@ func (c *Components) Unarchive(component v1alpha1.ZarfComponent) (err error) {
 
 	// if the component is already unarchived, skip
 	if !helpers.InvalidPath(cs.Base) {
-		message.Debugf("Component %q already unarchived", name)
 		return nil
 	}
 
-	message.Debugf("Unarchiving %q", filepath.Base(tb))
 	if err := archiver.Unarchive(tb, c.Base); err != nil {
 		return err
 	}

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -99,7 +99,6 @@ func (pp *PackagePaths) MigrateLegacy() (err error) {
 	legacySBOMs := filepath.Join(base, "sboms")
 	if !helpers.InvalidPath(legacySBOMs) {
 		pp = pp.AddSBOMs()
-		message.Debugf("Migrating %q to %q", legacySBOMs, pp.SBOMs.Path)
 		if err := os.Rename(legacySBOMs, pp.SBOMs.Path); err != nil {
 			return err
 		}
@@ -109,7 +108,6 @@ func (pp *PackagePaths) MigrateLegacy() (err error) {
 	legacyImagesTar := filepath.Join(base, "images.tar")
 	if !helpers.InvalidPath(legacyImagesTar) {
 		pp = pp.AddImages()
-		message.Debugf("Migrating %q to %q", legacyImagesTar, pp.Images.Base)
 		defer os.Remove(legacyImagesTar)
 		imgTags := []string{}
 		for _, component := range pkg.Components {
@@ -309,8 +307,6 @@ func (pp *PackagePaths) SetFromPaths(paths []string) {
 				pp.Components.Tarballs = make(map[string]string)
 			}
 			pp.Components.Tarballs[componentName] = filepath.Join(pp.Base, path)
-		default:
-			message.Debug("ignoring path", path)
 		}
 	}
 }

--- a/src/pkg/logging/handler.go
+++ b/src/pkg/logging/handler.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/zarf-dev/zarf/src/pkg/message"
+)
+
+// PtermHandler is a slog handler that prints using Pterm.
+type PtermHandler struct {
+	attrs []slog.Attr
+	group string
+}
+
+// NewPtermHandler returns a new instance of PtermHandler.
+func NewPtermHandler() *PtermHandler {
+	return &PtermHandler{}
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) Handle(ctx context.Context, r slog.Record) error {
+	attrs := []string{}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a.String())
+		return true
+	})
+	out := fmt.Sprintf("%s %s", r.Message, strings.Join(attrs, " "))
+	switch r.Level {
+	case slog.LevelDebug:
+		message.Debug(out)
+	case slog.LevelInfo:
+		message.Info(out)
+	case slog.LevelWarn:
+		message.Warn(out)
+	case slog.LevelError:
+		message.Warn(out)
+	}
+	return nil
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &PtermHandler{
+		attrs: append(h.attrs, attrs...),
+		group: h.group,
+	}
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) WithGroup(name string) slog.Handler {
+	return &PtermHandler{
+		attrs: h.attrs,
+		group: name,
+	}
+}

--- a/src/pkg/logging/logging.go
+++ b/src/pkg/logging/logging.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package logging contains logging related functionality.
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+type contextKey struct{}
+
+// NewContext returns a child context containing the given logger.
+func NewContext(ctx context.Context, log *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, log)
+}
+
+// FromContextOrDiscard returns the logger stored in the context.
+func FromContextOrDiscard(ctx context.Context) *slog.Logger {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	log, ok := v.(*slog.Logger)
+	if !ok {
+		// This should never happen.
+		panic("unexpected logger type")
+	}
+	return log
+}

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -131,12 +131,6 @@ func Warnf(format string, a ...any) {
 	pterm.Warning.Println(message)
 }
 
-// WarnErr prints an error message as a warning.
-func WarnErr(err any, message string) {
-	debugPrinter(2, err)
-	Warnf(message)
-}
-
 // WarnErrf prints an error message as a warning with a given format.
 func WarnErrf(err any, format string, a ...any) {
 	debugPrinter(2, err)

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -119,12 +119,6 @@ func Debug(payload ...any) {
 	debugPrinter(2, payload...)
 }
 
-// Debugf prints a debug message with a given format.
-func Debugf(format string, a ...any) {
-	message := fmt.Sprintf(format, a...)
-	debugPrinter(2, message)
-}
-
 // Warn prints a warning message.
 func Warn(message string) {
 	Warnf("%s", message)

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/deprecated"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -71,7 +72,7 @@ New creates a new package instance with the provided config.
 
 Note: This function creates a tmp directory that should be cleaned up with p.ClearTempPaths().
 */
-func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
+func New(ctx context.Context, cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("no config provided")
 	}
@@ -110,7 +111,7 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create package temp paths: %w", err)
 		}
-		message.Debug("Using temporary directory:", dir)
+		logging.FromContextOrDiscard(ctx).Debug("Using temporary directory", "directory", dir)
 		pkgr.layout = layout.New(dir)
 	}
 

--- a/src/pkg/packager/composer/oci.go
+++ b/src/pkg/packager/composer/oci.go
@@ -17,7 +17,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	ocistore "oras.land/oras-go/v2/content/oci"
@@ -80,7 +80,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 
 		dir = filepath.Join(cache, "dirs", id)
 
-		message.Debug("creating empty directory for remote component:", filepath.Join("<zarf-cache>", "oci", "dirs", id))
+		logging.FromContextOrDiscard(ctx).Debug("Creaing empty directory for remote component", "path", filepath.Join("<zarf-cache>", "oci", "dirs", id))
 	} else {
 		tb = filepath.Join(cache, "blobs", "sha256", componentDesc.Digest.Encoded())
 		dir = filepath.Join(cache, "dirs", componentDesc.Digest.Encoded())
@@ -97,7 +97,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 		} else if !exists {
 			doneSaving := make(chan error)
 			successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+remote.Repo().Reference.String())
-			go utils.RenderProgressBarForLocalDirWrite(cache, componentDesc.Size, doneSaving, "Pulling", successText)
+			go utils.RenderProgressBarForLocalDirWrite(ctx, cache, componentDesc.Size, doneSaving, "Pulling", successText)
 			err = remote.CopyToTarget(ctx, []ocispec.Descriptor{componentDesc}, store, remote.GetDefaultCopyOpts())
 			doneSaving <- err
 			<-doneSaving

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -41,7 +41,7 @@ func (p *Packager) Create(ctx context.Context) error {
 	}
 	p.cfg.Pkg = pkg
 
-	if !p.confirmAction(config.ZarfCreateStage, warnings, nil) {
+	if !p.confirmAction(ctx, config.ZarfCreateStage, warnings, nil) {
 		return fmt.Errorf("package creation canceled")
 	}
 

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
@@ -68,7 +69,7 @@ func (sc *SkeletonCreator) LoadPackageDefinition(ctx context.Context, src *layou
 	}
 
 	for _, warning := range warnings {
-		message.Warn(warning)
+		logging.FromContextOrDiscard(ctx).Warn(warning)
 	}
 
 	if err := Validate(pkg, sc.createOpts.BaseDir, sc.createOpts.SetVariables); err != nil {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -97,7 +97,7 @@ func (p *Packager) Deploy(ctx context.Context) error {
 	warnings = append(warnings, sbomWarnings...)
 
 	// Confirm the overall package deployment
-	if !p.confirmAction(config.ZarfDeployStage, warnings, sbomViewFiles) {
+	if !p.confirmAction(ctx, config.ZarfDeployStage, warnings, sbomViewFiles) {
 		return fmt.Errorf("deployment cancelled")
 	}
 
@@ -124,7 +124,7 @@ func (p *Packager) Deploy(ctx context.Context) error {
 		return err
 	}
 	if len(deployedComponents) == 0 {
-		message.Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
+		logging.FromContextOrDiscard(ctx).Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
 	}
 
 	// Notify all the things about the successful deployment
@@ -499,7 +499,7 @@ func (p *Packager) setupState(ctx context.Context) (err error) {
 	}
 
 	if p.cfg.Pkg.Metadata.YOLO && state.Distro != "YOLO" {
-		message.Warn("This package is in YOLO mode, but the cluster was already initialized with 'zarf init'. " +
+		logging.FromContextOrDiscard(ctx).Warn("This package is in YOLO mode, but the cluster was already initialized with 'zarf init'. " +
 			"This may cause issues if the package does not exclude any charts or manifests from the Zarf Agent using " +
 			"the pod or namespace label `zarf.dev/agent: ignore'.")
 	}

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -212,7 +213,7 @@ func TestGenerateValuesOverrides(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&types.PackagerConfig{DeployOpts: tt.deployOpts}, WithSource(&sources.TarballSource{}))
+			p, err := New(testutil.TestContext(t), &types.PackagerConfig{DeployOpts: tt.deployOpts}, WithSource(&sources.TarballSource{}))
 			require.NoError(t, err)
 			for k, v := range tt.setVariables {
 				p.variableConfig.SetVariable(k, v, false, false, v1alpha1.RawVariableType)

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -13,6 +13,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
@@ -91,7 +92,7 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 		return err
 	}
 	if len(deployedComponents) == 0 {
-		message.Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
+		logging.FromContextOrDiscard(ctx).Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
 	}
 
 	// Notify all the things about the successful deployment

--- a/src/pkg/packager/generate.go
+++ b/src/pkg/packager/generate.go
@@ -17,18 +17,21 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // Generate generates a Zarf package definition.
 func (p *Packager) Generate(ctx context.Context) (err error) {
+	log := logging.FromContextOrDiscard(ctx)
+
 	generatedZarfYAMLPath := filepath.Join(p.cfg.GenerateOpts.Output, layout.ZarfYAML)
 	spinner := message.NewProgressSpinner("Generating package for %q at %s", p.cfg.GenerateOpts.Name, generatedZarfYAMLPath)
 
 	if !helpers.InvalidPath(generatedZarfYAMLPath) {
 		prefixed := filepath.Join(p.cfg.GenerateOpts.Output, fmt.Sprintf("%s-%s", p.cfg.GenerateOpts.Name, layout.ZarfYAML))
 
-		message.Warnf("%s already exists, writing to %s", generatedZarfYAMLPath, prefixed)
+		log.Warn("path already exist, writing to alternative path", "original", generatedZarfYAMLPath, "alternative", prefixed)
 
 		generatedZarfYAMLPath = prefixed
 
@@ -66,7 +69,7 @@ func (p *Packager) Generate(ctx context.Context) (err error) {
 	images, err := p.findImages(ctx)
 	if err != nil {
 		// purposefully not returning error here, as we can still generate the package without images
-		message.Warnf("Unable to find images: %s", err.Error())
+		log.Warn("Unable to find images", "error", err)
 	}
 
 	for i := range p.cfg.Pkg.Components {

--- a/src/pkg/packager/interactive.go
+++ b/src/pkg/packager/interactive.go
@@ -5,6 +5,7 @@
 package packager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,11 +15,14 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
-func (p *Packager) confirmAction(stage string, warnings []string, sbomViewFiles []string) (confirm bool) {
+func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []string, sbomViewFiles []string) (confirm bool) {
+	log := logging.FromContextOrDiscard(ctx)
+
 	pterm.Println()
 	message.HeaderInfof("📦 PACKAGE DEFINITION")
 	utils.ColorPrintYAML(p.cfg.Pkg, p.getPackageYAMLHints(stage), true)
@@ -48,7 +52,7 @@ func (p *Packager) confirmAction(stage string, warnings []string, sbomViewFiles 
 				pterm.Println(viewNow)
 				pterm.Println(viewLater)
 			} else {
-				message.Warn("This package does NOT contain an SBOM.  If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.")
+				log.Warn("This package does NOT contain an SBOM.  If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.")
 			}
 		}
 	}
@@ -57,7 +61,7 @@ func (p *Packager) confirmAction(stage string, warnings []string, sbomViewFiles 
 		message.HorizontalRule()
 		message.Title("Package Warnings", "the following warnings were flagged while reading the package")
 		for _, warning := range warnings {
-			message.Warn(warning)
+			log.Warn(warning)
 		}
 	}
 

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -37,7 +37,7 @@ func (p *Packager) Mirror(ctx context.Context) error {
 	warnings = append(warnings, sbomWarnings...)
 
 	// Confirm the overall package mirror
-	if !p.confirmAction(config.ZarfMirrorStage, warnings, sbomViewFiles) {
+	if !p.confirmAction(ctx, config.ZarfMirrorStage, warnings, sbomViewFiles) {
 		return fmt.Errorf("mirror cancelled")
 	}
 

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -41,6 +41,8 @@ var imageFuzzyCheck = regexp.MustCompile(`(?mi)["|=]([a-z0-9\-.\/:]+:[\w.\-]*[a-
 
 // FindImages iterates over a Zarf.yaml and attempts to parse any images.
 func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) {
+	log := logging.FromContextOrDiscard(ctx)
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -48,7 +50,7 @@ func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) 
 	defer func() {
 		// Return to the original working directory
 		if err := os.Chdir(cwd); err != nil {
-			message.Warnf("Unable to return to the original working directory: %s", err.Error())
+			log.Warn("Unable to return the original working directory", "error", err)
 		}
 	}()
 	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
@@ -67,7 +69,7 @@ func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) 
 		return nil, err
 	}
 	for _, warning := range warnings {
-		message.Warn(warning)
+		log.Warn(warning)
 	}
 	p.cfg.Pkg = pkg
 

--- a/src/pkg/packager/prepare_test.go
+++ b/src/pkg/packager/prepare_test.go
@@ -91,7 +91,7 @@ func TestFindImages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(tt.cfg)
+			p, err := New(ctx, tt.cfg)
 			require.NoError(t, err)
 			images, err := p.FindImages(ctx)
 			if tt.expectedErr != "" {

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
@@ -171,7 +172,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 	onRemove := c.Actions.OnRemove
 	onFailure := func() {
 		if err := actions.Run(ctx, onRemove.Defaults, onRemove.OnFailure, nil); err != nil {
-			message.Debugf("Unable to run the failure action: %s", err)
+			logging.FromContextOrDiscard(ctx).Error("unable to run the failure action", "error", err)
 		}
 	}
 

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -143,7 +144,7 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 
 		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
 			if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
-				message.Warn("The package was signed but no public key was provided, skipping signature validation")
+				logging.FromContextOrDiscard(ctx).Warn("The package was signed but no public key was provided, skipping signature validation")
 			} else {
 				return pkg, nil, err
 			}

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mholt/archiver/v3"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
@@ -187,7 +188,7 @@ func (s *TarballSource) LoadPackageMetadata(ctx context.Context, dst *layout.Pac
 
 		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
 			if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
-				message.Warn("The package was signed but no public key was provided, skipping signature validation")
+				logging.FromContextOrDiscard(ctx).Warn("The package was signed but no public key was provided, skipping signature validation")
 			} else {
 				return pkg, nil, err
 			}

--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -17,7 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
@@ -36,7 +36,7 @@ func ValidatePackageSignature(ctx context.Context, paths *layout.PackagePaths, p
 	}
 
 	if publicKeyPath != "" {
-		message.Debugf("Using public key %q for signature validation", publicKeyPath)
+		logging.FromContextOrDiscard(ctx).Debug("using public key for signature validation", "path", publicKeyPath)
 	}
 
 	// Handle situations where there is no signature within the package

--- a/src/pkg/transform/git_test.go
+++ b/src/pkg/transform/git_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
 var gitURLs = []string{
@@ -44,7 +45,8 @@ var badGitURLs = []string{
 }
 
 func TestMutateGitURLsInText(t *testing.T) {
-	dummyLogger := func(_ string, _ ...any) {}
+	ctx := testutil.TestContext(t)
+
 	originalText := `
 	# Here we handle invalid URLs (see below comment)
 	# We transform https://*/*.git URLs
@@ -69,7 +71,7 @@ func TestMutateGitURLsInText(t *testing.T) {
 	https://www.defenseunicorns.com/
 	`
 
-	resultingText := MutateGitURLsInText(dummyLogger, "https://gitlab.com", originalText, "repo-owner")
+	resultingText := MutateGitURLsInText(ctx, "https://gitlab.com", originalText, "repo-owner")
 	require.Equal(t, expectedText, resultingText)
 }
 

--- a/src/pkg/transform/types.go
+++ b/src/pkg/transform/types.go
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
-
-package transform
-
-// Log is a function that logs a message.
-type Log func(string, ...any)

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
@@ -37,6 +38,8 @@ import (
 //
 // Forked from https://github.com/sigstore/cosign/blob/v1.7.1/pkg/sget/sget.go
 func Sget(ctx context.Context, image, key string, out io.Writer) error {
+	log := logging.FromContextOrDiscard(ctx)
+
 	message.Warnf(lang.WarnSGetDeprecation)
 
 	// Remove the custom protocol header from the url
@@ -131,11 +134,11 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 
 	for _, sig := range sp {
 		if cert, err := sig.Cert(); err == nil && cert != nil {
-			message.Debugf("Certificate subject: %s", cert.Subject)
+			log.Info("Certificate subject", "subject", cert.Subject)
 
 			ce := cosign.CertExtensions{Cert: cert}
 			if issuerURL := ce.GetIssuer(); issuerURL != "" {
-				message.Debugf("Certificate issuer URL: %s", issuerURL)
+				log.Debug("Certificate issues", "url", issuerURL)
 			}
 		}
 
@@ -144,7 +147,7 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 			spinner.Errorf(err, "Error getting payload")
 			return err
 		}
-		message.Debug(string(p))
+		log.Debug(string(p))
 	}
 
 	// TODO(mattmoor): Depending on what this is, use the higher-level stuff.

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -15,9 +15,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
-	"github.com/zarf-dev/zarf/src/config/lang"
-	"github.com/zarf-dev/zarf/src/pkg/logging"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
@@ -32,6 +29,9 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
+
+	"github.com/zarf-dev/zarf/src/pkg/logging"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // Sget performs a cosign signature verification on a given image using the specified public key.
@@ -40,7 +40,7 @@ import (
 func Sget(ctx context.Context, image, key string, out io.Writer) error {
 	log := logging.FromContextOrDiscard(ctx)
 
-	message.Warnf(lang.WarnSGetDeprecation)
+	logging.FromContextOrDiscard(ctx).Warn("Using sget to download resources is being deprecated and will removed in the v1.0.0 release of Zarf. Please publish the packages as OCI artifacts instead.")
 
 	// Remove the custom protocol header from the url
 	image = strings.TrimPrefix(image, helpers.SGETURLPrefix)

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -56,7 +56,7 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+r.Repo().Reference.String())
 
 	layerSize := oci.SumDescsSize(layersToPull)
-	go utils.RenderProgressBarForLocalDirWrite(destinationDir, layerSize, doneSaving, "Pulling", successText)
+	go utils.RenderProgressBarForLocalDirWrite(ctx, destinationDir, layerSize, doneSaving, "Pulling", successText)
 
 	dst, err := file.New(destinationDir)
 	if err != nil {


### PR DESCRIPTION
## Description

This change replaces use of message.Warn with structured logging.

## Related Issue

Depends on #2842 
Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
