### PR TITLE
docs: update dos games example

### DIFF
--- a/examples/composable-packages/zarf.yaml
+++ b/examples/composable-packages/zarf.yaml
@@ -31,7 +31,7 @@ components:
     # default: false    # the initial value overrides the child component
     import:
       # The URL to the skeleton package containing this component's package definition
-      url: oci://🦄/dos-games:1.0.0
+      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
       # Example optional custom name to point to in the imported package (default is to use this component's name)
       name: baseline
     # Un'name'd Zarf primitives will be appended to the end of the primitive's list for that component.

--- a/site/src/content/docs/getting-started/index.mdx
+++ b/site/src/content/docs/getting-started/index.mdx
@@ -23,7 +23,7 @@ import { Tabs, TabItem, LinkCard, CardGrid } from '@astrojs/starlight/components
     # (Select optional components as desired)
 
     # Now you are ready to deploy any Zarf Package, try out our Retro Arcade!!
-    zarf package deploy oci://🦄/dos-games:1.0.0 --key=https://zarf.dev/cosign.pub
+    zarf package deploy oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 --key=https://zarf.dev/cosign.pub
     # (Select 'Y' to confirm deployment)
     ```
 
@@ -39,7 +39,7 @@ import { Tabs, TabItem, LinkCard, CardGrid } from '@astrojs/starlight/components
     zarf init --confirm
 
     # Deploy the DOS Games package
-    zarf package deploy oci://🦄/dos-games:1.0.0 \
+    zarf package deploy oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 \
        --key=https://zarf.dev/cosign.pub \
        --confirm
     ```

--- a/src/test/e2e/09_component_compose_test.go
+++ b/src/test/e2e/09_component_compose_test.go
@@ -61,7 +61,7 @@ func (suite *CompositionSuite) Test_0_ComposabilityExample() {
 
 	// Ensure that the action was appended
 	suite.Contains(stdErr, `
-  - defenseunicorns/zarf-game:multi-tile-dark
+  - ghcr.io/zarf-dev/doom-game:0.0.1
   actions:
     onDeploy:
       before:

--- a/src/test/e2e/12_lint_test.go
+++ b/src/test/e2e/12_lint_test.go
@@ -46,14 +46,14 @@ func TestLint(t *testing.T) {
 		// Testing import / compose + variables are working
 		require.Contains(t, strippedStderr, ".components.[2].images.[3] | Image not pinned with digest - busybox:latest")
 		// Testing OCI imports get linted
-		require.Contains(t, strippedStderr, ".components.[0].images.[0] | Image not pinned with digest - defenseunicorns/zarf-game:multi-tile-dark")
+		require.Contains(t, strippedStderr, ".components.[0].images.[0] | Image not pinned with digest - ghcr.io/zarf-dev/doom-game:0.0.1")
 
 		// Check flavors
 		require.NotContains(t, strippedStderr, "image-in-bad-flavor-component:unpinned")
 		require.Contains(t, strippedStderr, "image-in-good-flavor-component:unpinned")
 
 		// Check reported filepaths
-		require.Contains(t, strippedStderr, "Linting package \"dos-games\" at oci://🦄/dos-games:1.0.0")
+		require.Contains(t, strippedStderr, "Linting package \"dos-games\" at oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0")
 		require.Contains(t, strippedStderr, fmt.Sprintf("Linting package \"lint\" at %s", testPackagePath))
 	})
 }

--- a/src/test/e2e/27_deploy_regression_test.go
+++ b/src/test/e2e/27_deploy_regression_test.go
@@ -18,13 +18,13 @@ func TestGHCRDeploy(t *testing.T) {
 	// shas for package published 2023-08-08T22:13:51Z
 	switch e2e.Arch {
 	case "arm64":
-		sha = "ac7d7684ca9b4edb061a7732aefc17cfb7b7c983fec23e1fe319cf535618a8b6"
+		sha = "844dff9aa60345c67b597d5315db5e263cbda01b50643a8d0b7f5ec721f8a16f"
 	case "amd64":
-		sha = "aca4d4cf24532d69a8941a446067fc3d8474581507236b37bb7188836d93bf89"
+		sha = "a44d17160cd6ce7b7b6d4687e7d3f75dad4fedba6670c79665af2e8665a7868e"
 	}
 
 	// Test with command from https://docs.zarf.dev/getting-started/install/
-	stdOut, stdErr, err := e2e.Zarf(t, "package", "deploy", fmt.Sprintf("oci://🦄/dos-games:1.0.0-%s@sha256:%s", e2e.Arch, sha), "--key=https://raw.githubusercontent.com/zarf-dev/zarf/v0.38.2/cosign.pub", "--confirm")
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "deploy", fmt.Sprintf("oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0@sha256:%s", sha), "--key=https://zarf.dev/cosign.pub", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "dos-games", "--confirm")

--- a/src/test/packages/12-lint/linted-import/zarf.yaml
+++ b/src/test/packages/12-lint/linted-import/zarf.yaml
@@ -19,5 +19,5 @@ components:
 
   - name: oci-games-url
     import:
-      url: oci://🦄/dos-games:1.0.0
+      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
       name: baseline

--- a/src/test/packages/12-lint/zarf.yaml
+++ b/src/test/packages/12-lint/zarf.yaml
@@ -32,7 +32,7 @@ components:
 
   - name: oci-games-url
     import:
-      url: oci://🦄/dos-games:1.0.0
+      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
       name: baseline
 
   - name: oci-games-url


### PR DESCRIPTION
## Description

Since we replaced the cosign key the dos games example in the docs won't work. We released a new dos-games package with the new private key and changed the docs references to those

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
