### PR TITLE
refactor: action retry to use go-retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/anchore/clio v0.0.0-20240705045624-ac88e09ad9d0
 	github.com/anchore/stereoscope v0.0.1
 	github.com/anchore/syft v0.100.0
+	github.com/avast/retry-go/v4 v4.6.0
 	github.com/defenseunicorns/pkg/helpers/v2 v2.0.1
 	github.com/defenseunicorns/pkg/kubernetes v0.2.0
 	github.com/defenseunicorns/pkg/oci v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.54.9 h1:e0Czh9AhrCVPuyaIUnibYmih3cYexJKlqlHSJ2eMKbI=
 github.com/aws/aws-sdk-go v1.54.9/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -229,26 +230,23 @@ func Pull(ctx context.Context, cfg PullConfig) (map[transform.Image]v1.Image, er
 
 	toPull := maps.Clone(fetched)
 
-	sc := func() error {
+	err = retry.Do(func() error {
 		saved, err := SaveConcurrent(ctx, cranePath, toPull)
 		for k := range saved {
 			delete(toPull, k)
 		}
 		return err
-	}
-
-	ss := func() error {
-		saved, err := SaveSequential(ctx, cranePath, toPull)
-		for k := range saved {
-			delete(toPull, k)
-		}
-		return err
-	}
-
-	if err := helpers.RetryWithContext(ctx, sc, 2, 5*time.Second, message.Warnf); err != nil {
+	}, retry.Context(ctx), retry.Attempts(2), retry.Delay(100*time.Millisecond))
+	if err != nil {
 		message.Warnf("Failed to save images in parallel, falling back to sequential save: %s", err.Error())
-
-		if err := helpers.RetryWithContext(ctx, ss, 2, 5*time.Second, message.Warnf); err != nil {
+		err = retry.Do(func() error {
+			saved, err := SaveSequential(ctx, cranePath, toPull)
+			for k := range saved {
+				delete(toPull, k)
+			}
+			return err
+		}, retry.Context(ctx), retry.Attempts(2), retry.Delay(100*time.Millisecond))
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
 
+	"github.com/avast/retry-go/v4"
 	pkgkubernetes "github.com/defenseunicorns/pkg/kubernetes"
 
 	"github.com/zarf-dev/zarf/src/pkg/message"
@@ -44,7 +45,25 @@ func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = waitForHealthyCluster(ctx, c.Clientset)
+	err = retry.Do(func() error {
+		nodeList, err := c.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if len(nodeList.Items) < 1 {
+			return fmt.Errorf("cluster does not have any nodes")
+		}
+		pods, err := c.Clientset.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodRunning {
+				return nil
+			}
+		}
+		return fmt.Errorf("no pods are in succeeded or running state")
+	}, retry.Context(ctx), retry.Attempts(0), retry.DelayType(retry.FixedDelay), retry.Delay(time.Second))
 	if err != nil {
 		return nil, err
 	}
@@ -76,45 +95,4 @@ func NewCluster() (*Cluster, error) {
 		return nil, errors.Join(clusterErr, err)
 	}
 	return c, nil
-}
-
-// WaitForHealthyCluster checks for an available K8s cluster every second until timeout.
-func waitForHealthyCluster(ctx context.Context, client kubernetes.Interface) error {
-	const waitDuration = 1 * time.Second
-
-	timer := time.NewTimer(0)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("error waiting for cluster to report healthy: %w", ctx.Err())
-		case <-timer.C:
-			// Make sure there is at least one running Node
-			nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-			if err != nil || len(nodeList.Items) < 1 {
-				message.Debugf("No nodes reporting healthy yet: %v\n", err)
-				timer.Reset(waitDuration)
-				continue
-			}
-
-			// Get the cluster pod list
-			pods, err := client.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				message.Debugf("Could not get the pod list: %v", err)
-				timer.Reset(waitDuration)
-				continue
-			}
-
-			// Check that at least one pod is in the 'succeeded' or 'running' state
-			for _, pod := range pods.Items {
-				if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodRunning {
-					return nil
-				}
-			}
-
-			message.Debug("No pods reported 'succeeded' or 'running' state yet.")
-			timer.Reset(waitDuration)
-		}
-	}
 }

