### PR TITLE
chore: update injector make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,6 @@ build-examples: ## Build all of the example packages
 
 	@test -s ./build/zarf-package-component-webhooks-$(ARCH)-0.0.1.tar.zst || $(ZARF_BIN) package create examples/component-webhooks -o build -a $(ARCH) --confirm
 
-build-injector-linux: ## Build the Zarf injector for AMD64 and ARM64
-	docker run --rm --user "$(id -u)":"$(id -g)" -v $$PWD/src/injector:/usr/src/zarf-injector -w /usr/src/zarf-injector rust:1.71.0-bookworm make build-injector-linux list-sizes
-
 ## NOTE: Requires an existing cluster or the env var APPLIANCE_MODE=true
 .PHONY: test-e2e
 test-e2e: test-e2e-without-cluster test-e2e-with-cluster  ## Run all of the core Zarf CLI E2E tests (builds any deps that aren't present)

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -111,9 +111,9 @@ components:
         architecture: amd64
     files:
       # Rust Injector Binary
-      - source: https://zarf-init.s3.us-east-2.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-amd64
+      - source: ../../src/injector/target/x86_64-unknown-linux-musl/release/zarf-injector
         target: "###ZARF_TEMP###/zarf-injector"
-        shasum: "###ZARF_PKG_TMPL_INJECTOR_AMD64_SHASUM###"
+        # shasum: "###ZARF_PKG_TMPL_INJECTOR_AMD64_SHASUM###"
         executable: true
 
   - name: zarf-injector
@@ -126,9 +126,9 @@ components:
         architecture: arm64
     files:
       # Rust Injector Binary
-      - source: https://zarf-init.s3.us-east-2.amazonaws.com/injector/###ZARF_PKG_TMPL_INJECTOR_VERSION###/zarf-injector-arm64
+      - source: ../../src/injector/target/aarch64-unknown-linux-musl/release/zarf-injector
         target: "###ZARF_TEMP###/zarf-injector"
-        shasum: "###ZARF_PKG_TMPL_INJECTOR_ARM64_SHASUM###"
+        # shasum: "###ZARF_PKG_TMPL_INJECTOR_ARM64_SHASUM###"
         executable: true
 
   - name: zarf-seed-registry

--- a/src/injector/Makefile
+++ b/src/injector/Makefile
@@ -16,11 +16,9 @@ install-cross:
 build-injector-linux: build-injector-linux-amd build-injector-linux-arm ## Build the Zarf injector for AMD64 and ARM64
 
 build-injector-linux-amd: install-cross
-	rustup target add aarch64-unknown-linux-musl
 	cross build --target aarch64-unknown-linux-musl --release
 
 build-injector-linux-arm: install-cross
-	rustup target add x86_64-unknown-linux-musl
 	cross build --target x86_64-unknown-linux-musl --release
 
 list-sizes: ## List the sizes of the Zarf injector binaries
@@ -29,4 +27,4 @@ list-sizes: ## List the sizes of the Zarf injector binaries
 	du --si target/aarch64-unknown-linux-musl/release/zarf-injector
 
 build-with-docker: ## Build the Zarf injector using Docker
-	docker run --rm --user "$(id -u)":"$(id -g)" -v $$PWD:/usr/src/zarf-injector -w /usr/src/zarf-injector rust:1.71.0-bookworm make build-injector-linux
+	docker run --rm --user "$(id -u)":"$(id -g)" -e CROSS_CONTAINER_IN_CONTAINER=true -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/usr/src/zarf-injector -w /usr/src/zarf-injector rust:1.71.0-bookworm make build-injector-linux

--- a/src/injector/Makefile
+++ b/src/injector/Makefile
@@ -10,54 +10,18 @@ help: ## Display this help information
 clean: ## Clean the build directory
 	rm -rf target
 
