### PR TITLE
ci: add renamed github workflow jobs to the shim workflow

### DIFF
--- a/.github/workflows/test-shim.yml
+++ b/.github/workflows/test-shim.yml
@@ -81,3 +81,52 @@ jobs:
       - name: Skipped
         run: |
           echo skipped
+
+  test-e2e-without-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  codeql-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  validate-bigbang:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  validate-external:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  validate-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped
+
+  validate-upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped


### PR DESCRIPTION
## Description

We recently changed the names of the jobs in github actions. Previously most were named validate, which made them hard to require / not require separately. We need to add the renamed actions to the shim so that they pass the required checks when a documentation PR is created

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
