### PR TITLE
feat: add deprecated bridge to v1beta1

### DIFF
--- a/src/api/v1beta1/component.go
+++ b/src/api/v1beta1/component.go
@@ -160,6 +160,8 @@ type GitRepoSource struct {
 	URL string `json:"url"`
 	// The sub directory to the chart within a git repo.
 	Path string `json:"path,omitempty"`
+	// The Tag of the repo where the helm chart is stored.
+	Tag string `json:"tag,omitempty"`
 }
 
 // LocalRepoSource represents a Helm chart stored locally.

--- a/src/api/v1beta1/component.go
+++ b/src/api/v1beta1/component.go
@@ -47,6 +47,18 @@ type ZarfComponent struct {
 	// List of git repos to include in the package.
 	Repos []string `json:"repos,omitempty"`
 
+	// DeprecatedGroup will not be included in the schema and cannot be set by the users of v1beta1
+	// This is here to maintain compatibility with v1alpha1 before the feature is removed in Zarf v1.0.0.
+	DeprecatedGroup string `json:"group,omitempty" jsonschema:"-"`
+
+	// DeprecatedExtensions will not be included in the schema and cannot be set by the users of v1beta1
+	// This is here to maintain compatibility with v1alpha1 before the feature is removed in Zarf v1.0.0.
+	DeprecatedExtensions ZarfComponentExtensions `json:"extensions,omitempty" jsonschema:"-"`
+
+	// DeprecatedCosignKeyPath will not be included in the schema and cannot be set by the users of v1beta1
+	// This is here to maintain compatibility with v1alpha1 before the feature is removed in Zarf v1.0.0.
+	DeprecatedCosignKeyPath string `json:"cosignKeyPath,omitempty" jsonschema:"-"`
+
 	// Custom commands to run at various stages of a package lifecycle.
 	Actions ZarfComponentActions `json:"actions,omitempty"`
 }
@@ -332,4 +344,24 @@ type Shell struct {
 	Windows string `json:"windows,omitempty" jsonschema:"description=(default 'powershell') Indicates a preference for the shell to use on Windows systems (note that choosing 'cmd' will turn off migrations like touch -> New-Item),example=powershell,example=cmd,example=pwsh,example=sh,example=bash,example=gsh"`
 	Linux   string `json:"linux,omitempty" jsonschema:"description=(default 'sh') Indicates a preference for the shell to use on Linux systems,example=sh,example=bash,example=fish,example=zsh,example=pwsh"`
 	Darwin  string `json:"darwin,omitempty" jsonschema:"description=(default 'sh') Indicates a preference for the shell to use on macOS systems,example=sh,example=bash,example=fish,example=zsh,example=pwsh"`
+}
+
+// ZarfComponentExtensions is a struct that contains all the official extensions.
+type ZarfComponentExtensions struct {
+	// Configurations for installing Big Bang and Flux in the cluster.
+	BigBang *BigBang `json:"bigbang,omitempty" jsonschema:"-"`
+}
+
+// BigBang holds the configuration for the Big Bang extension.
+type BigBang struct {
+	// The version of Big Bang to use.
+	Version string `json:"version" jsonschema:"-"`
+	// Override repo to pull Big Bang from instead of Repo One.
+	Repo string `json:"repo,omitempty" jsonschema:"-"`
+	// The list of values files to pass to Big Bang; these will be merged together.
+	ValuesFiles []string `json:"valuesFiles,omitempty" jsonschema:"-"`
+	// Whether to skip deploying flux; Defaults to false.
+	SkipFlux bool `json:"skipFlux,omitempty" jsonschema:"-"`
+	// Optional paths to Flux kustomize strategic merge patch files.
+	FluxPatchFiles []string `json:"fluxPatchFiles,omitempty" jsonschema:"-"`
 }

--- a/src/api/v1beta1/package.go
+++ b/src/api/v1beta1/package.go
@@ -59,6 +59,13 @@ func (pkg ZarfPackage) IsInitConfig() bool {
 	return pkg.Kind == ZarfInitConfig
 }
 
