### PR TITLE
fix: evaulate templates on schema check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,16 +40,3 @@ repos:
         types: [go]
         language: golang
         pass_filenames: false
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.14.0
-    hooks:
-      - id: check-jsonschema
-        name: "Validate Zarf Configs Against Schema"
-        files: "zarf.yaml"
-        types: [yaml]
-        args: ["--schemafile", "zarf.schema.json"]
-        exclude: |
-          (?x)^(
-            src/test/packages/12-lint/.*|
-            src/pkg/lint/testdata/package-with-templates/zarf.yaml
-          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,5 +50,6 @@ repos:
         args: ["--schemafile", "zarf.schema.json"]
         exclude: |
           (?x)^(
-            src/test/packages/12-lint/.*
+            src/test/packages/12-lint/.*|
+            src/pkg/lint/testdata/package-with-templates/zarf.yaml
           )$

--- a/src/pkg/lint/lint.go
+++ b/src/pkg/lint/lint.go
@@ -36,7 +36,7 @@ func Validate(ctx context.Context, createOpts types.ZarfCreateOptions) error {
 		return err
 	}
 	findings = append(findings, compFindings...)
-	schemaFindings, err := ValidatePackageSchema()
+	schemaFindings, err := ValidatePackageSchema(createOpts.SetVariables)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/lint/lint.go
+++ b/src/pkg/lint/lint.go
@@ -71,7 +71,7 @@ func lintComponents(ctx context.Context, pkg v1alpha1.ZarfPackage, createOpts ty
 		node := chain.Head()
 		for node != nil {
 			component := node.ZarfComponent
-			compFindings, err := fillObjTemplate(&component, createOpts.SetVariables)
+			compFindings, err := templateZarfObj(&component, createOpts.SetVariables)
 			if err != nil {
 				return nil, err
 			}
@@ -87,12 +87,12 @@ func lintComponents(ctx context.Context, pkg v1alpha1.ZarfPackage, createOpts ty
 	return findings, nil
 }
 
-func fillObjTemplate(rawObj any, setVariables map[string]string) ([]PackageFinding, error) {
+func templateZarfObj(zarfObj any, setVariables map[string]string) ([]PackageFinding, error) {
 	var findings []PackageFinding
 	templateMap := map[string]string{}
 
 	setVarsAndWarn := func(templatePrefix string, deprecated bool) error {
-		yamlTemplates, err := utils.FindYamlTemplates(rawObj, templatePrefix, "###")
+		yamlTemplates, err := utils.FindYamlTemplates(zarfObj, templatePrefix, "###")
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func fillObjTemplate(rawObj any, setVariables map[string]string) ([]PackageFindi
 		return nil, err
 	}
 
-	if err := utils.ReloadYamlTemplate(rawObj, templateMap); err != nil {
+	if err := utils.ReloadYamlTemplate(zarfObj, templateMap); err != nil {
 		return nil, err
 	}
 	return findings, nil

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -32,12 +32,10 @@ func TestLintComponents(t *testing.T) {
 		require.Error(t, err)
 	})
 }
-func TestFillComponentTemplate(t *testing.T) {
-	createOpts := types.ZarfCreateOptions{
-		SetVariables: map[string]string{
-			"KEY1": "value1",
-			"KEY2": "value2",
-		},
+func TestFillObjTemplate(t *testing.T) {
+	SetVariables := map[string]string{
+		"KEY1": "value1",
+		"KEY2": "value2",
 	}
 
 	component := v1alpha1.ZarfComponent{
@@ -48,7 +46,7 @@ func TestFillComponentTemplate(t *testing.T) {
 		},
 	}
 
-	findings, err := fillComponentTemplate(&component, createOpts)
+	findings, err := fillObjTemplate(&component, SetVariables)
 	require.NoError(t, err)
 	expectedFindings := []PackageFinding{
 		{

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -46,7 +46,7 @@ func TestFillObjTemplate(t *testing.T) {
 		},
 	}
 
-	findings, err := fillObjTemplate(&component, SetVariables)
+	findings, err := templateZarfObj(&component, SetVariables)
 	require.NoError(t, err)
 	expectedFindings := []PackageFinding{
 		{

--- a/src/pkg/lint/schema.go
+++ b/src/pkg/lint/schema.go
@@ -29,7 +29,7 @@ func ValidatePackageSchema(setVariables map[string]string) ([]PackageFinding, er
 		return nil, err
 	}
 
-	_, err = fillObjTemplate(&untypedZarfPackage, setVariables)
+	_, err = templateZarfObj(&untypedZarfPackage, setVariables)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/lint/schema.go
+++ b/src/pkg/lint/schema.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 
 	"github.com/xeipuuv/gojsonschema"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -30,29 +29,12 @@ func ValidatePackageSchema(setVariables map[string]string) ([]PackageFinding, er
 		return nil, err
 	}
 
-	untypedZarfPackage, err = templateRawYaml(untypedZarfPackage, setVariables)
+	_, err = fillObjTemplate(&untypedZarfPackage, setVariables)
 	if err != nil {
 		return nil, err
 	}
 
 	return getSchemaFindings(jsonSchema, untypedZarfPackage)
-}
-
-func templateRawYaml(untypedPackage any, values map[string]string) (any, error) {
-	templateMap := map[string]string{}
-
-	for key, value := range values {
-		templateMap[fmt.Sprintf("%s%s###", v1alpha1.ZarfPackageVariablePrefix, key)] = value
-	}
-
-	for key, value := range values {
-		templateMap[fmt.Sprintf("%s%s###", v1alpha1.ZarfPackageTemplatePrefix, key)] = value
-	}
-
-	if err := utils.ReloadYamlTemplate(&untypedPackage, templateMap); err != nil {
-		return nil, err
-	}
-	return untypedPackage, nil
 }
 
 func makeFieldPathYqCompat(field string) string {

--- a/src/pkg/lint/schema_test.go
+++ b/src/pkg/lint/schema_test.go
@@ -7,11 +7,13 @@ package lint
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
 func TestZarfSchema(t *testing.T) {
@@ -188,6 +190,24 @@ components:
 		}
 		require.ElementsMatch(t, expected, findings)
 	})
+}
+
+func TestValidatePackageSchema(t *testing.T) {
+	ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
+	setVariables := map[string]string{
+		"PACKAGE_NAME": "test-package",
+		"MY_COMP_NAME": "test-comp",
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(filepath.Join("testdata", "package-with-templates"))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(cwd))
+	}()
+	findings, err := ValidatePackageSchema(setVariables)
+	require.Empty(t, findings)
+	require.NoError(t, err)
 }
 
 func TestYqCompat(t *testing.T) {

--- a/src/pkg/lint/testdata/package-with-templates/zarf.yaml
+++ b/src/pkg/lint/testdata/package-with-templates/zarf.yaml
@@ -1,5 +1,5 @@
 kind: ZarfPackageConfig
 metadata:
-  name: "###ZARF_PKG_TMPL_PACKAGE_NAME###"
+  name: "###ZARF_PKG_VAR_PACKAGE_NAME###"
 components:
-  - name: ok
+  - name: "###ZARF_PKG_TMPL_MY_COMP_NAME###"

--- a/src/pkg/lint/testdata/package-with-templates/zarf.yaml
+++ b/src/pkg/lint/testdata/package-with-templates/zarf.yaml
@@ -1,0 +1,5 @@
+kind: ZarfPackageConfig
+metadata:
+  name: "###ZARF_PKG_TMPL_PACKAGE_NAME###"
+components:
+  - name: ok

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -119,7 +119,7 @@ func (pc *PackageCreator) LoadPackageDefinition(ctx context.Context, src *layout
 		}
 	}
 
-	if err := Validate(pkg, pc.createOpts.BaseDir); err != nil {
+	if err := Validate(pkg, pc.createOpts.BaseDir, pc.createOpts.SetVariables); err != nil {
 		return v1alpha1.ZarfPackage{}, nil, err
 	}
 

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -71,7 +71,7 @@ func (sc *SkeletonCreator) LoadPackageDefinition(ctx context.Context, src *layou
 		message.Warn(warning)
 	}
 
-	if err := Validate(pkg, sc.createOpts.BaseDir); err != nil {
+	if err := Validate(pkg, sc.createOpts.BaseDir, sc.createOpts.SetVariables); err != nil {
 		return v1alpha1.ZarfPackage{}, nil, err
 	}
 

--- a/src/pkg/packager/creator/utils.go
+++ b/src/pkg/packager/creator/utils.go
@@ -19,12 +19,12 @@ import (
 
 // Validate errors if a package violates the schema or any runtime validations
 // This must be run while in the parent directory of the zarf.yaml being validated
-func Validate(pkg v1alpha1.ZarfPackage, baseDir string) error {
+func Validate(pkg v1alpha1.ZarfPackage, baseDir string, setVariables map[string]string) error {
 	if err := lint.ValidatePackage(pkg); err != nil {
 		return fmt.Errorf("package validation failed: %w", err)
 	}
 
-	findings, err := lint.ValidatePackageSchema()
+	findings, err := lint.ValidatePackageSchema(setVariables)
 	if err != nil {
 		return fmt.Errorf("unable to check schema: %w", err)
 	}

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -53,7 +53,7 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := creator.Validate(p.cfg.Pkg, p.cfg.CreateOpts.BaseDir); err != nil {
+	if err := creator.Validate(p.cfg.Pkg, p.cfg.CreateOpts.BaseDir, p.cfg.CreateOpts.SetVariables); err != nil {
 		return fmt.Errorf("package validation failed: %w", err)
 	}
 


### PR DESCRIPTION
## Description
We are currently not evaluating templates on schema creation, this can lead to issues if templates are used where there are regex patterns in the schema. This fixes it to evaluate templates on schema creation

## Issue
Fixes #2908

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
