### PR TITLE
refactor: break --insecure into separate flags

### DIFF
--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -22,15 +22,16 @@ zarf COMMAND [flags]
 ### Options
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-  -h, --help                  help for zarf
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+  -h, --help                       help for zarf
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -25,14 +25,15 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -48,14 +48,15 @@ zarf completion bash
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -39,14 +39,15 @@ zarf completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -36,14 +36,15 @@ zarf completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -50,14 +50,15 @@ zarf completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -39,14 +39,15 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -23,14 +23,15 @@ zarf connect list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -35,14 +35,15 @@ zarf destroy --confirm [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -19,14 +19,15 @@ Commands useful for developing packages
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -37,14 +37,15 @@ zarf dev deploy [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -37,14 +37,15 @@ zarf dev find-images [ PACKAGE ] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -32,14 +32,15 @@ zarf dev generate-config [ FILENAME ] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -34,14 +34,15 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -29,14 +29,15 @@ zarf dev lint [ DIRECTORY ] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -25,14 +25,15 @@ zarf dev patch-git HOST FILE [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -24,14 +24,15 @@ zarf dev sha256sum { FILE | URL } [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -76,6 +76,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --registry-url string             External registry url address to use for this Zarf cluster
       --retries int                     Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
       --set stringToString              Specify deployment variables to set on the command line (KEY=value) (default [])
+      --skip-signature-validation       Skip validating the signature of the Zarf package
       --skip-webhooks                   [alpha] Skip waiting for external webhooks to execute as each package component is deployed
       --storage-class string            Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard
       --timeout duration                Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
@@ -84,14 +85,15 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -21,14 +21,15 @@ Zarf package commands for creating, deploying, and inspecting packages
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -42,15 +42,16 @@ zarf package create [ DIRECTORY ] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -22,30 +22,32 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-      --adopt-existing-resources   Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
-      --components string          Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported.
-      --confirm                    Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
-  -h, --help                       help for deploy
-      --retries int                Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
-      --set stringToString         Specify deployment variables to set on the command line (KEY=value) (default [])
-      --shasum string              Shasum of the package to deploy. Required if deploying a remote package and "--insecure" is not provided
-      --skip-webhooks              [alpha] Skip waiting for external webhooks to execute as each package component is deployed
-      --timeout duration           Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
+      --adopt-existing-resources    Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
+      --components string           Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported.
+      --confirm                     Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
+  -h, --help                        help for deploy
+      --retries int                 Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
+      --set stringToString          Specify deployment variables to set on the command line (KEY=value) (default [])
+      --shasum string               Shasum of the package to deploy. Required if deploying a remote package.
+      --skip-signature-validation   Skip validating the signature of the Zarf package
+      --skip-webhooks               [alpha] Skip waiting for external webhooks to execute as each package component is deployed
+      --timeout duration            Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -21,25 +21,27 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-  -h, --help              help for inspect
-      --list-images       List images in the package (prints to stdout)
-  -s, --sbom              View SBOM contents while inspecting the package
-      --sbom-out string   Specify an output directory for the SBOMs from the inspected Zarf package
+  -h, --help                        help for inspect
+      --list-images                 List images in the package (prints to stdout)
+  -s, --sbom                        View SBOM contents while inspecting the package
+      --sbom-out string             Specify an output directory for the SBOMs from the inspected Zarf package
+      --skip-signature-validation   Skip validating the signature of the Zarf package
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -23,16 +23,17 @@ zarf package list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -57,21 +57,23 @@ $ zarf package mirror-resources <your-package.tar.zst> \
       --registry-push-username string   Username to access to the registry Zarf is configured to use (default "zarf-push")
       --registry-url string             External registry url address to use for this Zarf cluster
       --retries int                     Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
+      --skip-signature-validation       Skip validating the signature of the Zarf package
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -29,24 +29,26 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
 ### Options
 
 ```
-  -h, --help                      help for publish
-      --signing-key string        Path to a private key file for signing or re-signing packages with a new key
-      --signing-key-pass string   Password to the private key file used for publishing packages
+  -h, --help                        help for publish
+      --signing-key string          Path to a private key file for signing or re-signing packages with a new key
+      --signing-key-pass string     Password to the private key file used for publishing packages
+      --skip-signature-validation   Skip validating the signature of the Zarf package
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -38,16 +38,17 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -17,24 +17,26 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
 ### Options
 
 ```
-      --components string   Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
-      --confirm             REQUIRED. Confirm the removal action to prevent accidental deletions
-  -h, --help                help for remove
+      --components string           Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
+      --confirm                     REQUIRED. Confirm the removal action to prevent accidental deletions
+  -h, --help                        help for remove
+      --skip-signature-validation   Skip validating the signature of the Zarf package
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -k, --key string            Path to public key file for validating signed packages
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -k, --key string                 Path to public key file for validating signed packages
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 3)
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -19,14 +19,15 @@ Collection of additional tools to make airgap easier
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -19,14 +19,15 @@ Compresses/Decompresses generic archives, including Zarf packages
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -23,14 +23,15 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -24,14 +24,15 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -23,14 +23,15 @@ zarf tools archiver version [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -24,13 +24,14 @@ zarf tools clear-cache [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -24,14 +24,15 @@ zarf tools download-init [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -23,14 +23,15 @@ zarf tools gen-key [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -24,14 +24,15 @@ zarf tools gen-pki HOST [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -43,14 +43,15 @@ $ zarf tools get-creds artifact
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_helm.md
+++ b/site/src/content/docs/commands/zarf_tools_helm.md
@@ -36,6 +36,13 @@ Subset of the Helm CLI that includes the repo and dependency commands for managi
       --repository-config string        path to the file containing repository names and URLs
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency.md
@@ -71,6 +71,7 @@ for this case.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -81,6 +82,7 @@ for this case.
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
@@ -41,6 +41,7 @@ zarf tools helm dependency build CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -51,6 +52,7 @@ zarf tools helm dependency build CHART [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
@@ -37,6 +37,7 @@ zarf tools helm dependency list CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -47,6 +48,7 @@ zarf tools helm dependency list CHART [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
@@ -45,6 +45,7 @@ zarf tools helm dependency update CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -55,6 +56,7 @@ zarf tools helm dependency update CHART [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo.md
@@ -29,6 +29,7 @@ It can be used to add, remove, list, and index chart repositories.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -39,6 +40,7 @@ It can be used to add, remove, list, and index chart repositories.
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
@@ -46,6 +46,7 @@ zarf tools helm repo add [NAME] [URL] [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
@@ -40,6 +40,7 @@ zarf tools helm repo index [DIR] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -50,6 +51,7 @@ zarf tools helm repo index [DIR] [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
@@ -26,6 +26,7 @@ zarf tools helm repo list [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -36,6 +37,7 @@ zarf tools helm repo list [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
@@ -25,6 +25,7 @@ zarf tools helm repo remove [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -35,6 +36,7 @@ zarf tools helm repo remove [REPO1 [REPO2 ...]] [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
@@ -37,6 +37,7 @@ zarf tools helm repo update [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -47,6 +48,7 @@ zarf tools helm repo update [REPO1 [REPO2 ...]] [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_helm_version.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_version.md
@@ -25,6 +25,7 @@ zarf tools helm version [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation
@@ -35,6 +36,7 @@ zarf tools helm version [flags]
       --kube-token string               bearer token used for authentication
       --kubeconfig string               path to the kubeconfig file
   -n, --namespace string                namespace scope for this request
+      --plain-http                      Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --qps float32                     queries per second used when communicating with the Kubernetes API, not including bursting
       --registry-config string          path to the registry config file
       --repository-cache string         path to the file containing cached repository indexes

--- a/site/src/content/docs/commands/zarf_tools_kubectl.md
+++ b/site/src/content/docs/commands/zarf_tools_kubectl.md
@@ -20,6 +20,13 @@ zarf tools kubectl [flags]
   -h, --help   help for kubectl
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_monitor.md
+++ b/site/src/content/docs/commands/zarf_tools_monitor.md
@@ -44,6 +44,12 @@ zarf tools monitor [flags]
       --write                          Sets write mode by overriding the readOnly configuration setting
 ```
 
+### Options inherited from parent commands
+
+```
+      --plain-http   Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -20,6 +20,13 @@ Tools for working with container registries using go-containertools
   -v, --verbose                            Enable debug logs
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -38,6 +38,8 @@ $ zarf tools registry catalog reg.example.com
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -28,6 +28,8 @@ zarf tools registry copy SRC DST [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -37,6 +37,8 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -39,6 +39,8 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -28,6 +28,8 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -39,6 +39,8 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -26,6 +26,8 @@ zarf tools registry prune [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -40,6 +40,8 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -43,6 +43,8 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -32,6 +32,8 @@ zarf tools registry version [flags]
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
       --insecure                           Allow image references to be fetched without TLS
+      --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --platform string                    Specifies the platform in the form os/arch[/variant][:osversion] (e.g. linux/amd64). (default "all")
   -v, --verbose                            Enable debug logs
 ```

--- a/site/src/content/docs/commands/zarf_tools_sbom.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom.md
@@ -38,6 +38,13 @@ zarf tools sbom [flags]
   -v, --verbose count            increase verbosity (-v = info, -vv = debug)
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_sbom_attest.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_attest.md
@@ -36,9 +36,11 @@ zarf tools sbom attest --output [FORMAT] <IMAGE> [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   syft configuration file
-  -q, --quiet           suppress all logging output
-  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
+  -c, --config string              syft configuration file
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -q, --quiet                      suppress all logging output
+  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_sbom_convert.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_convert.md
@@ -30,9 +30,11 @@ zarf tools sbom convert [SOURCE-SBOM] -o [FORMAT] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   syft configuration file
-  -q, --quiet           suppress all logging output
-  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
+  -c, --config string              syft configuration file
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -q, --quiet                      suppress all logging output
+  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_sbom_login.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_login.md
@@ -26,9 +26,11 @@ zarf tools sbom login [OPTIONS] [SERVER] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   syft configuration file
-  -q, --quiet           suppress all logging output
-  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
+  -c, --config string              syft configuration file
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -q, --quiet                      suppress all logging output
+  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_sbom_scan.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_scan.md
@@ -38,9 +38,11 @@ zarf tools sbom scan [SOURCE] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   syft configuration file
-  -q, --quiet           suppress all logging output
-  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
+  -c, --config string              syft configuration file
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -q, --quiet                      suppress all logging output
+  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_sbom_version.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_version.md
@@ -24,9 +24,11 @@ zarf tools sbom version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   syft configuration file
-  -q, --quiet           suppress all logging output
-  -v, --verbose count   increase verbosity (-v = info, -vv = debug)
+  -c, --config string              syft configuration file
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -q, --quiet                      suppress all logging output
+  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -72,14 +72,15 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -54,6 +54,13 @@ $ zarf tools wait-for http google.com success                           #  wait 
       --timeout string     Specify the timeout duration for the wait command. (default "5m")
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_yq.md
+++ b/site/src/content/docs/commands/zarf_tools_yq.md
@@ -81,6 +81,13 @@ zarf tools yq -P sample.json
       --xml-strict-mode               enables strict parsing of XML. See https://pkg.go.dev/encoding/xml for more details.
 ```
 
+### Options inherited from parent commands
+
+```
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+```
+
 ### SEE ALSO
 
 * [zarf tools](/commands/zarf_tools/)	 - Collection of additional tools to make airgap easier

--- a/site/src/content/docs/commands/zarf_tools_yq_completion.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_completion.md
@@ -68,6 +68,7 @@ zarf tools yq completion [bash|zsh|fish|powershell]
   -I, --indent int                    sets indent level for output (default 2)
   -i, --inplace                       update the file in place of first file given.
   -p, --input-format string           [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|lua|l] parse format for input. (default "auto")
+      --insecure-skip-tls-verify      Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --lua-globals                   output keys as top-level global variables
       --lua-prefix string             prefix (default "return ")
       --lua-suffix string             suffix (default ";\n")
@@ -77,6 +78,7 @@ zarf tools yq completion [bash|zsh|fish|powershell]
   -0, --nul-output                    Use NUL char to separate values. If unwrap scalar is also set, fail if unwrapped scalar contains NUL char.
   -n, --null-input                    Don't read input, simply evaluate the expression given. Useful for creating docs from scratch.
   -o, --output-format string          [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|shell|s|lua|l] output format type. (default "auto")
+      --plain-http                    Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -P, --prettyPrint                   pretty print, shorthand for '... style = ""'
       --properties-array-brackets     use [x] in array paths (e.g. for SpringBoot)
       --properties-separator string   separator to use between keys and values (default " = ")

--- a/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
@@ -64,6 +64,7 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
   -I, --indent int                    sets indent level for output (default 2)
   -i, --inplace                       update the file in place of first file given.
   -p, --input-format string           [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|lua|l] parse format for input. (default "auto")
+      --insecure-skip-tls-verify      Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --lua-globals                   output keys as top-level global variables
       --lua-prefix string             prefix (default "return ")
       --lua-suffix string             suffix (default ";\n")
@@ -73,6 +74,7 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
   -0, --nul-output                    Use NUL char to separate values. If unwrap scalar is also set, fail if unwrapped scalar contains NUL char.
   -n, --null-input                    Don't read input, simply evaluate the expression given. Useful for creating docs from scratch.
   -o, --output-format string          [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|shell|s|lua|l] output format type. (default "auto")
+      --plain-http                    Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -P, --prettyPrint                   pretty print, shorthand for '... style = ""'
       --properties-array-brackets     use [x] in array paths (e.g. for SpringBoot)
       --properties-separator string   separator to use between keys and values (default " = ")

--- a/site/src/content/docs/commands/zarf_tools_yq_eval.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval.md
@@ -66,6 +66,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
   -I, --indent int                    sets indent level for output (default 2)
   -i, --inplace                       update the file in place of first file given.
   -p, --input-format string           [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|lua|l] parse format for input. (default "auto")
+      --insecure-skip-tls-verify      Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --lua-globals                   output keys as top-level global variables
       --lua-prefix string             prefix (default "return ")
       --lua-suffix string             suffix (default ";\n")
@@ -75,6 +76,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
   -0, --nul-output                    Use NUL char to separate values. If unwrap scalar is also set, fail if unwrapped scalar contains NUL char.
   -n, --null-input                    Don't read input, simply evaluate the expression given. Useful for creating docs from scratch.
   -o, --output-format string          [auto|a|yaml|y|json|j|props|p|csv|c|tsv|t|xml|x|base64|uri|toml|shell|s|lua|l] output format type. (default "auto")
+      --plain-http                    Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -P, --prettyPrint                   pretty print, shorthand for '... style = ""'
       --properties-array-brackets     use [x] in array paths (e.g. for SpringBoot)
       --properties-separator string   separator to use between keys and values (default " = ")

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -28,14 +28,15 @@ zarf version [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --architecture string   Architecture for OCI images and Zarf packages
-      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
-  -l, --log-level string      Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color              Disable colors in output
-      --no-log-file           Disable log file creation
-      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
-      --tmpdir string         Specify the temporary directory to use for intermediate files
-      --zarf-cache string     Specify the location of the Zarf cache directory (default "~/.zarf-cache")
+  -a, --architecture string        Architecture for OCI images and Zarf packages
+      --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable colors in output
+      --no-log-file                Disable log file creation
+      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
+      --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/tutorials/6-publish-and-deploy.mdx
+++ b/site/src/content/docs/tutorials/6-publish-and-deploy.mdx
@@ -142,7 +142,7 @@ You attempted to publish a package with no version metadata.
 
 You attempted to publish a package to an insecure registry, using http instead of https.
 
-1. Use the `--insecure` flag.  Note that this is not suitable for production workloads.
+1. Use the `--plain-http` flag.  Note that this is not suitable for production workloads.
 
 :::
 

--- a/src/cmd/common/viper.go
+++ b/src/cmd/common/viper.go
@@ -20,14 +20,16 @@ const (
 
 	// Root config keys
 
-	VLogLevel     = "log_level"
-	VArchitecture = "architecture"
-	VNoLogFile    = "no_log_file"
-	VNoProgress   = "no_progress"
-	VNoColor      = "no_color"
-	VZarfCache    = "zarf_cache"
-	VTmpDir       = "tmp_dir"
-	VInsecure     = "insecure"
+	VLogLevel              = "log_level"
+	VArchitecture          = "architecture"
+	VNoLogFile             = "no_log_file"
+	VNoProgress            = "no_progress"
+	VNoColor               = "no_color"
+	VZarfCache             = "zarf_cache"
+	VTmpDir                = "tmp_dir"
+	VInsecure              = "insecure"
+	VPlainHTTP             = "plain_http"
+	VInsecureSkipTLSVerify = "insecure_skip_tls_verify"
 
 	// Init config keys
 

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -223,6 +223,7 @@ func init() {
 
 	initCmd.Flags().IntVar(&pkgConfig.PkgOpts.Retries, "retries", v.GetInt(common.VPkgRetries), lang.CmdPackageFlagRetries)
 	initCmd.Flags().StringVarP(&pkgConfig.PkgOpts.PublicKeyPath, "key", "k", v.GetString(common.VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
+	initCmd.Flags().BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 
 	initCmd.Flags().SortFlags = true
 }

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -79,6 +79,12 @@ var packageDeployCmd = &cobra.Command{
 	Short:   lang.CmdPackageDeployShort,
 	Long:    lang.CmdPackageDeployLong,
 	Args:    cobra.MaximumNArgs(1),
+	PreRun: func(_ *cobra.Command, _ []string) {
+		// If --insecure was provided, set --skip-signature-validation to match
+		if config.CommonOptions.Insecure {
+			pkgConfig.PkgOpts.SkipSignatureValidation = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packageSource, err := choosePackage(args)
 		if err != nil {
@@ -112,6 +118,12 @@ var packageMirrorCmd = &cobra.Command{
 	Long:    lang.CmdPackageMirrorLong,
 	Example: lang.CmdPackageMirrorExample,
 	Args:    cobra.MaximumNArgs(1),
+	PreRun: func(_ *cobra.Command, _ []string) {
+		// If --insecure was provided, set --skip-signature-validation to match
+		if config.CommonOptions.Insecure {
+			pkgConfig.PkgOpts.SkipSignatureValidation = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packageSource, err := choosePackage(args)
 		if err != nil {
@@ -136,6 +148,12 @@ var packageInspectCmd = &cobra.Command{
 	Short:   lang.CmdPackageInspectShort,
 	Long:    lang.CmdPackageInspectLong,
 	Args:    cobra.MaximumNArgs(1),
+	PreRun: func(_ *cobra.Command, _ []string) {
+		// If --insecure was provided, set --skip-signature-validation to match
+		if config.CommonOptions.Insecure {
+			pkgConfig.PkgOpts.SkipSignatureValidation = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packageSource, err := choosePackage(args)
 		if err != nil {
@@ -208,6 +226,12 @@ var packageRemoveCmd = &cobra.Command{
 	Aliases: []string{"u", "rm"},
 	Args:    cobra.MaximumNArgs(1),
 	Short:   lang.CmdPackageRemoveShort,
+	PreRun: func(_ *cobra.Command, _ []string) {
+		// If --insecure was provided, set --skip-signature-validation to match
+		if config.CommonOptions.Insecure {
+			pkgConfig.PkgOpts.SkipSignatureValidation = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packageSource, err := choosePackage(args)
 		if err != nil {
@@ -236,6 +260,12 @@ var packagePublishCmd = &cobra.Command{
 	Short:   lang.CmdPackagePublishShort,
 	Example: lang.CmdPackagePublishExample,
 	Args:    cobra.ExactArgs(2),
+	PreRun: func(_ *cobra.Command, _ []string) {
+		// If --insecure was provided, set --skip-signature-validation to match
+		if config.CommonOptions.Insecure {
+			pkgConfig.PkgOpts.SkipSignatureValidation = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pkgConfig.PkgOpts.PackageSource = args[0]
 
@@ -430,6 +460,7 @@ func bindDeployFlags(v *viper.Viper) {
 	deployFlags.StringVar(&pkgConfig.PkgOpts.OptionalComponents, "components", v.GetString(common.VPkgDeployComponents), lang.CmdPackageDeployFlagComponents)
 	deployFlags.StringVar(&pkgConfig.PkgOpts.Shasum, "shasum", v.GetString(common.VPkgDeployShasum), lang.CmdPackageDeployFlagShasum)
 	deployFlags.StringVar(&pkgConfig.PkgOpts.SGetKeyPath, "sget", v.GetString(common.VPkgDeploySget), lang.CmdPackageDeployFlagSget)
+	deployFlags.BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 
 	deployFlags.MarkHidden("sget")
 }
@@ -446,6 +477,7 @@ func bindMirrorFlags(v *viper.Viper) {
 	mirrorFlags.BoolVar(&config.CommonOptions.Confirm, "confirm", false, lang.CmdPackageDeployFlagConfirm)
 
 	mirrorFlags.BoolVar(&pkgConfig.MirrorOpts.NoImgChecksum, "no-img-checksum", false, lang.CmdPackageMirrorFlagNoChecksum)
+	mirrorFlags.BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 
 	mirrorFlags.IntVar(&pkgConfig.PkgOpts.Retries, "retries", v.GetInt(common.VPkgRetries), lang.CmdPackageFlagRetries)
 	mirrorFlags.StringVar(&pkgConfig.PkgOpts.OptionalComponents, "components", v.GetString(common.VPkgDeployComponents), lang.CmdPackageMirrorFlagComponents)
@@ -466,12 +498,14 @@ func bindInspectFlags(_ *viper.Viper) {
 	inspectFlags.BoolVarP(&pkgConfig.InspectOpts.ViewSBOM, "sbom", "s", false, lang.CmdPackageInspectFlagSbom)
 	inspectFlags.StringVar(&pkgConfig.InspectOpts.SBOMOutputDir, "sbom-out", "", lang.CmdPackageInspectFlagSbomOut)
 	inspectFlags.BoolVar(&pkgConfig.InspectOpts.ListImages, "list-images", false, lang.CmdPackageInspectFlagListImages)
+	inspectFlags.BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 }
 
 func bindRemoveFlags(v *viper.Viper) {
 	removeFlags := packageRemoveCmd.Flags()
 	removeFlags.BoolVar(&config.CommonOptions.Confirm, "confirm", false, lang.CmdPackageRemoveFlagConfirm)
 	removeFlags.StringVar(&pkgConfig.PkgOpts.OptionalComponents, "components", v.GetString(common.VPkgDeployComponents), lang.CmdPackageRemoveFlagComponents)
+	removeFlags.BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 	_ = packageRemoveCmd.MarkFlagRequired("confirm")
 }
 
@@ -479,6 +513,7 @@ func bindPublishFlags(v *viper.Viper) {
 	publishFlags := packagePublishCmd.Flags()
 	publishFlags.StringVar(&pkgConfig.PublishOpts.SigningKeyPath, "signing-key", v.GetString(common.VPkgPublishSigningKey), lang.CmdPackagePublishFlagSigningKey)
 	publishFlags.StringVar(&pkgConfig.PublishOpts.SigningKeyPassword, "signing-key-pass", v.GetString(common.VPkgPublishSigningKeyPassword), lang.CmdPackagePublishFlagSigningKeyPassword)
+	publishFlags.BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 }
 
 func bindPullFlags(v *viper.Viper) {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -37,6 +37,12 @@ var (
 var rootCmd = &cobra.Command{
 	Use: "zarf COMMAND",
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		// If --insecure was provided, set --insecure-skip-tls-verify and --plain-http to match
+		if config.CommonOptions.Insecure {
+			config.CommonOptions.InsecureSkipTLSVerify = true
+			config.CommonOptions.PlainHTTP = true
+		}
+
 		// Skip for vendor only commands
 		if common.CheckVendorOnlyFromPath(cmd) {
 			return nil
@@ -121,4 +127,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", v.GetString(common.VZarfCache), lang.RootCmdFlagCachePath)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", v.GetString(common.VTmpDir), lang.RootCmdFlagTempDir)
 	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.Insecure, "insecure", v.GetBool(common.VInsecure), lang.RootCmdFlagInsecure)
+	rootCmd.PersistentFlags().MarkDeprecated("insecure", "please use --plain-http, --insecure-skip-tls-verify, or --skip-signature-validation instead.")
+	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.PlainHTTP, "plain-http", v.GetBool(common.VPlainHTTP), lang.RootCmdFlagPlainHTTP)
+	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", v.GetBool(common.VInsecureSkipTLSVerify), lang.RootCmdFlagInsecureSkipTLSVerify)
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -45,14 +45,16 @@ const (
 	RootCmdLong  = "Zarf eliminates the complexity of air gap software delivery for Kubernetes clusters and cloud native workloads\n" +
 		"using a declarative packaging strategy to support DevSecOps in offline and semi-connected environments."
 
-	RootCmdFlagLogLevel    = "Log level when running Zarf. Valid options are: warn, info, debug, trace"
-	RootCmdFlagArch        = "Architecture for OCI images and Zarf packages"
-	RootCmdFlagSkipLogFile = "Disable log file creation"
-	RootCmdFlagNoProgress  = "Disable fancy UI progress bars, spinners, logos, etc"
-	RootCmdFlagNoColor     = "Disable colors in output"
-	RootCmdFlagCachePath   = "Specify the location of the Zarf cache directory"
-	RootCmdFlagTempDir     = "Specify the temporary directory to use for intermediate files"
-	RootCmdFlagInsecure    = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."
+	RootCmdFlagLogLevel              = "Log level when running Zarf. Valid options are: warn, info, debug, trace"
+	RootCmdFlagArch                  = "Architecture for OCI images and Zarf packages"
+	RootCmdFlagSkipLogFile           = "Disable log file creation"
+	RootCmdFlagNoProgress            = "Disable fancy UI progress bars, spinners, logos, etc"
+	RootCmdFlagNoColor               = "Disable colors in output"
+	RootCmdFlagCachePath             = "Specify the location of the Zarf cache directory"
+	RootCmdFlagTempDir               = "Specify the temporary directory to use for intermediate files"
+	RootCmdFlagInsecure              = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."
+	RootCmdFlagPlainHTTP             = "Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture."
+	RootCmdFlagInsecureSkipTLSVerify = "Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture."
 
 	RootCmdDeprecatedDeploy = "Deprecated: Please use \"zarf package deploy %s\" to deploy this package.  This warning will be removed in Zarf v1.0.0."
 	RootCmdDeprecatedCreate = "Deprecated: Please use \"zarf package create\" to create this package.  This warning will be removed in Zarf v1.0.0."
@@ -210,10 +212,11 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInternalCrc32Short = "Generates a decimal CRC32 for the given text"
 
 	// zarf package
-	CmdPackageShort             = "Zarf package commands for creating, deploying, and inspecting packages"
-	CmdPackageFlagConcurrency   = "Number of concurrent layer operations to perform when interacting with a remote package."
-	CmdPackageFlagFlagPublicKey = "Path to public key file for validating signed packages"
-	CmdPackageFlagRetries       = "Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs"
+	CmdPackageShort                       = "Zarf package commands for creating, deploying, and inspecting packages"
+	CmdPackageFlagConcurrency             = "Number of concurrent layer operations to perform when interacting with a remote package."
+	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
+	CmdPackageFlagSkipSignatureValidation = "Skip validating the signature of the Zarf package"
+	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs"
 
 	CmdPackageCreateShort = "Creates a Zarf package from a given directory or the current directory"
 	CmdPackageCreateLong  = "Builds an archive of resources and dependencies defined by the 'zarf.yaml' in the specified directory.\n" +
@@ -273,7 +276,7 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageDeployFlagAdoptExistingResources         = "Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover."
 	CmdPackageDeployFlagSet                            = "Specify deployment variables to set on the command line (KEY=value)"
 	CmdPackageDeployFlagComponents                     = "Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported."
-	CmdPackageDeployFlagShasum                         = "Shasum of the package to deploy. Required if deploying a remote package and \"--insecure\" is not provided"
+	CmdPackageDeployFlagShasum                         = "Shasum of the package to deploy. Required if deploying a remote package."
 	CmdPackageDeployFlagSget                           = "[Deprecated] Path to public sget key file for remote packages signed via cosign. This flag will be removed in v1.0.0 please use the --key flag instead."
 	CmdPackageDeployFlagSkipWebhooks                   = "[alpha] Skip waiting for external webhooks to execute as each package component is deployed"
 	CmdPackageDeployFlagTimeout                        = "Timeout for health checks and Helm operations such as installs and rollbacks"

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -143,7 +143,7 @@ func (h *Helm) TemplateChart(ctx context.Context) (manifest string, chartValues 
 	client.IncludeCRDs = true
 	// TODO: Further research this with regular/OCI charts
 	client.Verify = false
-	client.InsecureSkipTLSverify = config.CommonOptions.Insecure
+	client.InsecureSkipTLSverify = config.CommonOptions.InsecureSkipTLSVerify
 	if h.kubeVersion != "" {
 		parsedKubeVersion, err := chartutil.ParseKubeVersion(h.kubeVersion)
 		if err != nil {

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -192,7 +192,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 		Verify:  downloader.VerifyNever,
 		Getters: getter.All(pull.Settings),
 		Options: []getter.Option{
-			getter.WithInsecureSkipVerifyTLS(config.CommonOptions.Insecure),
+			getter.WithInsecureSkipVerifyTLS(config.CommonOptions.InsecureSkipTLSVerify),
 			getter.WithBasicAuth(username, password),
 		},
 	}

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -50,9 +50,9 @@ type PushConfig struct {
 func NoopOpt(*crane.Options) {}
 
 // WithGlobalInsecureFlag returns an option for crane that configures insecure
-// based upon Zarf's global --insecure flag.
+// based upon Zarf's global --insecure-skip-tls-verify (and --insecure) flags.
 func WithGlobalInsecureFlag() []crane.Option {
-	if config.CommonOptions.Insecure {
+	if config.CommonOptions.InsecureSkipTLSVerify {
 		return []crane.Option{crane.Insecure}
 	}
 	// passing a nil option will cause panic
@@ -103,7 +103,7 @@ func createPushOpts(cfg PushConfig, pb *message.ProgressBar) []crane.Option {
 	opts = append(opts, WithPushAuth(cfg.RegInfo))
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig.InsecureSkipVerify = config.CommonOptions.Insecure
+	transport.TLSClientConfig.InsecureSkipVerify = config.CommonOptions.InsecureSkipTLSVerify
 	// TODO (@WSTARR) This is set to match the TLSHandshakeTimeout to potentially mitigate effects of https://github.com/zarf-dev/zarf/issues/1444
 	transport.ResponseHeaderTimeout = 10 * time.Second
 

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -281,14 +281,17 @@ func (pc *PackageCreator) Output(ctx context.Context, dst *layout.PackagePaths, 
 			return fmt.Errorf("unable to publish package: %w", err)
 		}
 		message.HorizontalRule()
-		flags := ""
-		if config.CommonOptions.Insecure {
-			flags = "--insecure"
+		flags := []string{}
+		if config.CommonOptions.PlainHTTP {
+			flags = append(flags, "--plain-http")
+		}
+		if config.CommonOptions.InsecureSkipTLSVerify {
+			flags = append(flags, "--insecure-skip-tls-verify")
 		}
 		message.Title("To inspect/deploy/pull:", "")
-		message.ZarfCommand("package inspect %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), flags)
-		message.ZarfCommand("package deploy %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), flags)
-		message.ZarfCommand("package pull %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), flags)
+		message.ZarfCommand("package inspect %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
+		message.ZarfCommand("package deploy %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
+		message.ZarfCommand("package pull %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
 	} else {
 		// Use the output path if the user specified it.
 		packageName := fmt.Sprintf("%s%s", sources.NameFromMetadata(pkg, pc.createOpts.IsSkeleton), sources.PkgSuffix(pkg.Metadata.Uncompressed))

--- a/src/pkg/packager/sources/new_test.go
+++ b/src/pkg/packager/sources/new_test.go
@@ -155,7 +155,7 @@ func TestPackageSource(t *testing.T) {
 		{
 			name:        "http-insecure",
 			src:         fmt.Sprintf("%s/zarf-package-wordpress-amd64-16.0.4.tar.zst", ts.URL),
-			expectedErr: "remote package provided without a shasum, use --insecure to ignore, or provide one w/ --shasum",
+			expectedErr: "remote package provided without a shasum, please provide one with --shasum",
 		},
 	}
 	for _, tt := range tests {

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -79,8 +79,10 @@ func (s *OCISource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, f
 
 		spinner.Success()
 
-		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
-			return pkg, nil, err
+		if !s.SkipSignatureValidation {
+			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
+				return pkg, nil, err
+			}
 		}
 	}
 
@@ -141,11 +143,13 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 			spinner.Success()
 		}
 
-		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
-			if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
-				message.Warn("The package was signed but no public key was provided, skipping signature validation")
-			} else {
-				return pkg, nil, err
+		if !s.SkipSignatureValidation {
+			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
+				if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
+					message.Warn("The package was signed but no public key was provided, skipping signature validation")
+				} else {
+					return pkg, nil, err
+				}
 			}
 		}
 	}

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -107,8 +107,10 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 
 		spinner.Success()
 
-		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
-			return pkg, nil, err
+		if !s.SkipSignatureValidation {
+			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
+				return pkg, nil, err
+			}
 		}
 	}
 
@@ -185,11 +187,13 @@ func (s *TarballSource) LoadPackageMetadata(ctx context.Context, dst *layout.Pac
 			spinner.Success()
 		}
 
-		if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
-			if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
-				message.Warn("The package was signed but no public key was provided, skipping signature validation")
-			} else {
-				return pkg, nil, err
+		if !s.SkipSignatureValidation {
+			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
+				if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
+					message.Warn("The package was signed but no public key was provided, skipping signature validation")
+				} else {
+					return pkg, nil, err
+				}
 			}
 		}
 	}

--- a/src/pkg/packager/sources/url.go
+++ b/src/pkg/packager/sources/url.go
@@ -32,8 +32,8 @@ type URLSource struct {
 
 // Collect downloads a package from the source URL.
 func (s *URLSource) Collect(ctx context.Context, dir string) (string, error) {
-	if !config.CommonOptions.Insecure && s.Shasum == "" && !strings.HasPrefix(s.PackageSource, helpers.SGETURLPrefix) {
-		return "", fmt.Errorf("remote package provided without a shasum, use --insecure to ignore, or provide one w/ --shasum")
+	if s.Shasum == "" && !strings.HasPrefix(s.PackageSource, helpers.SGETURLPrefix) {
+		return "", fmt.Errorf("remote package provided without a shasum, please provide one with --shasum")
 	}
 	var packageURL string
 	if s.Shasum != "" {

--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
-	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -25,16 +24,11 @@ var (
 	// ErrPkgKeyButNoSig is returned when a key was provided but the package is not signed
 	ErrPkgKeyButNoSig = errors.New("a key was provided but the package is not signed - the package may be corrupted or the --key flag was erroneously specified")
 	// ErrPkgSigButNoKey is returned when a package is signed but no key was provided
-	ErrPkgSigButNoKey = errors.New("package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
+	ErrPkgSigButNoKey = errors.New("package is signed but no key was provided - add a key with the --key flag or use the --skip-signature-validation flag and run the command again")
 )
 
 // ValidatePackageSignature validates the signature of a package
 func ValidatePackageSignature(ctx context.Context, paths *layout.PackagePaths, publicKeyPath string) error {
-	// If the insecure flag was provided ignore the signature validation
-	if config.CommonOptions.Insecure {
-		return nil
-	}
-
 	if publicKeyPath != "" {
 		message.Debugf("Using public key %q for signature validation", publicKeyPath)
 	}

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -32,8 +32,8 @@ type Remote struct {
 func NewRemote(url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
 	logger := slog.New(message.ZarfHandler{})
 	modifiers := append([]oci.Modifier{
-		oci.WithPlainHTTP(config.CommonOptions.Insecure),
-		oci.WithInsecureSkipVerify(config.CommonOptions.Insecure),
+		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
+		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),
 		oci.WithLogger(logger),
 		oci.WithUserAgent("zarf/" + config.CLIVersion),
 	}, mods...)

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -61,7 +61,7 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	suite.Contains(stdErr, "Package signature validated!")
 
 	// Test pull w/ bad ref.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+badPullInspectRef.String(), "--insecure")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+badPullInspectRef.String(), "--plain-http")
 	suite.Error(err, stdOut, stdErr)
 }
 
@@ -69,7 +69,7 @@ func (suite *PullInspectTestSuite) Test_1_Remote_Inspect() {
 	suite.T().Log("E2E: Package Inspect oci://")
 
 	// Test inspect w/ bad ref.
-	_, stdErr, err := e2e.Zarf(suite.T(), "package", "inspect", "oci://"+badPullInspectRef.String(), "--insecure")
+	_, stdErr, err := e2e.Zarf(suite.T(), "package", "inspect", "oci://"+badPullInspectRef.String(), "--plain-http")
 	suite.Error(err, stdErr)
 
 	// Test inspect on a public package.

--- a/src/test/e2e/14_oci_compose_test.go
+++ b/src/test/e2e/14_oci_compose_test.go
@@ -65,47 +65,47 @@ func (suite *PublishCopySkeletonSuite) Test_0_Publish_Skeletons() {
 	ref := suite.Reference.String()
 
 	helmCharts := filepath.Join("examples", "helm-charts")
-	_, stdErr, err := e2e.Zarf(suite.T(), "package", "publish", helmCharts, "oci://"+ref, "--insecure")
+	_, stdErr, err := e2e.Zarf(suite.T(), "package", "publish", helmCharts, "oci://"+ref, "--plain-http")
 	suite.NoError(err)
 	suite.Contains(stdErr, "Published "+ref)
 
 	bigBang := filepath.Join("src", "test", "packages", "14-import-everything", "big-bang-min")
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", bigBang, "oci://"+ref, "--insecure")
+	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", bigBang, "oci://"+ref, "--plain-http")
 	suite.NoError(err)
 	suite.Contains(stdErr, "Published "+ref)
 
 	composable := filepath.Join("src", "test", "packages", "09-composable-packages")
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", composable, "oci://"+ref, "--insecure")
+	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", composable, "oci://"+ref, "--plain-http")
 	suite.NoError(err)
 	suite.Contains(stdErr, "Published "+ref)
 
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", importEverything, "oci://"+ref, "--insecure")
+	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", importEverything, "oci://"+ref, "--plain-http")
 	suite.NoError(err)
 	suite.Contains(stdErr, "Published "+ref)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/import-everything:0.0.1", "--insecure", "-a", "skeleton")
+	_, _, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/import-everything:0.0.1", "--plain-http", "-a", "skeleton")
 	suite.NoError(err)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/import-everything:0.0.1", "-o", "build", "--insecure", "-a", "skeleton")
+	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/import-everything:0.0.1", "-o", "build", "--plain-http", "-a", "skeleton")
 	suite.NoError(err)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/helm-charts:0.0.1", "-o", "build", "--insecure", "-a", "skeleton")
+	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/helm-charts:0.0.1", "-o", "build", "--plain-http", "-a", "skeleton")
 	suite.NoError(err)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/big-bang-min:2.10.0", "-o", "build", "--insecure", "-a", "skeleton")
+	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/big-bang-min:2.10.0", "-o", "build", "--plain-http", "-a", "skeleton")
 	suite.NoError(err)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/test-compose-package:0.0.1", "-o", "build", "--insecure", "-a", "skeleton")
+	_, _, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/test-compose-package:0.0.1", "-o", "build", "--plain-http", "-a", "skeleton")
 	suite.NoError(err)
 }
 
 func (suite *PublishCopySkeletonSuite) Test_1_Compose_Everything_Inception() {
 	suite.T().Log("E2E: Skeleton Package Compose oci://")
 
-	_, _, err := e2e.Zarf(suite.T(), "package", "create", importEverything, "-o", "build", "--insecure", "--confirm")
+	_, _, err := e2e.Zarf(suite.T(), "package", "create", importEverything, "-o", "build", "--plain-http", "--confirm")
 	suite.NoError(err)
 
-	_, _, err = e2e.Zarf(suite.T(), "package", "create", importception, "-o", "build", "--insecure", "--confirm")
+	_, _, err = e2e.Zarf(suite.T(), "package", "create", importception, "-o", "build", "--plain-http", "--confirm")
 	suite.NoError(err)
 
 	_, stdErr, err := e2e.Zarf(suite.T(), "package", "inspect", importEverythingPath)
@@ -183,7 +183,7 @@ func (suite *PublishCopySkeletonSuite) Test_3_Copy() {
 	t := suite.T()
 
 	example := filepath.Join("build", fmt.Sprintf("zarf-package-helm-charts-%s-0.0.1.tar.zst", e2e.Arch))
-	stdOut, stdErr, err := e2e.Zarf(t, "package", "publish", example, "oci://"+suite.Reference.Registry, "--insecure")
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "publish", example, "oci://"+suite.Reference.Registry, "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 
 	suite.Reference.Repository = "helm-charts"

--- a/src/test/e2e/29_config_file_test.go
+++ b/src/test/e2e/29_config_file_test.go
@@ -103,7 +103,8 @@ func configFileDefaultTests(t *testing.T) {
 		"Disable log file creation (default true)",
 		"Disable fancy UI progress bars, spinners, logos, etc (default true)",
 		"zarf_cache: 978499a5",
-		"Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.",
+		"Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.",
+		"Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.",
 		"tmp_dir: c457359e",
 	}
 

--- a/src/test/e2e/31_checksum_and_signature_test.go
+++ b/src/test/e2e/31_checksum_and_signature_test.go
@@ -37,7 +37,7 @@ func TestChecksumAndSignature(t *testing.T) {
 	// Test that we get an error when trying to deploy a package without providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, e2e.StripMessageFormatting(stdErr), "failed to deploy package: unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
+	require.Contains(t, e2e.StripMessageFormatting(stdErr), "failed to deploy package: unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --skip-signature-validation flag and run the command again")
 
 	// Test that we don't get an error when we remember to provide the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, publicKeyFlag, "--confirm")

--- a/src/test/e2e/34_custom_init_package_test.go
+++ b/src/test/e2e/34_custom_init_package_test.go
@@ -38,7 +38,7 @@ func TestCustomInit(t *testing.T) {
 	// Test that we get an error when trying to deploy a package without providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "init", "--confirm")
 	require.Error(t, err, stdOut, stdErr)
-	require.Contains(t, e2e.StripMessageFormatting(stdErr), "unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --insecure flag and run the command again")
+	require.Contains(t, e2e.StripMessageFormatting(stdErr), "unable to load the package: package is signed but no key was provided - add a key with the --key flag or use the --skip-signature-validation flag and run the command again")
 
 	/* Test operations during package deploy */
 	// Test that we can deploy the package with the public key

--- a/src/test/e2e/50_oci_publish_deploy_test.go
+++ b/src/test/e2e/50_oci_publish_deploy_test.go
@@ -46,35 +46,35 @@ func (suite *PublishDeploySuiteTestSuite) Test_0_Publish() {
 	// Publish package.
 	example := filepath.Join(suite.PackagesDir, fmt.Sprintf("zarf-package-helm-charts-%s-0.0.1.tar.zst", e2e.Arch))
 	ref := suite.Reference.String()
-	stdOut, stdErr, err := e2e.Zarf(suite.T(), "package", "publish", example, "oci://"+ref, "--insecure")
+	stdOut, stdErr, err := e2e.Zarf(suite.T(), "package", "publish", example, "oci://"+ref, "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 	suite.Contains(stdErr, "Published "+ref)
 
 	// Pull the package via OCI.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/helm-charts:0.0.1", "--insecure")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", "oci://"+ref+"/helm-charts:0.0.1", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Publish w/ package missing `metadata.version` field.
 	example = filepath.Join(suite.PackagesDir, fmt.Sprintf("zarf-package-component-actions-%s.tar.zst", e2e.Arch))
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", example, "oci://"+ref, "--insecure")
+	_, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", example, "oci://"+ref, "--plain-http")
 	suite.Error(err, stdErr)
 
 	// Inline publish package.
 	dir := filepath.Join("examples", "helm-charts")
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", dir, "-o", "oci://"+ref, "--insecure", "--oci-concurrency=5", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", dir, "-o", "oci://"+ref, "--plain-http", "--oci-concurrency=5", "--confirm")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Inline publish flavor.
 	dir = filepath.Join("examples", "package-flavors")
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", dir, "-o", "oci://"+ref, "--flavor", "oracle-cookie-crunch", "--insecure", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", dir, "-o", "oci://"+ref, "--flavor", "oracle-cookie-crunch", "--plain-http", "--confirm")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Inspect published flavor.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/package-flavors:1.0.0-oracle-cookie-crunch", "--insecure")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/package-flavors:1.0.0-oracle-cookie-crunch", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Inspect the published package.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/helm-charts:0.0.1", "--insecure")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "oci://"+ref+"/helm-charts:0.0.1", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 }
 
@@ -87,15 +87,15 @@ func (suite *PublishDeploySuiteTestSuite) Test_1_Deploy() {
 	ref := suite.Reference.String()
 
 	// Deploy the package via OCI.
-	stdOut, stdErr, err := e2e.Zarf(suite.T(), "package", "deploy", "oci://"+ref, "--insecure", "--confirm")
+	stdOut, stdErr, err := e2e.Zarf(suite.T(), "package", "deploy", "oci://"+ref, "--plain-http", "--confirm")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Remove the package via OCI.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "remove", "oci://"+ref, "--insecure", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "remove", "oci://"+ref, "--plain-http", "--confirm")
 	suite.NoError(err, stdOut, stdErr)
 
 	// Test deploy w/ bad ref.
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "deploy", "oci://"+badDeployRef.String(), "--insecure", "--confirm")
+	_, stdErr, err = e2e.Zarf(suite.T(), "package", "deploy", "oci://"+badDeployRef.String(), "--plain-http", "--confirm")
 	suite.Error(err, stdErr)
 }
 

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -14,6 +14,10 @@ type ZarfCommonOptions struct {
 	Confirm bool
 	// Allow insecure connections for remote packages
 	Insecure bool
+	// Disable checking the server TLS certificate for validity
+	InsecureSkipTLSVerify bool
+	// Force connections to be over http instead of https
+	PlainHTTP bool
 	// Path to use to cache images and git repos on package create
 	CachePath string
 	// Location Zarf should use as a staging ground when managing files and images for package creation and deployment
@@ -38,6 +42,8 @@ type ZarfPackageOptions struct {
 	PublicKeyPath string
 	// The number of retries to perform for Zarf deploy operations like image pushes or Helm installs
 	Retries int
+	// Skip validating the signature of the Zarf package
+	SkipSignatureValidation bool
 }
 
 // ZarfInspectOptions tracks the user-defined preferences during a package inspection.


### PR DESCRIPTION
## Description

Attempting to break up the `--insecure` global flag into four separate flags:

* `--plain-http`
* `--insecure-skip-tls-verify`
* `--skip-signature-validation`

## Related Issue

Fixes #2860
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
