### PR TITLE
fix: update creds not breaking when internal git server not deployed

### DIFF
--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -157,7 +157,8 @@ var updateCredsCmd = &cobra.Command{
 			if slices.Contains(args, message.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() {
 				pushToken, err := c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
 				updateErr := fmt.Errorf("Unable to create the new Gitea artifact token: %w", err)
-				// TODO once Zarf state stops defaulting to internal values, we can error on isNotFound
+				// TODO we change the default Zarf state to be empty for a service when it is not deployed
+				// and sufficient time has passed for users state to get updated we should error on isNotFound
 				if err != nil && !kerrors.IsNotFound(err) {
 					return updateErr
 				}
@@ -187,7 +188,8 @@ var updateCredsCmd = &cobra.Command{
 			if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() {
 				err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
 				updateErr := fmt.Errorf("Unable to update Zarf Git Server values: %w", err)
-				// TODO once Zarf state stops defaulting to internal values, we can error on isNotFound
+				// TODO we change the default Zarf state to be empty for a service when it is not deployed
+				// and sufficient time has passed for users state to get updated we should error on isNotFound
 				if err != nil && !kerrors.IsNotFound(err) {
 					return updateErr
 				}

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -188,8 +188,6 @@ var updateCredsCmd = &cobra.Command{
 			if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() {
 				err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
 				updateErr := fmt.Errorf("unable to update Zarf Git Server values: %w", err)
-				// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
-				// and sufficient time has passed for users state to get updated we should error on isNotFound
 				if err != nil && !kerrors.IsNotFound(err) {
 					return updateErr
 				}

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -156,8 +156,8 @@ var updateCredsCmd = &cobra.Command{
 			// Update artifact token (if internal)
 			if slices.Contains(args, message.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() {
 				pushToken, err := c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
-				updateErr := fmt.Errorf("Unable to create the new Gitea artifact token: %w", err)
-				// TODO we change the default Zarf state to be empty for a service when it is not deployed
+				updateErr := fmt.Errorf("unable to create the new Gitea artifact token: %w", err)
+				// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
 				// and sufficient time has passed for users state to get updated we should error on isNotFound
 				if err != nil && !kerrors.IsNotFound(err) {
 					return updateErr
@@ -187,8 +187,8 @@ var updateCredsCmd = &cobra.Command{
 			}
 			if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() {
 				err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
-				updateErr := fmt.Errorf("Unable to update Zarf Git Server values: %w", err)
-				// TODO we change the default Zarf state to be empty for a service when it is not deployed
+				updateErr := fmt.Errorf("unable to update Zarf Git Server values: %w", err)
+				// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
 				// and sufficient time has passed for users state to get updated we should error on isNotFound
 				if err != nil && !kerrors.IsNotFound(err) {
 					return updateErr

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -69,7 +69,7 @@ var getCredsCmd = &cobra.Command{
 		}
 		// TODO: Determine if this is actually needed.
 		if state.Distro == "" {
-			return errors.New("Zarf state secret did not load properly")
+			return errors.New("zarf state secret did not load properly")
 		}
 
 		if len(args) > 0 {
@@ -152,7 +152,7 @@ var updateCredsCmd = &cobra.Command{
 				}
 			}
 			// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
-			// and sufficient time has passed for users state to get updated we should error on isNotFound
+			// and sufficient time has passed for users state to get updated we can remove this check
 			internalGitServerExists, err := c.InternalGitServerExists(cmd.Context())
 			if err != nil {
 				return err

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -576,9 +576,7 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 	CmdToolsUpdateCredsConfirmFlag          = "Confirm updating credentials without prompting"
 	CmdToolsUpdateCredsConfirmProvided      = "Confirm flag specified, continuing without prompting."
 	CmdToolsUpdateCredsConfirmContinue      = "Continue with these changes?"
-	CmdToolsUpdateCredsUnableCreateToken    = "Unable to create the new Gitea artifact token: %s"
 	CmdToolsUpdateCredsUnableUpdateRegistry = "Unable to update Zarf Registry values: %s"
-	CmdToolsUpdateCredsUnableUpdateGit      = "Unable to update Zarf Git Server values: %s"
 	CmdToolsUpdateCredsUnableUpdateAgent    = "Unable to update Zarf Agent TLS secrets: %s"
 	CmdToolsUpdateCredsUnableUpdateCreds    = "Unable to update Zarf credentials"
 

--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -349,3 +349,12 @@ func (c *Cluster) UpdateInternalGitServerSecret(ctx context.Context, oldGitServe
 	}
 	return nil
 }
+
+// InternalGitServerExists checks if the Zarf internal git server exists in the cluster.
+func (c *Cluster) InternalGitServerExists(ctx context.Context) (bool, error) {
+	_, err := c.Clientset.CoreV1().Services(ZarfNamespaceName).Get(ctx, ZarfGitServerName, metav1.GetOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return false, err
+	}
+	return !kerrors.IsNotFound(err), nil
+}

--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -20,6 +20,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/internal/gitea"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -287,4 +288,64 @@ func (c *Cluster) GetInstalledChartsForComponent(ctx context.Context, packageNam
 	}
 
 	return installedCharts, nil
+}
+
+// UpdateInternalArtifactServerToken updates the the artifact server token on the internal gitea server and returns it
+func (c *Cluster) UpdateInternalArtifactServerToken(ctx context.Context, oldGitServer types.GitServerInfo) (string, error) {
+	tunnel, err := c.NewTunnel(ZarfNamespaceName, SvcResource, ZarfGitServerName, "", 0, ZarfGitServerPort)
+	if err != nil {
+		return "", err
+	}
+	_, err = tunnel.Connect(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer tunnel.Close()
+	tunnelURL := tunnel.HTTPEndpoint()
+	giteaClient, err := gitea.NewClient(tunnelURL, oldGitServer.PushUsername, oldGitServer.PushPassword)
+	if err != nil {
+		return "", err
+	}
+	var newToken string
+	err = tunnel.Wrap(func() error {
+		newToken, err = giteaClient.CreatePackageRegistryToken(ctx)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return newToken, err
+}
+
+// UpdateInternalGitServerSecret updates the internal gitea server secrets with the new git server info
+func (c *Cluster) UpdateInternalGitServerSecret(ctx context.Context, oldGitServer types.GitServerInfo, newGitServer types.GitServerInfo) error {
+	tunnel, err := c.NewTunnel(ZarfNamespaceName, SvcResource, ZarfGitServerName, "", 0, ZarfGitServerPort)
+	if err != nil {
+		return err
+	}
+	_, err = tunnel.Connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer tunnel.Close()
+	tunnelURL := tunnel.HTTPEndpoint()
+	giteaClient, err := gitea.NewClient(tunnelURL, oldGitServer.PushUsername, oldGitServer.PushPassword)
+	if err != nil {
+		return err
+	}
+	err = tunnel.Wrap(func() error {
+		err := giteaClient.UpdateGitUser(ctx, newGitServer.PullUsername, newGitServer.PullPassword)
+		if err != nil {
+			return err
+		}
+		err = giteaClient.UpdateGitUser(ctx, newGitServer.PushUsername, newGitServer.PushPassword)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/test/e2e/99_appliance_remove_test.go
+++ b/src/test/e2e/99_appliance_remove_test.go
@@ -36,15 +36,6 @@ func TestApplianceRemove(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf(t, "init", "--components=k3s", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
-	// Test update creds still works without a git server existing
-	prevAgentSecretData, _, err := e2e.Kubectl(t, "get", "secret", "agent-hook-tls", "-n", "zarf", "-o", "jsonpath={.data}")
-	require.NoError(t, err)
-	_, _, err = e2e.Zarf(t, "tools", "update-creds", "--confirm")
-	require.NoError(t, err)
-	newAgentSecretData, _, err := e2e.Kubectl(t, "get", "secret", "agent-hook-tls", "-n", "zarf", "-o", "jsonpath={.data}")
-	require.NoError(t, err)
-	require.NotEqual(t, prevAgentSecretData, newAgentSecretData)
-
 	// Destroy the cluster to test Zarf cleaning up after itself
 	stdOut, stdErr, err = e2e.Zarf(t, "destroy", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)

--- a/src/test/e2e/99_appliance_remove_test.go
+++ b/src/test/e2e/99_appliance_remove_test.go
@@ -36,6 +36,15 @@ func TestApplianceRemove(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf(t, "init", "--components=k3s", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
+	// Test update creds still works without a git server existing
+	prevAgentSecretData, _, err := e2e.Kubectl(t, "get", "secret", "agent-hook-tls", "-n", "zarf", "-o", "jsonpath={.data}")
+	require.NoError(t, err)
+	_, _, err = e2e.Zarf(t, "tools", "update-creds", "--confirm")
+	require.NoError(t, err)
+	newAgentSecretData, _, err := e2e.Kubectl(t, "get", "secret", "agent-hook-tls", "-n", "zarf", "-o", "jsonpath={.data}")
+	require.NoError(t, err)
+	require.NotEqual(t, prevAgentSecretData, newAgentSecretData)
+
 	// Destroy the cluster to test Zarf cleaning up after itself
 	stdOut, stdErr, err = e2e.Zarf(t, "destroy", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)


### PR DESCRIPTION
## Description

This PR fixes a bug where Zarf will error when the git server or artifact server doesn't exist and `zarf tools update-creds` is run

## Related Issue

Fixes #2903 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
