### PR TITLE
fix: replace helpers.Retry with go-retry and adjust delay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/anchore/clio v0.0.0-20240705045624-ac88e09ad9d0
 	github.com/anchore/stereoscope v0.0.1
 	github.com/anchore/syft v0.100.0
+	github.com/avast/retry-go/v4 v4.6.0
 	github.com/defenseunicorns/pkg/helpers/v2 v2.0.1
 	github.com/defenseunicorns/pkg/kubernetes v0.2.0
 	github.com/defenseunicorns/pkg/oci v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.54.9 h1:e0Czh9AhrCVPuyaIUnibYmih3cYexJKlqlHSJ2eMKbI=
 github.com/aws/aws-sdk-go v1.54.9/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
 
+	"github.com/avast/retry-go/v4"
 	pkgkubernetes "github.com/defenseunicorns/pkg/kubernetes"
 
 	"github.com/zarf-dev/zarf/src/pkg/message"
@@ -44,7 +45,25 @@ func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = waitForHealthyCluster(ctx, c.Clientset)
+	err = retry.Do(func() error {
+		nodeList, err := c.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if len(nodeList.Items) < 1 {
+			return fmt.Errorf("cluster does not have any nodes")
+		}
+		pods, err := c.Clientset.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodRunning {
+				return nil
+			}
+		}
+		return fmt.Errorf("no pods are in succeeded or running state")
+	}, retry.Context(ctx), retry.Attempts(0), retry.DelayType(retry.FixedDelay), retry.Delay(time.Second))
 	if err != nil {
 		return nil, err
 	}
@@ -76,45 +95,4 @@ func NewCluster() (*Cluster, error) {
 		return nil, errors.Join(clusterErr, err)
 	}
 	return c, nil
-}
-
-// WaitForHealthyCluster checks for an available K8s cluster every second until timeout.
-func waitForHealthyCluster(ctx context.Context, client kubernetes.Interface) error {
-	const waitDuration = 1 * time.Second
-
-	timer := time.NewTimer(0)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("error waiting for cluster to report healthy: %w", ctx.Err())
-		case <-timer.C:
-			// Make sure there is at least one running Node
-			nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-			if err != nil || len(nodeList.Items) < 1 {
-				message.Debugf("No nodes reporting healthy yet: %v\n", err)
-				timer.Reset(waitDuration)
-				continue
-			}
-
-			// Get the cluster pod list
-			pods, err := client.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				message.Debugf("Could not get the pod list: %v", err)
-				timer.Reset(waitDuration)
-				continue
-			}
-
-			// Check that at least one pod is in the 'succeeded' or 'running' state
-			for _, pod := range pods.Items {
-				if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodRunning {
-					return nil
-				}
-			}
-
-			message.Debug("No pods reported 'succeeded' or 'running' state yet.")
-			timer.Reset(waitDuration)
-		}
-	}
 }

--- a/src/pkg/cluster/namespace.go
+++ b/src/pkg/cluster/namespace.go
@@ -6,8 +6,10 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,23 +29,20 @@ func (c *Cluster) DeleteZarfNamespace(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	timer := time.NewTimer(0)
-	defer timer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timer.C:
-			_, err := c.Clientset.CoreV1().Namespaces().Get(ctx, ZarfNamespaceName, metav1.GetOptions{})
-			if kerrors.IsNotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			timer.Reset(1 * time.Second)
+	err = retry.Do(func() error {
+		_, err := c.Clientset.CoreV1().Namespaces().Get(ctx, ZarfNamespaceName, metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			return nil
 		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("namespace still exists")
+	}, retry.Context(ctx), retry.Attempts(0), retry.DelayType(retry.FixedDelay), retry.Delay(time.Second))
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 // NewZarfManagedNamespace returns a corev1.Namespace with Zarf-managed labels

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -93,6 +93,7 @@ func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefau
 	timeout := time.After(duration)
 
 	// Keep trying until the max retries is reached.
+	// TODO: Refactor using go-retry
 retryCmd:
 	for remaining := actionDefaults.MaxRetries + 1; remaining > 0; remaining-- {
 		// Perform the action run.

--- a/src/test/e2e/35_custom_retries_test.go
+++ b/src/test/e2e/35_custom_retries_test.go
@@ -26,7 +26,6 @@ func TestRetries(t *testing.T) {
 
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path.Join(tmpDir, pkgName), "--retries", "2", "--timeout", "3s", "--tmpdir", tmpDir, "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "Retrying in 5s")
 	require.Contains(t, e2e.StripMessageFormatting(stdErr), "unable to install chart after 2 attempts")
 
 	_, _, err = e2e.Zarf(t, "package", "remove", "dos-games", "--confirm")


### PR DESCRIPTION
## Description

This change replaces the different retry implementations with only using go-retry.

## Related Issue

Part of #2827  
Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