--- a/src/pkg/cluster/namespace.go
+++ b/src/pkg/cluster/namespace.go
@@ -6,8 +6,10 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,23 +29,20 @@ func (c *Cluster) DeleteZarfNamespace(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	timer := time.NewTimer(0)
-	defer timer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timer.C:
-			_, err := c.Clientset.CoreV1().Namespaces().Get(ctx, ZarfNamespaceName, metav1.GetOptions{})
-			if kerrors.IsNotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			timer.Reset(1 * time.Second)
+	err = retry.Do(func() error {
+		_, err := c.Clientset.CoreV1().Namespaces().Get(ctx, ZarfNamespaceName, metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			return nil
 		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("namespace still exists")
+	}, retry.Context(ctx), retry.Attempts(0), retry.DelayType(retry.FixedDelay), retry.Delay(time.Second))
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 // NewZarfManagedNamespace returns a corev1.Namespace with Zarf-managed labels

--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
@@ -308,7 +308,6 @@ type Tunnel struct {
 	resourceType string
 	resourceName string
 	urlSuffix    string
-	attempt      int
 	stopChan     chan struct{}
 	readyChan    chan struct{}
 	errChan      chan error
@@ -352,38 +351,16 @@ func (tunnel *Tunnel) Wrap(function func() error) error {
 
 // Connect will establish a tunnel to the specified target.
 func (tunnel *Tunnel) Connect(ctx context.Context) (string, error) {
-	url, err := tunnel.establish(ctx)
-
-	// Try to establish the tunnel up to 3 times.
+	url, err := retry.DoWithData(func() (string, error) {
+		url, err := tunnel.establish(ctx)
+		if err != nil {
+			return "", err
+		}
+		return url, nil
+	}, retry.Context(ctx), retry.Attempts(3))
 	if err != nil {
-		tunnel.attempt++
-
-		// If we have exceeded the number of attempts, exit with an error.
-		if tunnel.attempt > 3 {
-			return "", fmt.Errorf("unable to establish tunnel after 3 attempts: %w", err)
-		}
-
-		// Otherwise, retry the connection but delay increasing intervals between attempts.
-		delay := tunnel.attempt * 10
-		message.Debugf("%s", err.Error())
-		message.Debugf("Delay creating tunnel, waiting %d seconds...", delay)
-
-		timer := time.NewTimer(0)
-		defer timer.Stop()
-
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-timer.C:
-			url, err = tunnel.Connect(ctx)
-			if err != nil {
-				return "", err
-			}
-
-			timer.Reset(time.Duration(delay) * time.Second)
-		}
+		return "", err
 	}
-
 	return url, nil
 }
 

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -93,6 +93,7 @@ func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefau
 	timeout := time.After(duration)
 
 	// Keep trying until the max retries is reached.
+	// TODO: Refactor using go-retry
 retryCmd:
 	for remaining := actionDefaults.MaxRetries + 1; remaining > 0; remaining-- {
 		// Perform the action run.

--- a/src/test/e2e/35_custom_retries_test.go
+++ b/src/test/e2e/35_custom_retries_test.go
@@ -26,7 +26,6 @@ func TestRetries(t *testing.T) {
 
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path.Join(tmpDir, pkgName), "--retries", "2", "--timeout", "3s", "--tmpdir", tmpDir, "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "Retrying in 5s")
 	require.Contains(t, e2e.StripMessageFormatting(stdErr), "unable to install chart after 2 attempts")
 
 	_, _, err = e2e.Zarf(t, "package", "remove", "dos-games", "--confirm")


### PR DESCRIPTION
## Description

This change replaces the custom retry logic with using go-retry. It simplifies legibility a lot by removing use of labels to break out of the outer loop.

## Related Issue

Depends on #2856 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