-cross-injector-linux: cross-injector-amd cross-injector-arm
-
-cross-injector-amd: 
-	rustup target add x86_64-unknown-linux-musl
-	test -s x86_64-linux-musl-cross || curl https://zarf-public.s3-us-gov-west-1.amazonaws.com/pipelines/x86_64-linux-musl-cross.tgz | tar -xz
-	export PATH="$$PWD/x86_64-linux-musl-cross/bin:$$PATH"
-	export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-cc
-
-	cargo install cross --git https://github.com/cross-rs/cross
-
-	cross build --target x86_64-unknown-linux-musl --release
-
-
-cross-injector-arm:
-	rustup target add aarch64-unknown-linux-musl
-	test -s aarch64-linux-musl-cross || curl https://zarf-public.s3-us-gov-west-1.amazonaws.com/pipelines/aarch64-linux-musl-cross.tgz | tar -xz
-	export PATH="$$PWD/aarch64-linux-musl-cross/bin:$$PATH"
-	export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-cc
-
-	cross build --target aarch64-unknown-linux-musl --release
-
-
+install-cross:
+	cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
 build-injector-linux: build-injector-linux-amd build-injector-linux-arm ## Build the Zarf injector for AMD64 and ARM64
 
-build-injector-linux-amd: ## Build the Zarf injector for AMD64
-	rustup target add x86_64-unknown-linux-musl
-
-	if [ "$(shell uname -m)" = "arm64" ] || [ "$(shell uname -m)" = "aarch64" ]; then \
-		test -s x86_64-linux-musl-cross || curl https://zarf-public.s3-us-gov-west-1.amazonaws.com/pipelines/x86_64-linux-musl-cross.tgz | tar -xz; \
-		export PATH="$$PWD/x86_64-linux-musl-cross/bin:$$PATH"; \
-		export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-cc; \
-		cargo build --target x86_64-unknown-linux-musl --release; \
-	elif [ "$(shell uname -m)" = "x86_64" ]; then \
-		cargo build --target x86_64-unknown-linux-musl --release; \
-	fi
-
-build-injector-linux-arm: ## Build the Zarf injector for ARM64
+build-injector-linux-amd: install-cross
 	rustup target add aarch64-unknown-linux-musl
+	cross build --target aarch64-unknown-linux-musl --release
 
-	if [ "$(shell uname -m)" = "arm64" ] || [ "$(shell uname -m)" = "aarch64" ]; then \
-		cargo build --target aarch64-unknown-linux-musl --release; \
-	elif [ "$(shell uname -m)" = "x86_64" ]; then \
-		test -s aarch64-linux-musl-cross || curl https://zarf-public.s3-us-gov-west-1.amazonaws.com/pipelines/aarch64-linux-musl-cross.tgz | tar -xz; \
-		export PATH="$$PWD/aarch64-linux-musl-cross/bin:$$PATH"; \
-		export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-cc; \
-		cargo build --target aarch64-unknown-linux-musl --release; \
-	fi
+build-injector-linux-arm: install-cross
+	rustup target add x86_64-unknown-linux-musl
+	cross build --target x86_64-unknown-linux-musl --release
 
 list-sizes: ## List the sizes of the Zarf injector binaries
 	@echo '\n\033[0;36mSize of Zarf injector binaries:\033[0m\n'; \

--- a/src/injector/Makefile
+++ b/src/injector/Makefile
@@ -25,6 +25,3 @@ list-sizes: ## List the sizes of the Zarf injector binaries
 	@echo '\n\033[0;36mSize of Zarf injector binaries:\033[0m\n'; \
 	du --si target/x86_64-unknown-linux-musl/release/zarf-injector; \
 	du --si target/aarch64-unknown-linux-musl/release/zarf-injector
-
-build-with-docker: ## Build the Zarf injector using Docker
-	docker run --rm --user "$(id -u)":"$(id -g)" -e CROSS_CONTAINER_IN_CONTAINER=true -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/usr/src/zarf-injector -w /usr/src/zarf-injector rust:1.71.0-bookworm make build-injector-linux

--- a/src/injector/Makefile
+++ b/src/injector/Makefile
@@ -10,6 +10,12 @@ help: ## Display this help information
 clean: ## Clean the build directory
 	rm -rf target
 
+# This is for local dev with mac arm machines since our cross images are not supported on that platform
+build-injector-darwin-arm:
+	rustup target add aarch64-unknown-linux-musl
+	cargo build --target aarch64-unknown-linux-musl --release
+
+# $HOME/.cargo/bin must be added to path for cross to work
 install-cross:
 	cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 


### PR DESCRIPTION
## Description

This simplifies the makefile by using [cross](https://github.com/cross-rs/cross) and gets rid of external dependencies on S3 for building the object. 

It does also eliminate the ability to create the injector on an arm64 machine. The arm64 binary can still be created through cross on an amd64 machine. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
