### PR TITLE
fix: install grype during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install tools
         uses: ./.github/actions/install-tools
 
+      - name: install grype
+        env:
+          VERSION: v0.74.6
+        run: "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $VERSION"
+        shell: bash
+
       - name: Build CLI
         run: |
           make build-cli-linux-amd

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,4 @@
+ignore:	
+  # From helm - This behavior was introduced intentionally, and cannot be removed without breaking backwards compatibility (some users may be relying on these values).	
+  # https://helm.sh/blog/response-cve-2019-25210/	
+  - vulnerability: GHSA-jw44-4f3j-q396	


### PR DESCRIPTION
## Description

During some cleanup in #2802 we broke the release pipeline because we did not see that Grype was still being used during the release. This change reintroduces installation of Grype in the release workflow.

## Related Issue

N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
