### PR TITLE
ci: stop codeql on merge queue

### DIFF
--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -16,16 +16,6 @@ on:
       - "adr/**"
       - "docs/**"
       - "CODEOWNERS"
-  merge_group:
-    paths-ignore:
-      - "**.md"
-      - "**.jpg"
-      - "**.png"
-      - "**.gif"
-      - "**.svg"
-      - "adr/**"
-      - "docs/**"
-      - "CODEOWNERS"
   schedule:
     - cron: "32 2 * * 5"
 

--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -20,12 +20,19 @@ on:
     - cron: "32 2 * * 5"
 
 jobs:
-  go-codeql-scan:
+  codeql-scan:
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout
@@ -38,7 +45,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
         with:
-          languages: go
+          languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yaml
 
       - name: Build
@@ -47,4 +54,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
         with:
-          category: "/language:go"
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/test-shim.yml
+++ b/.github/workflows/test-shim.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           echo skipped
 
-  go-codeql-scan:
+  codeql-scan:
     runs-on: ubuntu-latest
     steps:
       - name: Skipped


### PR DESCRIPTION
## Description

matrix jobs add to the job name which breaks the shim. Additionally, codeql can break during merge queues so we are going to stop running it in merge queues for the time being. It should be impossible for a change from a previous branch to cause a new security error in the merged branch anyway. 
![image](https://github.com/user-attachments/assets/35c3bcab-c037-4158-9877-1517eab154e4)

## Relating issue
Fixes #2954

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
