### PR TITLE
fix: update injector

### DIFF
--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -111,7 +111,7 @@ components:
         architecture: amd64
     files:
       # Rust Injector Binary
-      - source: https://zarf-public.s3-us-gov-west-1.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-amd64
+      - source: https://zarf-init.s3.us-east-2.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-amd64
         target: "###ZARF_TEMP###/zarf-injector"
         shasum: "###ZARF_PKG_TMPL_INJECTOR_AMD64_SHASUM###"
         executable: true
@@ -126,7 +126,7 @@ components:
         architecture: arm64
     files:
       # Rust Injector Binary
-      - source: https://zarf-public.s3-us-gov-west-1.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-arm64
+      - source: https://zarf-init.s3.us-east-2.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-arm64
         target: "###ZARF_TEMP###/zarf-injector"
         shasum: "###ZARF_PKG_TMPL_INJECTOR_ARM64_SHASUM###"
         executable: true

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -43,9 +43,9 @@ func TestUseCLI(t *testing.T) {
 	t.Run("zarf prepare sha256sum <remote>", func(t *testing.T) {
 		t.Parallel()
 		// Test `zarf prepare sha256sum` for a remote asset
-		expectedShasum := "c3cdea0573ba5a058ec090b5d2683bf398e8b1614c37ec81136ed03b78167617\n"
+		expectedShasum := "b905e647e0d7876cfd5b665632cfc43ad919dc60408f7236c5b541c53277b503\n"
 
-		stdOut, stdErr, err := e2e.Zarf(t, "prepare", "sha256sum", "https://zarf-public.s3-us-gov-west-1.amazonaws.com/pipelines/zarf-prepare-shasum-remote-test-file.txt")
+		stdOut, stdErr, err := e2e.Zarf(t, "prepare", "sha256sum", "https://zarf-init.s3.us-east-2.amazonaws.com/injector/2024-07-22/zarf-injector-arm64")
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdOut, expectedShasum, "The expected SHASUM should equal the actual SHASUM")
 	})

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -5,9 +5,9 @@ agent_image = 'zarf-dev/zarf/agent'
 agent_image_tag = 'local'
 
 # Tag for the zarf injector binary to use
-injector_version = '2024-05-15'
-injector_amd64_shasum = '1b34519ac30daf0e5a4a2f0a0766dbcd0852c0b5364b35576eea4ac9e22d9e82'
-injector_arm64_shasum = 'ca20f427f9cf91ff42646a785c4772be5892a6752fa14924c5085b2d0109b008'
+injector_version = '2024-07-22'
+injector_amd64_shasum = '8463bfd66930a4b26c665b51f25e8a32ed5948068bae49987013c89173394478'
+injector_arm64_shasum = 'b905e647e0d7876cfd5b665632cfc43ad919dc60408f7236c5b541c53277b503'
 
 
 # The image reference to use for the registry that Zarf deploys into the cluster


### PR DESCRIPTION
## Description

Injector is pointed to govcloud account which is down atm, it should be in the defenese unicorn account anyway

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
