### PR TITLE
feat: better error message on helm fail

### DIFF
--- a/examples/helm-charts/zarf.yaml
+++ b/examples/helm-charts/zarf.yaml
@@ -22,36 +22,6 @@ components:
           - name: REPLICA_COUNT
             description: "Override the number of pod replicas"
             path: replicaCount
-
-      - name: podinfo-oci
-        version: 6.4.0
-        namespace: podinfo-from-oci
-        # In this case `url` will load the helm chart located in the podinfo OCI repository
-        url: oci://ghcr.io/stefanprodan/charts/podinfo
-        valuesFiles:
-          - values.yaml
-
-      - name: podinfo-git
-        version: 6.4.0
-        namespace: podinfo-from-git
-        # In this case `url` will load the helm chart located in the podinfo git repository
-        url: https://github.com/stefanprodan/podinfo.git
-        # By default git will look in the root of the git repository but you can define a sub directory with `gitPath`
-        gitPath: charts/podinfo
-        valuesFiles:
-          - values.yaml
-
-      - name: podinfo-repo
-        version: 6.4.0
-        namespace: podinfo-from-repo
-        # In this case `url` will load the helm chart located in the podinfo helm repository
-        url: https://stefanprodan.github.io/podinfo
-        # By default the chart `name` will be what is used to search a repository but since Zarf chart names must be unique per-component you can override this with `repoName`
-        repoName: podinfo
-        # By default the release name will be the chart name, but you can override this with the `releaseName` key
-        releaseName: cool-release-name
-        valuesFiles:
-          - values.yaml
     images:
       - ghcr.io/stefanprodan/podinfo:6.4.0
       # This is the cosign signature for the podinfo image for image signature verification
@@ -64,24 +34,6 @@ components:
                 kind: deployment
                 name: podinfo-local
                 namespace: podinfo-from-local-chart
-                condition: available
-          - wait:
-              cluster:
-                kind: deployment
-                name: podinfo-oci
-                namespace: podinfo-from-oci
-                condition: available
-          - wait:
-              cluster:
-                kind: deployment
-                name: podinfo-git
-                namespace: podinfo-from-git
-                condition: available
-          - wait:
-              cluster:
-                kind: deployment
-                name: cool-release-name-podinfo
-                namespace: podinfo-from-repo
                 condition: available
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI

--- a/examples/helm-charts/zarf.yaml
+++ b/examples/helm-charts/zarf.yaml
@@ -22,6 +22,36 @@ components:
           - name: REPLICA_COUNT
             description: "Override the number of pod replicas"
             path: replicaCount
+
+      - name: podinfo-oci
+        version: 6.4.0
+        namespace: podinfo-from-oci
+        # In this case `url` will load the helm chart located in the podinfo OCI repository
+        url: oci://ghcr.io/stefanprodan/charts/podinfo
+        valuesFiles:
+          - values.yaml
+
+      - name: podinfo-git
+        version: 6.4.0
+        namespace: podinfo-from-git
+        # In this case `url` will load the helm chart located in the podinfo git repository
+        url: https://github.com/stefanprodan/podinfo.git
+        # By default git will look in the root of the git repository but you can define a sub directory with `gitPath`
+        gitPath: charts/podinfo
+        valuesFiles:
+          - values.yaml
+
+      - name: podinfo-repo
+        version: 6.4.0
+        namespace: podinfo-from-repo
+        # In this case `url` will load the helm chart located in the podinfo helm repository
+        url: https://stefanprodan.github.io/podinfo
+        # By default the chart `name` will be what is used to search a repository but since Zarf chart names must be unique per-component you can override this with `repoName`
+        repoName: podinfo
+        # By default the release name will be the chart name, but you can override this with the `releaseName` key
+        releaseName: cool-release-name
+        valuesFiles:
+          - values.yaml
     images:
       - ghcr.io/stefanprodan/podinfo:6.4.0
       # This is the cosign signature for the podinfo image for image signature verification
@@ -34,6 +64,24 @@ components:
                 kind: deployment
                 name: podinfo-local
                 namespace: podinfo-from-local-chart
+                condition: available
+          - wait:
+              cluster:
+                kind: deployment
+                name: podinfo-oci
+                namespace: podinfo-from-oci
+                condition: available
+          - wait:
+              cluster:
+                kind: deployment
+                name: podinfo-git
+                namespace: podinfo-from-git
+                condition: available
+          - wait:
+              cluster:
+                kind: deployment
+                name: cool-release-name-podinfo
+                namespace: podinfo-from-repo
                 condition: available
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -96,7 +96,8 @@ func Execute(ctx context.Context) {
 	if len(comps) > 1 && comps[1] == "tools" && slices.Contains(defaultPrintCmds, comps[2]) {
 		cmd.PrintErrln(cmd.ErrPrefix(), err.Error())
 	} else {
-		pterm.Error.Println(err.Error())
+		errParagraph := message.Paragraph(err.Error())
+		pterm.Error.Println(errParagraph)
 	}
 	os.Exit(1)
 }

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -91,8 +91,7 @@ func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings,
 		return nil
 	}, retry.Context(ctx), retry.Attempts(uint(h.retries)), retry.Delay(500*time.Millisecond))
 	if err != nil {
-		removeMsg := "if you need to remove the failed chart, use `zarf package remove`"
-		installErr := fmt.Errorf("unable to install chart after %d attempts: %w: %s", h.retries, err, removeMsg)
+		message.Warn(err.Error())
 
 		releases, _ := histClient.Run(h.chart.ReleaseName)
 		previouslyDeployedVersion := 0
@@ -103,6 +102,9 @@ func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings,
 				previouslyDeployedVersion = release.Version
 			}
 		}
