### PR TITLE
refactor: provide usage when payload sha is missing

### DIFF
--- a/src/injector/src/main.rs
+++ b/src/injector/src/main.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::path::PathBuf;
+use std::process::exit;
 
 use axum::{
     body::Body,
@@ -257,14 +258,15 @@ async fn handle_get_digest(tag: String) -> Response {
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        println!("Usage: {} <sha256sum>", args[0]);
+        exit(1);
+    }
 
     println!("unpacking: {}", args[1]);
-    let payload_sha = &args[1];
-
-    unpack(payload_sha);
+    unpack(&args[1]);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:5000").await.unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
     axum::serve(listener, start_seed_registry()).await.unwrap();
-    println!("Usage: {} <sha256sum>", args[1]);
 }


### PR DESCRIPTION
## Description

Prior to this change, `zarf-injector` will panic if it's not provided a payload as an argument:
```shell
$ ./zarf-injector 
thread 'main' panicked at src/main.rs:261:35:
index out of bounds: the len is 1 but the index is 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: abort      ./zarf-injector
```

With this change, `zarf-injector` will return usage as expected and exit gracefully:
```shell
$ ./zarf-injector 
Usage: ./zarf-injector <sha256sum>
```

## Related Issue

I don't believe there's a related issue for this, but I figured it was worth submitting a fix for it since I came across this.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