+func (pkg ZarfPackage) IsAirGap() bool {
+	if pkg.Metadata.Airgap == nil {
+		return true
+	}
+	return *pkg.Metadata.Airgap
+}
+
 // HasImages returns true if one of the components contains an image.
 func (pkg ZarfPackage) HasImages() bool {
 	for _, component := range pkg.Components {

--- a/src/api/v1beta1/translate_test.go
+++ b/src/api/v1beta1/translate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1/extensions"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,6 +39,20 @@ func TestTranslate(t *testing.T) {
 					{
 						Name:     "not-optional",
 						Required: helpers.BoolPtr(true),
+					},
+					{
+						Name:                    "deprecated",
+						DeprecatedGroup:         "a-group",
+						DeprecatedCosignKeyPath: "path/to/my/key.key",
+						Extensions: extensions.ZarfComponentExtensions{
+							BigBang: &extensions.BigBang{
+								Repo:           "repo.git",
+								Version:        "2.0.0",
+								ValuesFiles:    []string{"my-values.yaml"},
+								SkipFlux:       true,
+								FluxPatchFiles: []string{"my-patch"},
+							},
+						},
 					},
 					{
 						Name: "manifests",
@@ -138,6 +153,21 @@ func TestTranslate(t *testing.T) {
 					{
 						Name:     "not-optional",
 						Optional: helpers.BoolPtr(false),
+					},
+					{
+						Name:                    "deprecated",
+						Optional:                helpers.BoolPtr(true),
+						DeprecatedGroup:         "a-group",
+						DeprecatedCosignKeyPath: "path/to/my/key.key",
+						DeprecatedExtensions: ZarfComponentExtensions{
+							BigBang: &BigBang{
+								Repo:           "repo.git",
+								Version:        "2.0.0",
+								ValuesFiles:    []string{"my-values.yaml"},
+								SkipFlux:       true,
+								FluxPatchFiles: []string{"my-patch"},
+							},
+						},
 					},
 					{
 						Name:     "manifests",

--- a/src/extensions/bigbang/bigbang.go
+++ b/src/extensions/bigbang/bigbang.go
@@ -18,7 +18,7 @@ import (
 	fluxHelmCtrl "github.com/fluxcd/helm-controller/api/v2beta1"
 	fluxSrcCtrl "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1/extensions"
+	"github.com/zarf-dev/zarf/src/api/v1beta1"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/message"
@@ -43,9 +43,9 @@ var tenMins = metav1.Duration{
 
 // Run mutates a component that should deploy Big Bang to a set of manifests
 // that contain the flux deployment of Big Bang
-func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1alpha1.ZarfComponent) (v1alpha1.ZarfComponent, error) {
-	cfg := c.Extensions.BigBang
-	manifests := []v1alpha1.ZarfManifest{}
+func Run(ctx context.Context, airgap bool, tmpPaths *layout.ComponentPaths, c v1beta1.ZarfComponent) (v1beta1.ZarfComponent, error) {
+	cfg := c.DeprecatedExtensions.BigBang
+	manifests := []v1beta1.ZarfManifest{}
 
 	validVersionResponse, err := isValidVersion(cfg.Version)
 
@@ -76,7 +76,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 		// Add the flux manifests to the list of manifests to be pulled down by Zarf.
 		manifests = append(manifests, fluxManifest)
 
-		if !YOLO {
+		if !airgap {
 			// Add the images to the list of images to be pulled down by Zarf.
 			c.Images = append(c.Images, images...)
 		}
@@ -86,13 +86,15 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 
 	// Configure helm to pull down the Big Bang chart.
 	helmCfg := helm.New(
-		v1alpha1.ZarfChart{
-			Name:        bb,
-			Namespace:   bb,
-			URL:         bbRepo,
-			Version:     cfg.Version,
+		v1beta1.ZarfChart{
+			Name:      bb,
+			Namespace: bb,
+			Git: v1beta1.GitRepoSource{
+				URL:  bbRepo,
+				Tag:  cfg.Version,
+				Path: "./chart",
+			},
 			ValuesFiles: cfg.ValuesFiles,
-			GitPath:     "./chart",
 		},
 		path.Join(tmpPaths.Temp, bb),
 		path.Join(tmpPaths.Temp, bb, "values"),
@@ -113,7 +115,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	}
 
 	// Add the Big Bang repo to the list of repos to be pulled down by Zarf.
-	if !YOLO {
+	if !airgap {
 		bbRepo := fmt.Sprintf("%s@%s", cfg.Repo, cfg.Version)
 		c.Repos = append(c.Repos, bbRepo)
 	}
@@ -122,7 +124,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	if err != nil {
 		return c, fmt.Errorf("unable to find Big Bang resources: %w", err)
 	}
-	if !YOLO {
+	if !airgap {
 		for _, gitRepo := range gitRepos {
 			c.Repos = append(c.Repos, gitRepo)
 		}
@@ -139,9 +141,9 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	}
 
 	// ten minutes in seconds
-	maxTotalSeconds := 10 * 60
+	maxTotalSeconds := time.Duration(10 * 60 * time.Second)
 
-	defaultMaxTotalSeconds := c.Actions.OnDeploy.Defaults.MaxTotalSeconds
+	defaultMaxTotalSeconds := c.Actions.OnDeploy.Defaults.Timeout.Duration
 	if defaultMaxTotalSeconds > maxTotalSeconds {
 		maxTotalSeconds = defaultMaxTotalSeconds
 	}
@@ -149,11 +151,11 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	// Add wait actions for each of the helm releases in generally the order they should be deployed.
 	for _, hrNamespacedName := range namespacedHelmReleaseNames {
 		hr := hrDependencies[hrNamespacedName]
-		action := v1alpha1.ZarfComponentAction{
-			Description:     fmt.Sprintf("Big Bang Helm Release `%s` to be ready", hrNamespacedName),
-			MaxTotalSeconds: &maxTotalSeconds,
-			Wait: &v1alpha1.ZarfComponentActionWait{
-				Cluster: &v1alpha1.ZarfComponentActionWaitCluster{
+		action := v1beta1.ZarfComponentAction{
+			Description: fmt.Sprintf("Big Bang Helm Release `%s` to be ready", hrNamespacedName),
+			Timeout:     &metav1.Duration{Duration: maxTotalSeconds},
+			Wait: &v1beta1.ZarfComponentActionWait{
+				Cluster: &v1beta1.ZarfComponentActionWaitCluster{
 					Kind:      "HelmRelease",
 					Name:      hr.Metadata.Name,
 					Namespace: hr.Metadata.Namespace,
@@ -168,7 +170,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 		// https://repo1.dso.mil/big-bang/bigbang/-/blob/1.54.0/chart/templates/metrics-server/helmrelease.yaml
 		if hr.Metadata.Name == "metrics-server" {
 			action.Description = "K8s metric server to exist or be deployed by Big Bang"
-			action.Wait.Cluster = &v1alpha1.ZarfComponentActionWaitCluster{
+			action.Wait.Cluster = &v1beta1.ZarfComponentActionWaitCluster{
 				Kind: "APIService",
 				// https://github.com/kubernetes-sigs/metrics-server#compatibility-matrix
 				Name: "v1beta1.metrics.k8s.io",
@@ -195,13 +197,13 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 
 	// Add onFailure actions with additional troubleshooting information.
 	for _, cmd := range failureGeneral {
-		c.Actions.OnDeploy.OnFailure = append(c.Actions.OnDeploy.OnFailure, v1alpha1.ZarfComponentAction{
+		c.Actions.OnDeploy.OnFailure = append(c.Actions.OnDeploy.OnFailure, v1beta1.ZarfComponentAction{
 			Cmd: fmt.Sprintf("./zarf tools kubectl %s", cmd),
 		})
 	}
 
 	for _, cmd := range failureDebug {
-		c.Actions.OnDeploy.OnFailure = append(c.Actions.OnDeploy.OnFailure, v1alpha1.ZarfComponentAction{
+		c.Actions.OnDeploy.OnFailure = append(c.Actions.OnDeploy.OnFailure, v1beta1.ZarfComponentAction{
 			Mute:        &t,
 			Description: "Storing debug information to the log for troubleshooting.",
 			Cmd:         fmt.Sprintf("./zarf tools kubectl %s", cmd),
@@ -209,13 +211,13 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	}
 
 	// Add a pre-remove action to suspend the Big Bang HelmReleases to prevent reconciliation during removal.
-	c.Actions.OnRemove.Before = append(c.Actions.OnRemove.Before, v1alpha1.ZarfComponentAction{
+	c.Actions.OnRemove.Before = append(c.Actions.OnRemove.Before, v1beta1.ZarfComponentAction{
 		Description: "Suspend Big Bang HelmReleases to prevent reconciliation during removal.",
 		Cmd:         `./zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"spec":{"suspend":true}}'`,
 	})
 
 	// Select the images needed to support the repos for this configuration of Big Bang.
-	if !YOLO {
+	if !airgap {
 		for _, hr := range hrDependencies {
 			namespacedName := getNamespacedNameFromMeta(hr.Metadata)
 			gitRepo := gitRepos[hr.NamespacedSource]
@@ -234,7 +236,7 @@ func Run(ctx context.Context, YOLO bool, tmpPaths *layout.ComponentPaths, c v1al
 	}
 
 	// Create the flux wrapper around Big Bang for deployment.
-	manifest, err := addBigBangManifests(YOLO, tmpPaths.Temp, cfg)
+	manifest, err := addBigBangManifests(airgap, tmpPaths.Temp, cfg)
 	if err != nil {
 		return c, err
 	}
@@ -453,7 +455,7 @@ func findBBResources(t string) (gitRepos map[string]string, helmReleaseDeps map[
 }
 
 // addBigBangManifests creates the manifests component for deploying Big Bang.
-func addBigBangManifests(YOLO bool, manifestDir string, cfg *extensions.BigBang) (v1alpha1.ZarfManifest, error) {
+func addBigBangManifests(airgap bool, manifestDir string, cfg *v1beta1.BigBang) (v1alpha1.ZarfManifest, error) {
 	// Create a manifest component that we add to the zarf package for bigbang.
 	manifest := v1alpha1.ZarfManifest{
 		Name:      bb,
@@ -484,7 +486,7 @@ func addBigBangManifests(YOLO bool, manifestDir string, cfg *extensions.BigBang)
 	var hrValues []fluxHelmCtrl.ValuesReference
 
 	// If YOLO mode is enabled, do not include the zarf-credentials secret
-	if !YOLO {
+	if airgap {
 		// Create the zarf-credentials secret manifest.
 		if err := addManifest("bb-ext-zarf-credentials.yaml", manifestZarfCredentials(cfg.Version)); err != nil {
 			return manifest, err

--- a/src/extensions/bigbang/flux.go
+++ b/src/extensions/bigbang/flux.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	fluxHelmCtrl "github.com/fluxcd/helm-controller/api/v2beta1"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1/extensions"
+	"github.com/zarf-dev/zarf/src/api/v1beta1"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -43,7 +42,7 @@ func (h HelmReleaseDependency) Dependencies() []string {
 }
 
 // getFlux Creates a component to deploy Flux.
-func getFlux(baseDir string, cfg *extensions.BigBang) (manifest v1alpha1.ZarfManifest, images []string, err error) {
+func getFlux(baseDir string, cfg *v1beta1.BigBang) (manifest v1beta1.ZarfManifest, images []string, err error) {
 	localPath := path.Join(baseDir, "bb-ext-flux.yaml")
 	kustomizePath := path.Join(baseDir, "kustomization.yaml")
 
@@ -72,7 +71,7 @@ func getFlux(baseDir string, cfg *extensions.BigBang) (manifest v1alpha1.ZarfMan
 	}
 
 	// Add the flux.yaml file to the component manifests.
-	manifest = v1alpha1.ZarfManifest{
+	manifest = v1beta1.ZarfManifest{
 		Name:      "flux-system",
 		Namespace: "flux-system",
 		Files:     []string{localPath},

--- a/src/extensions/bigbang/manifests.go
+++ b/src/extensions/bigbang/manifests.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	fluxHelmCtrl "github.com/fluxcd/helm-controller/api/v2beta1"
 	fluxSrcCtrl "github.com/fluxcd/source-controller/api/v1"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1/extensions"
+	"github.com/zarf-dev/zarf/src/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -84,7 +84,7 @@ func manifestZarfCredentials(version string) corev1.Secret {
 }
 
 // manifestGitRepo generates a GitRepository object for the Big Bang umbrella repo.
-func manifestGitRepo(cfg *extensions.BigBang) fluxSrcCtrl.GitRepository {
+func manifestGitRepo(cfg *v1beta1.BigBang) fluxSrcCtrl.GitRepository {
 	apiVersion := "source.toolkit.fluxcd.io/v1beta2"
 
 	// Set apiVersion to v1 on BB v2.7.0 or higher falling back to v1beta2 as needed

--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/api/v1beta1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/message"
@@ -51,7 +52,7 @@ type Helm struct {
 type Modifier func(*Helm)
 
 // New returns a new Helm config struct.
-func New(chart v1alpha1.ZarfChart, chartPath string, valuesPath string, mods ...Modifier) *Helm {
+func New(chart v1beta1.ZarfChart, chartPath string, valuesPath string, mods ...Modifier) *Helm {
 	h := &Helm{
 		chart:      chart,
 		chartPath:  chartPath,

--- a/src/pkg/packager/filters/deploy.go
+++ b/src/pkg/packager/filters/deploy.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/agnivade/levenshtein"
 	"github.com/defenseunicorns/pkg/helpers/v2"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/api/v1beta1"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
 )
 
@@ -40,9 +40,9 @@ var (
 )
 
 // Apply applies the filter.
-func (f *deploymentFilter) Apply(pkg v1alpha1.ZarfPackage) ([]v1alpha1.ZarfComponent, error) {
-	var selectedComponents []v1alpha1.ZarfComponent
-	groupedComponents := map[string][]v1alpha1.ZarfComponent{}
+func (f *deploymentFilter) Apply(pkg v1beta1.ZarfPackage) ([]v1beta1.ZarfComponent, error) {
+	var selectedComponents []v1beta1.ZarfComponent
+	groupedComponents := map[string][]v1beta1.ZarfComponent{}
 	orderedComponentGroups := []string{}
 
 	// Group the components by Name and Group while maintaining order
@@ -66,8 +66,8 @@ func (f *deploymentFilter) Apply(pkg v1alpha1.ZarfPackage) ([]v1alpha1.ZarfCompo
 
 		// NOTE: This does not use forIncludedComponents as it takes group, default and required status into account.
 		for _, groupKey := range orderedComponentGroups {
-			var groupDefault *v1alpha1.ZarfComponent
-			var groupSelected *v1alpha1.ZarfComponent
+			var groupDefault *v1beta1.ZarfComponent
+			var groupSelected *v1beta1.ZarfComponent
 
 			for _, component := range groupedComponents[groupKey] {
 				// Ensure we have a local version of the component to point to (otherwise the pointer might change on us)
@@ -75,7 +75,7 @@ func (f *deploymentFilter) Apply(pkg v1alpha1.ZarfPackage) ([]v1alpha1.ZarfCompo
 
 				selectState, matchedRequest := includedOrExcluded(component.Name, f.requestedComponents)
 
-				if !component.IsRequired() {
+				if component.IsOptional() {
 					if selectState == excluded {
 						// If the component was explicitly excluded, record the match and continue
 						matchedRequests[matchedRequest] = true
@@ -161,7 +161,7 @@ func (f *deploymentFilter) Apply(pkg v1alpha1.ZarfPackage) ([]v1alpha1.ZarfCompo
 			} else {
 				component := groupedComponents[groupKey][0]
 
-				if component.IsRequired() {
+				if !component.IsOptional() {
 					selectedComponents = append(selectedComponents, component)
 					continue
 				}

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -120,7 +120,7 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 	}
 	dst.SetFromLayers(layersFetched)
 
-	pkg, warnings, err = dst.ReadZarfYAML()
+	pkg, warnings, err = dst.ReadGeneratedZarfYaml()
 	if err != nil {
 		return pkg, nil, err
 	}

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -84,7 +84,7 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 
 	dst.SetFromPaths(pathsExtracted)
 
-	pkg, warnings, err = dst.ReadZarfYAML()
+	pkg, warnings, err = dst.ReadGeneratedZarfYaml()
 	if err != nil {
 		return pkg, nil, err
 	}
@@ -164,7 +164,7 @@ func (s *TarballSource) LoadPackageMetadata(ctx context.Context, dst *layout.Pac
 
 	dst.SetFromPaths(pathsExtracted)
 
-	pkg, warnings, err = dst.ReadZarfYAML()
+	pkg, warnings, err = dst.ReadGeneratedZarfYaml()
 	if err != nil {
 		return pkg, nil, err
 	}


### PR DESCRIPTION
## Description

This is a POC to tryout how we will translate objects from v1alpha1 to v1beta1

This adds the deprecated fields from v1alpha1 that do not have a replacement to v1beta1. These fields are excluded from the v1beta1 schema, and therefore can't be set by the user on package create, but doing this allows us to change internal methods to accept v1alpha1 before completely eliminating the deprecated features. 

Relates to #2852 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