+
+		removeMsg := "if you need to remove the failed chart, use `zarf package remove`"
+		installErr := fmt.Errorf("unable to install chart after %d attempts: %s", h.retries, removeMsg)
 
 		// No prior releases means this was an initial install.
 		if previouslyDeployedVersion == 0 {

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -91,7 +91,8 @@ func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings,
 		return nil
 	}, retry.Context(ctx), retry.Attempts(uint(h.retries)), retry.Delay(500*time.Millisecond))
 	if err != nil {
-		message.Warn(err.Error())
+		removeMsg := "if you need to remove the failed chart, use `zarf package remove`"
+		installErr := fmt.Errorf("unable to install chart after %d attempts: %w: %s", h.retries, err, removeMsg)
 
 		releases, _ := histClient.Run(h.chart.ReleaseName)
 		previouslyDeployedVersion := 0
@@ -102,9 +103,6 @@ func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings,
 				previouslyDeployedVersion = release.Version
 			}
 		}
-
-		removeMsg := "if you need to remove the failed chart, use `zarf package remove`"
-		installErr := fmt.Errorf("unable to install chart after %d attempts: %s", h.retries, removeMsg)
 
 		// No prior releases means this was an initial install.
 		if previouslyDeployedVersion == 0 {

--- a/src/test/e2e/09_component_compose_test.go
+++ b/src/test/e2e/09_component_compose_test.go
@@ -185,7 +185,7 @@ func (suite *CompositionSuite) Test_2_ComposabilityBadLocalOS() {
 
 	_, stdErr, err := e2e.Zarf(suite.T(), "package", "create", composeTestBadLocalOS, "-o", "build", "--no-color", "--confirm")
 	suite.Error(err)
-	suite.Contains(stdErr, "\"only.localOS\" \"linux\" cannot be redefined as \"windows\" during compose")
+	suite.Contains(e2e.StripMessageFormatting(stdErr), "\"only.localOS\" \"linux\" cannot be redefined as \"windows\" during compose")
 }
 
 func TestCompositionSuite(t *testing.T) {

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -44,7 +44,7 @@ func TestZarfInit(t *testing.T) {
 		// We need to use the --architecture flag here to force zarf to find the package.
 		_, stdErr, err = e2e.Zarf(t, "init", "--architecture", mismatchedArch, "--components=k3s", "--confirm")
 		require.Error(t, err, stdErr)
-		require.Contains(t, stdErr, expectedErrorMessage)
+		require.Contains(t, e2e.StripMessageFormatting(stdErr), expectedErrorMessage)
 	}
 
 	if !e2e.ApplianceMode {

--- a/src/test/e2e/31_checksum_and_signature_test.go
+++ b/src/test/e2e/31_checksum_and_signature_test.go
@@ -37,7 +37,7 @@ func TestChecksumAndSignature(t *testing.T) {
 	// Test that we get an error when trying to deploy a package without providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "failed to deploy package: unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
+	require.Contains(t, e2e.StripMessageFormatting(stdErr), "failed to deploy package: unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
 
 	// Test that we don't get an error when we remember to provide the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, publicKeyFlag, "--confirm")

--- a/src/test/e2e/34_custom_init_package_test.go
+++ b/src/test/e2e/34_custom_init_package_test.go
@@ -38,7 +38,7 @@ func TestCustomInit(t *testing.T) {
 	// Test that we get an error when trying to deploy a package without providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "init", "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
+	require.Contains(t, e2e.StripMessageFormatting(stdErr), "unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
 
 	/* Test operations during package deploy */
 	// Test that we can deploy the package with the public key


### PR DESCRIPTION
## Description

In a recent change, we stopped giving the helm install error as a warning to users. 

I considered keeping it a warning or appending it to the other errors. The warning looked nicer, but only because newlines look weird with how are error messages are formatted in pterm. Changed the error message to be paragraphed and went with that.
warning: 
![warning-zarf-helm](https://github.com/user-attachments/assets/54ecbddd-dff7-4eb8-b44c-f65214991056)
error: 
![all-error](https://github.com/user-attachments/assets/fbe1e254-061b-4aba-bfce-8d4dc51ee0bb)
error (paragraph formatting):
![image](https://github.com/user-attachments/assets/e164dd7f-ab02-480f-bd2d-9e8112a41036)

## Related Issue

Fixes: #2907

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
