### PR TITLE
refactor: replace message.Info, message.Note and message.Success with context logger

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -53,7 +53,7 @@ var devDeployCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ var devGenerateCmd = &cobra.Command{
 		pkgConfig.CreateOpts.BaseDir = "."
 		pkgConfig.FindImagesOpts.RepoHelmChartPath = pkgConfig.GenerateOpts.GitPath
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -229,7 +229,7 @@ var devFindImagesCmd = &cobra.Command{
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ var devLintCmd = &cobra.Command{
 		pkgConfig.CreateOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -63,7 +63,7 @@ var initCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig, packager.WithSource(src))
+		pkgClient, err := packager.New(cmd.Context(), &pkgConfig, packager.WithSource(src))
 		if err != nil {
 			return err
 		}

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zarf-dev/zarf/src/cmd/common"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -127,7 +128,7 @@ func downloadInitPackage(ctx context.Context, cacheDirectory string) (string, er
 	// Give the user the choice to download the init-package and note that this does require an internet connection
 	message.Question(fmt.Sprintf(lang.CmdInitPullAsk, url))
 
-	message.Note(lang.CmdInitPullNote)
+	logging.FromContextOrDiscard(ctx).Info("Downloading init package will require an internet connection")
 
 	// Prompt the user if --confirm not specified
 	if !confirmDownload {

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent"
 	"github.com/zarf-dev/zarf/src/internal/gitea"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -67,7 +68,7 @@ var httpProxyCmd = &cobra.Command{
 var genCLIDocs = &cobra.Command{
 	Use:   "gen-cli-docs",
 	Short: lang.CmdInternalGenerateCliDocsShort,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Don't include the datestamp in the output
 		rootCmd.DisableAutoGenTag = true
 
@@ -161,7 +162,7 @@ tableOfContents: false
 		if err := doc.GenMarkdownTreeCustom(rootCmd, "./site/src/content/docs/commands", prependTitle, linkHandler); err != nil {
 			return err
 		}
-		message.Success(lang.CmdInternalGenerateCliDocsSuccess)
+		logging.FromContextOrDiscard(cmd.Context()).Info("Successfully createed the CLI documentation")
 		return nil
 	},
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -87,6 +89,10 @@ var rootCmd = &cobra.Command{
 
 // Execute is the entrypoint for the CLI.
 func Execute(ctx context.Context) {
+	handler := logging.NewPtermHandler()
+	log := slog.New(handler)
+	ctx = logging.NewContext(ctx, log)
+
 	cmd, err := rootCmd.ExecuteContextC(ctx)
 	if err == nil {
 		return

--- a/src/cmd/tools/wait.go
+++ b/src/cmd/tools/wait.go
@@ -29,7 +29,7 @@ var waitForCmd = &cobra.Command{
 	Long:    lang.CmdToolsWaitForLong,
 	Example: lang.CmdToolsWaitForExample,
 	Args:    cobra.MinimumNArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse the timeout string
 		timeout, err := time.ParseDuration(waitTimeout)
 		if err != nil {
@@ -51,7 +51,7 @@ var waitForCmd = &cobra.Command{
 		}
 
 		// Execute the wait command.
-		if err := utils.ExecuteWait(waitTimeout, waitNamespace, condition, kind, identifier, timeout); err != nil {
+		if err := utils.ExecuteWait(cmd.Context(), waitTimeout, waitNamespace, condition, kind, identifier, timeout); err != nil {
 			return err
 		}
 		return err

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -142,7 +142,6 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInitErrValidateArtifact = "the 'artifact-push-username' and 'artifact-push-token' flags must be provided if the 'artifact-url' flag is provided"
 
 	CmdInitPullAsk       = "It seems the init package could not be found locally, but can be pulled from oci://%s"
-	CmdInitPullNote      = "Note: This will require an internet connection."
 	CmdInitPullConfirm   = "Do you want to pull this init package?"
 	CmdInitPullErrManual = "pull the init package manually and place it in the current working directory"
 
@@ -183,8 +182,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 		"This command starts up a http proxy that can be used by running pods to transform queries " +
 		"that conform to Gitea / Gitlab repository and package URLs in the airgap."
 
-	CmdInternalGenerateCliDocsShort   = "Creates auto-generated markdown of all the commands for the CLI"
-	CmdInternalGenerateCliDocsSuccess = "Successfully created the CLI documentation"
+	CmdInternalGenerateCliDocsShort = "Creates auto-generated markdown of all the commands for the CLI"
 
 	CmdInternalConfigSchemaShort = "Generates a JSON schema for the zarf.yaml configuration"
 
@@ -417,8 +415,6 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 	CmdToolsRegistryPruneShort       = "Prunes images from the registry that are not currently being used by any Zarf packages."
 	CmdToolsRegistryPruneFlagConfirm = "Confirm the image prune action to prevent accidental deletions"
-	CmdToolsRegistryPruneImageList   = "The following image digests will be pruned from the registry:"
-	CmdToolsRegistryPruneNoImages    = "There are no images to prune"
 	CmdToolsRegistryPruneLookup      = "Looking up images within package definitions"
 	CmdToolsRegistryPruneCatalog     = "Cataloging images in the registry"
 	CmdToolsRegistryPruneCalculate   = "Calculating images to prune"
@@ -482,15 +478,12 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsHelmLong  = "Subset of the Helm CLI that includes the repo and dependency commands for managing helm charts destined for the air gap."
 
 	CmdToolsClearCacheShort         = "Clears the configured git and image cache directory"
-	CmdToolsClearCacheDir           = "Cache directory set to: %s"
-	CmdToolsClearCacheSuccess       = "Successfully cleared the cache from %s"
 	CmdToolsClearCacheFlagCachePath = "Specify the location of the Zarf artifact cache (images and git repositories)"
 
 	CmdToolsDownloadInitShort               = "Downloads the init package for the current Zarf version into the specified directory"
 	CmdToolsDownloadInitFlagOutputDirectory = "Specify a directory to place the init package in."
 
 	CmdToolsGenPkiShort       = "Generates a Certificate Authority and PKI chain of trust for the given host"
-	CmdToolsGenPkiSuccess     = "Successfully created a chain of trust for %s"
 	CmdToolsGenPkiFlagAltName = "Specify Subject Alternative Names for the certificate"
 
 	CmdToolsGenKeyShort                = "Generates a cosign public/private keypair that can be used to sign packages"
@@ -499,7 +492,6 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsGenKeyPromptExists         = "File %s already exists. Overwrite? "
 	CmdToolsGenKeyErrUnableGetPassword = "unable to get password for private key: %s"
 	CmdToolsGenKeyErrPasswordsNotMatch = "passwords do not match"
-	CmdToolsGenKeySuccess              = "Generated key pair and written to %s and %s"
 
 	CmdToolsSbomShort = "Generates a Software Bill of Materials (SBOM) for the given package"
 
@@ -573,7 +565,6 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 # NOTE: Not specifying a pull username/password will keep the previous pull username/password.
 `
 	CmdToolsUpdateCredsConfirmFlag          = "Confirm updating credentials without prompting"
-	CmdToolsUpdateCredsConfirmProvided      = "Confirm flag specified, continuing without prompting."
 	CmdToolsUpdateCredsConfirmContinue      = "Continue with these changes?"
 	CmdToolsUpdateCredsUnableUpdateRegistry = "Unable to update Zarf Registry values: %s"
 	CmdToolsUpdateCredsUnableUpdateAgent    = "Unable to update Zarf Agent TLS secrets: %s"
@@ -595,7 +586,6 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 // These are only seen in the Kubernetes logs.
 const (
 	AgentInfoWebhookAllowed        = "Webhook [%s - %s] - Allowed: %t"
-	AgentInfoPort                  = "Server running in port: %s"
 	AgentWarnNotOCIType            = "Skipping HelmRepo mutation because the type is not OCI: %s"
 	AgentWarnSemVerRef             = "Detected a semver OCI ref (%s) - continuing but will be unable to guarantee against collisions if multiple OCI artifacts with the same name are brought in from different registries"
 	AgentErrBadRequest             = "could not read request body: %s"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -315,9 +315,8 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a ar
 $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a skeleton`
 	CmdPackagePullFlagOutputDirectory = "Specify the output directory for the pulled Zarf package"
 
-	CmdPackageChoose                = "Choose or type the package file"
-	CmdPackageClusterSourceFallback = "%q does not satisfy any current sources, assuming it is a package deployed to a cluster"
-	CmdPackageInvalidSource         = "Unable to identify source from %q: %s"
+	CmdPackageChoose        = "Choose or type the package file"
+	CmdPackageInvalidSource = "Unable to identify source from %q: %s"
 
 	// zarf dev (prepare is an alias for dev)
 	CmdDevShort = "Commands useful for developing packages"

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
@@ -64,8 +63,6 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 	if err != nil {
 		return nil, err
 	}
-
-	message.Debugf("Using the url of (%s) to mutate the ArgoCD Application", state.GitServer.Address)
 
 	app := Application{}
 	if err = json.Unmarshal(r.Object.Raw, &app); err != nil {
@@ -125,7 +122,6 @@ func getPatchedRepoURL(repoURL string, gs types.GitServerInfo, r *v1.AdmissionRe
 			return "", fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original repoURL of (%s) got mutated to (%s)", repoURL, patchedURL)
 	}
 
 	return patchedURL, nil

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -91,7 +91,6 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 			return nil, fmt.Errorf("unable the git url: %w", err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original url of (%s) got mutated to (%s)", repoCreds.URL, patchedURL)
 	}
 
 	patches := populateArgoRepositoryPatchOperations(patchedURL, state.GitServer)

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -14,7 +14,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
@@ -56,8 +55,6 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	if err != nil {
 		return nil, err
 	}
-
-	message.Infof("Using the url of (%s) to mutate the ArgoCD Repository Secret", state.GitServer.Address)
 
 	secret := corev1.Secret{}
 	if err = json.Unmarshal(r.Object.Raw, &secret); err != nil {

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -16,7 +16,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	v1 "k8s.io/api/admission/v1"
 )
@@ -51,8 +50,6 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		return nil, err
 	}
 
-	message.Debugf("Using the url of (%s) to mutate the flux repository", state.GitServer.Address)
-
 	repo := flux.GitRepository{}
 	if err = json.Unmarshal(r.Object.Raw, &repo); err != nil {
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
@@ -78,7 +75,6 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 			return nil, fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}
 		patchedURL = transformedURL.String()
-		message.Debugf("original git URL of (%s) got mutated to (%s)", repo.Spec.URL, patchedURL)
 	}
 
 	// Patch updates of the repo spec

--- a/src/internal/agent/hooks/flux-helmrepo.go
+++ b/src/internal/agent/hooks/flux-helmrepo.go
@@ -65,8 +65,6 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 		return nil, err
 	}
 
-	message.Debugf("Using the url of (%s) to mutate the flux HelmRepository", registryAddress)
-
 	patchedSrc, err := transform.ImageTransformHost(registryAddress, src.Spec.URL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to transform the HelmRepo URL: %w", err)
@@ -77,8 +75,6 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 		return nil, fmt.Errorf("unable to parse the HelmRepo URL: %w", err)
 	}
 	patchedURL := helpers.OCIURLPrefix + patchedRefInfo.Name
-
-	message.Debugf("original HelmRepo URL of (%s) got mutated to (%s)", src.Spec.URL, patchedURL)
 
 	patches := populateHelmRepoPatchOperations(patchedURL, zarfState.RegistryInfo.IsInternal())
 

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -44,7 +44,7 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		src.Spec.Reference = &flux.OCIRepositoryRef{}
 	}
 
-	// If we have a semver we want to continue since we wil still have the upstream tag
+	// If we have a semver we want to continue since we will still have the upstream tag
 	// but should warn that we can't guarantee there won't be collisions
 	if src.Spec.Reference.SemVer != "" {
 		message.Warnf(lang.AgentWarnSemVerRef, src.Spec.Reference.SemVer)
@@ -69,8 +69,6 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	}
 
 	// For the internal registry this will be the ip & port of the service, it may look like 10.43.36.151:5000
-	message.Debugf("Using the url of (%s) to mutate the flux OCIRepository", registryAddress)
-
 	ref := src.Spec.URL
 	if src.Spec.Reference.Digest != "" {
 		ref = fmt.Sprintf("%s@%s", ref, src.Spec.Reference.Digest)
@@ -96,8 +94,6 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	} else if patchedRefInfo.Tag != "" {
 		patchedRef.Tag = patchedRefInfo.Tag
 	}
-
-	message.Debugf("original OCIRepo URL of (%s) got mutated to (%s)", src.Spec.URL, patchedURL)
 
 	patches := populateOCIRepoPatchOperations(patchedURL, zarfState.RegistryInfo.IsInternal(), patchedRef)
 

--- a/src/internal/agent/http/admission/handler.go
+++ b/src/internal/agent/http/admission/handler.go
@@ -117,7 +117,6 @@ func (h *Handler) Serve(hook operations.Hook) http.HandlerFunc {
 			return
 		}
 
-		message.Infof(lang.AgentInfoWebhookAllowed, r.URL.Path, review.Request.Operation, result.Allowed)
 		w.WriteHeader(http.StatusOK)
 		//nolint: errcheck // ignore
 		w.Write(jsonResponse)

--- a/src/internal/agent/http/proxy.go
+++ b/src/internal/agent/http/proxy.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -14,17 +15,19 @@ import (
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
 // ProxyHandler constructs a new httputil.ReverseProxy and returns an http handler.
-func ProxyHandler(cluster *cluster.Cluster) http.HandlerFunc {
+func ProxyHandler(ctx context.Context, cluster *cluster.Cluster) http.HandlerFunc {
+	log := logging.FromContextOrDiscard(ctx)
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		state, err := cluster.LoadZarfState(r.Context())
 		if err != nil {
-			message.Debugf("%#v", err)
+			log.Debug("load zarf state failed", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			//nolint: errcheck // ignore
 			w.Write([]byte("unable to load Zarf state, see the Zarf HTTP proxy logs for more details"))
@@ -32,7 +35,7 @@ func ProxyHandler(cluster *cluster.Cluster) http.HandlerFunc {
 		}
 		err = proxyRequestTransform(r, state)
 		if err != nil {
-			message.Debugf("%#v", err)
+			log.Debug("proxy request transporm failed", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			//nolint: errcheck // ignore
 			w.Write([]byte("unable to transform the provided request, see the Zarf HTTP proxy logs for more details"))

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -58,7 +58,7 @@ func StartWebhook(ctx context.Context, cluster *cluster.Cluster) error {
 // StartHTTPProxy launches the zarf agent proxy in the cluster.
 func StartHTTPProxy(ctx context.Context, cluster *cluster.Cluster) error {
 	mux := http.NewServeMux()
-	mux.Handle("/", agentHttp.ProxyHandler(cluster))
+	mux.Handle("/", agentHttp.ProxyHandler(ctx, cluster))
 	return startServer(ctx, httpPort, mux)
 }
 

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -14,12 +14,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/agent/hooks"
 	agentHttp "github.com/zarf-dev/zarf/src/internal/agent/http"
 	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 )
 
 // Heavily influenced by https://github.com/douglasmakey/admissioncontroller and
@@ -93,7 +92,7 @@ func startServer(ctx context.Context, port string, mux *http.ServeMux) error {
 		}
 		return nil
 	})
-	message.Infof(lang.AgentInfoPort, httpPort)
+	logging.FromContextOrDiscard(ctx).Info("server running", "port", httpPort)
 	err := g.Wait()
 	if err != nil {
 		return err

--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/zarf-dev/zarf/src/pkg/logging"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -96,7 +95,7 @@ func Clone(ctx context.Context, rootPath, address string, shallow bool) (*Reposi
 	}
 	repo, err := git.PlainCloneContext(ctx, r.path, false, cloneOpts)
 	if err != nil {
-		message.Notef("Falling back to host 'git', failed to clone the repo %q with Zarf: %s", gitURLNoRef, err.Error())
+		logging.FromContextOrDiscard(ctx).Error("Failling back to the host git, failed to clone the repo with Zarf", "error", err, "repository", gitURLNoRef)
 		err := r.gitCloneFallback(ctx, gitURLNoRef, ref, shallow)
 		if err != nil {
 			return nil, err

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -193,8 +193,7 @@ func (h *Helm) RemoveChart(namespace string, name string, spinner *message.Spinn
 	// Establish a new actionConfig for the namespace.
 	_ = h.createActionConfig(namespace, spinner)
 	// Perform the uninstall.
-	response, err := h.uninstallChart(name)
-	message.Debug(response)
+	_, err := h.uninstallChart(name)
 	return err
 }
 

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/git"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -39,7 +40,7 @@ func (h *Helm) PackageChart(ctx context.Context, cosignKeyPath string) error {
 		// check if the chart is a git url with a ref (if an error is returned url will be empty)
 		isGitURL := strings.HasSuffix(url, ".git")
 		if err != nil {
-			message.Debugf("unable to parse the url, continuing with %s", h.chart.URL)
+			logging.FromContextOrDiscard(ctx).Debug("continuing with original url as the url could not be parsed", "url", h.chart.URL, "error", err)
 		}
 
 		if isGitURL {
@@ -147,7 +148,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 
 	// Not returning the error here since the repo file is only needed if we are pulling from a repo that requires authentication
 	if err != nil {
-		message.Debugf("Unable to load the repo file at %q: %s", pull.Settings.RepositoryConfig, err.Error())
+		logging.FromContextOrDiscard(ctx).Debug("unable to load the repository file", "path", pull.Settings.RepositoryConfig, "error", err)
 	}
 
 	var username string

--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -112,7 +112,7 @@ func (h *Helm) UpdateZarfAgentValues(ctx context.Context) error {
 					Value: agentImage.Tag,
 				},
 			})
-			applicationTemplates, err := template.GetZarfTemplates("zarf-agent", h.state)
+			applicationTemplates, err := template.GetZarfTemplates(ctx, "zarf-agent", h.state)
 			if err != nil {
 				return fmt.Errorf("error setting up the templates: %w", err)
 			}

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -225,7 +225,7 @@ func Pull(ctx context.Context, cfg PullConfig) (map[transform.Image]v1.Image, er
 
 	doneSaving := make(chan error)
 	updateText := fmt.Sprintf("Pulling %d images", imageCount)
-	go utils.RenderProgressBarForLocalDirWrite(cfg.DestinationDirectory, totalBytes.Load(), doneSaving, updateText, updateText)
+	go utils.RenderProgressBarForLocalDirWrite(ctx, cfg.DestinationDirectory, totalBytes.Load(), doneSaving, updateText, updateText)
 
 	toPull := maps.Clone(fetched)
 

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -115,8 +115,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 				return err
 			}
 
-			message.Debugf("push %s -> %s)", refInfo.Reference, offlineName)
-
 			if err = pushImage(img, offlineName); err != nil {
 				return err
 			}

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -5,6 +5,7 @@
 package sbom
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"os"
@@ -27,6 +28,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -48,7 +50,7 @@ var transformRegex = regexp.MustCompile(`(?m)[^a-zA-Z0-9\.\-]`)
 var componentPrefix = "zarf-component-"
 
 // Catalog catalogs the given components and images to create an SBOM.
-func Catalog(componentSBOMs map[string]*layout.ComponentSBOM, imageList []transform.Image, paths *layout.PackagePaths) error {
+func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBOM, imageList []transform.Image, paths *layout.PackagePaths) error {
 	imageCount := len(imageList)
 	componentCount := len(componentSBOMs)
 	builder := Builder{
@@ -103,7 +105,7 @@ func Catalog(componentSBOMs map[string]*layout.ComponentSBOM, imageList []transf
 		builder.spinner.Updatef("Creating component file SBOMs (%d of %d): %s", currComponent, componentCount, component)
 
 		if componentSBOMs[component] == nil {
-			message.Debugf("Component %s has invalid SBOM, skipping", component)
+			logging.FromContextOrDiscard(ctx).Debug("component has invalid SBOM, skipping", "component", component)
 			continue
 		}
 

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -5,6 +5,7 @@
 package template
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
@@ -41,7 +43,7 @@ func GetZarfVariableConfig() *variables.VariableConfig {
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.
-func GetZarfTemplates(componentName string, state *types.ZarfState) (templateMap map[string]*variables.TextTemplate, err error) {
+func GetZarfTemplates(ctx context.Context, componentName string, state *types.ZarfState) (templateMap map[string]*variables.TextTemplate, err error) {
 	templateMap = make(map[string]*variables.TextTemplate)
 
 	if state != nil {
@@ -100,7 +102,7 @@ func GetZarfTemplates(componentName string, state *types.ZarfState) (templateMap
 		}
 	}
 
-	debugPrintTemplateMap(templateMap)
+	debugPrintTemplateMap(ctx, templateMap)
 
 	return templateMap, nil
 }
@@ -125,7 +127,7 @@ func generateHtpasswd(regInfo *types.RegistryInfo) (string, error) {
 	return "", nil
 }
 
-func debugPrintTemplateMap(templateMap map[string]*variables.TextTemplate) {
+func debugPrintTemplateMap(ctx context.Context, templateMap map[string]*variables.TextTemplate) {
 	debugText := "templateMap = { "
 
 	for key, template := range templateMap {
@@ -137,6 +139,5 @@ func debugPrintTemplateMap(templateMap map[string]*variables.TextTemplate) {
 	}
 
 	debugText += " }"
-
-	message.Debug(debugText)
+	logging.FromContextOrDiscard(ctx).Debug(debugText)
 }

--- a/src/pkg/cluster/secrets.go
+++ b/src/pkg/cluster/secrets.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -198,7 +199,7 @@ func (c *Cluster) GetServiceInfoFromRegistryAddress(ctx context.Context, stateRe
 	// If this is an internal service then we need to look it up and
 	svc, port, err := serviceInfoFromNodePortURL(serviceList.Items, stateRegistryAddress)
 	if err != nil {
-		message.Debugf("registry appears to not be a nodeport service, using original address %q", stateRegistryAddress)
+		logging.FromContextOrDiscard(ctx).Debug("registry appears to not be a node port service, using original address", "address", stateRegistryAddress)
 		return stateRegistryAddress, nil
 	}
 

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/types"
@@ -203,7 +204,7 @@ func (c *Cluster) LoadZarfState(ctx context.Context) (state *types.ZarfState, er
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 	return state, nil
 }
 
@@ -228,7 +229,7 @@ func (c *Cluster) sanitizeZarfState(state *types.ZarfState) *types.ZarfState {
 	return state
 }
 
-func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
+func (c *Cluster) debugPrintZarfState(ctx context.Context, state *types.ZarfState) {
 	if state == nil {
 		return
 	}
@@ -239,12 +240,12 @@ func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
 	if err != nil {
 		return
 	}
-	message.Debugf("ZarfState - %s", string(b))
+	logging.FromContextOrDiscard(ctx).Debug("ZarfState", "state", string(b))
 }
 
 // SaveZarfState takes a given state and persists it to the Zarf/zarf-state secret.
 func (c *Cluster) SaveZarfState(ctx context.Context, state *types.ZarfState) error {
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 
 	data, err := json.Marshal(&state)
 	if err != nil {

--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -12,15 +12,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/gitea"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -181,7 +182,7 @@ func (c *Cluster) RecordPackageDeployment(ctx context.Context, pkg v1alpha1.Zarf
 	var componentWebhooks map[string]map[string]types.Webhook
 	existingPackageSecret, err := c.GetDeployedPackage(ctx, packageName)
 	if err != nil {
-		message.Debugf("Unable to fetch existing secret for package '%s': %s", packageName, err.Error())
+		logging.FromContextOrDiscard(ctx).Debug("unable to fetch existing secret for package", "package", packageName, "error", err)
 	}
 	if existingPackageSecret != nil {
 		componentWebhooks = existingPackageSecret.ComponentWebhooks

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/mholt/archiver/v3"
+
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // ComponentPaths contains paths for a component.
@@ -58,7 +58,6 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 	}
 	if size > 0 {
 		tb := fmt.Sprintf("%s.tar", base)
-		message.Debugf("Archiving %q", name)
 		if err := helpers.CreateReproducibleTarballFromDir(base, name, tb); err != nil {
 			return err
 		}
@@ -66,8 +65,6 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 			c.Tarballs = make(map[string]string)
 		}
 		c.Tarballs[name] = tb
-	} else {
-		message.Debugf("Component %q is empty, skipping archiving", name)
 	}
 
 	delete(c.Dirs, name)
@@ -126,11 +123,9 @@ func (c *Components) Unarchive(component v1alpha1.ZarfComponent) (err error) {
 
 	// if the component is already unarchived, skip
 	if !helpers.InvalidPath(cs.Base) {
-		message.Debugf("Component %q already unarchived", name)
 		return nil
 	}
 
-	message.Debugf("Unarchiving %q", filepath.Base(tb))
 	if err := archiver.Unarchive(tb, c.Base); err != nil {
 		return err
 	}

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -99,7 +99,6 @@ func (pp *PackagePaths) MigrateLegacy() (err error) {
 	legacySBOMs := filepath.Join(base, "sboms")
 	if !helpers.InvalidPath(legacySBOMs) {
 		pp = pp.AddSBOMs()
-		message.Debugf("Migrating %q to %q", legacySBOMs, pp.SBOMs.Path)
 		if err := os.Rename(legacySBOMs, pp.SBOMs.Path); err != nil {
 			return err
 		}
@@ -109,7 +108,6 @@ func (pp *PackagePaths) MigrateLegacy() (err error) {
 	legacyImagesTar := filepath.Join(base, "images.tar")
 	if !helpers.InvalidPath(legacyImagesTar) {
 		pp = pp.AddImages()
-		message.Debugf("Migrating %q to %q", legacyImagesTar, pp.Images.Base)
 		defer os.Remove(legacyImagesTar)
 		imgTags := []string{}
 		for _, component := range pkg.Components {
@@ -309,8 +307,6 @@ func (pp *PackagePaths) SetFromPaths(paths []string) {
 				pp.Components.Tarballs = make(map[string]string)
 			}
 			pp.Components.Tarballs[componentName] = filepath.Join(pp.Base, path)
-		default:
-			message.Debug("ignoring path", path)
 		}
 	}
 }

--- a/src/pkg/lint/lint.go
+++ b/src/pkg/lint/lint.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/packager/composer"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/types"
@@ -43,7 +43,7 @@ func Validate(ctx context.Context, createOpts types.ZarfCreateOptions) error {
 	findings = append(findings, schemaFindings...)
 
 	if len(findings) == 0 {
-		message.Successf("0 findings for %q", pkg.Metadata.Name)
+		logging.FromContextOrDiscard(ctx).Info("No findings found", "package", pkg.Metadata.Name)
 		return nil
 	}
 	PrintFindings(findings, SevWarn, createOpts.BaseDir, pkg.Metadata.Name)

--- a/src/pkg/logging/handler.go
+++ b/src/pkg/logging/handler.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/zarf-dev/zarf/src/pkg/message"
+)
+
+// PtermHandler is a slog handler that prints using Pterm.
+type PtermHandler struct {
+	attrs []slog.Attr
+	group string
+}
+
+// NewPtermHandler returns a new instance of PtermHandler.
+func NewPtermHandler() *PtermHandler {
+	return &PtermHandler{}
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) Handle(ctx context.Context, r slog.Record) error {
+	attrs := []string{}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a.String())
+		return true
+	})
+	out := fmt.Sprintf("%s %s", r.Message, strings.Join(attrs, " "))
+	switch r.Level {
+	case slog.LevelDebug:
+		message.Debug(out)
+	case slog.LevelInfo:
+		message.Info(out)
+	case slog.LevelWarn:
+		message.Warn(out)
+	case slog.LevelError:
+		message.Warn(out)
+	}
+	return nil
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &PtermHandler{
+		attrs: append(h.attrs, attrs...),
+		group: h.group,
+	}
+}
+
+//nolint:revive // ignore
+func (h *PtermHandler) WithGroup(name string) slog.Handler {
+	return &PtermHandler{
+		attrs: h.attrs,
+		group: name,
+	}
+}

--- a/src/pkg/logging/logging.go
+++ b/src/pkg/logging/logging.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package logging contains logging related functionality.
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+type contextKey struct{}
+
+// NewContext returns a child context containing the given logger.
+func NewContext(ctx context.Context, log *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, log)
+}
+
+// FromContextOrDiscard returns the logger stored in the context.
+func FromContextOrDiscard(ctx context.Context) *slog.Logger {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	log, ok := v.(*slog.Logger)
+	if !ok {
+		// This should never happen.
+		panic("unexpected logger type")
+	}
+	return log
+}

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -119,12 +119,6 @@ func Debug(payload ...any) {
 	debugPrinter(2, payload...)
 }
 
-// Debugf prints a debug message with a given format.
-func Debugf(format string, a ...any) {
-	message := fmt.Sprintf(format, a...)
-	debugPrinter(2, message)
-}
-
 // Warn prints a warning message.
 func Warn(message string) {
 	Warnf("%s", message)

--- a/src/pkg/message/message.go
+++ b/src/pkg/message/message.go
@@ -156,11 +156,6 @@ func Infof(format string, a ...any) {
 	}
 }
 
-// Success prints a success message.
-func Success(message string) {
-	Successf("%s", message)
-}
-
 // Successf prints a success message with a given format.
 func Successf(format string, a ...any) {
 	message := Paragraph(format, a...)

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/deprecated"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -71,7 +72,7 @@ New creates a new package instance with the provided config.
 
 Note: This function creates a tmp directory that should be cleaned up with p.ClearTempPaths().
 */
-func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
+func New(ctx context.Context, cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("no config provided")
 	}
@@ -110,7 +111,7 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create package temp paths: %w", err)
 		}
-		message.Debug("Using temporary directory:", dir)
+		logging.FromContextOrDiscard(ctx).Debug("Using temporary directory", "directory", dir)
 		pkgr.layout = layout.New(dir)
 	}
 

--- a/src/pkg/packager/composer/oci.go
+++ b/src/pkg/packager/composer/oci.go
@@ -17,7 +17,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	ocistore "oras.land/oras-go/v2/content/oci"
@@ -80,7 +80,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 
 		dir = filepath.Join(cache, "dirs", id)
 
-		message.Debug("creating empty directory for remote component:", filepath.Join("<zarf-cache>", "oci", "dirs", id))
+		logging.FromContextOrDiscard(ctx).Debug("Creaing empty directory for remote component", "path", filepath.Join("<zarf-cache>", "oci", "dirs", id))
 	} else {
 		tb = filepath.Join(cache, "blobs", "sha256", componentDesc.Digest.Encoded())
 		dir = filepath.Join(cache, "dirs", componentDesc.Digest.Encoded())
@@ -97,7 +97,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 		} else if !exists {
 			doneSaving := make(chan error)
 			successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+remote.Repo().Reference.String())
-			go utils.RenderProgressBarForLocalDirWrite(cache, componentDesc.Size, doneSaving, "Pulling", successText)
+			go utils.RenderProgressBarForLocalDirWrite(ctx, cache, componentDesc.Size, doneSaving, "Pulling", successText)
 			err = remote.CopyToTarget(ctx, []ocispec.Descriptor{componentDesc}, store, remote.GetDefaultCopyOpts())
 			doneSaving <- err
 			<-doneSaving

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 )
 
@@ -27,7 +27,7 @@ func (p *Packager) Create(ctx context.Context) error {
 		return fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
 	}
 
-	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
+	logging.FromContextOrDiscard(ctx).Info("Using build directory", "path", p.cfg.CreateOpts.BaseDir)
 
 	pc := creator.NewPackageCreator(p.cfg.CreateOpts, cwd)
 

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -128,7 +128,7 @@ func (p *Packager) Deploy(ctx context.Context) error {
 	}
 
 	// Notify all the things about the successful deployment
-	message.Successf("Zarf deployment complete")
+	logging.FromContextOrDiscard(ctx).Info("Zarf deployment complete")
 
 	err = p.printTablesForDeployment(ctx, deployedComponents)
 	if err != nil {
@@ -257,7 +257,7 @@ func (p *Packager) deployInitComponent(ctx context.Context, component v1alpha1.Z
 	}
 
 	if hasExternalRegistry && (isSeedRegistry || isInjector || isRegistry) {
-		message.Notef("Not deploying the component (%s) since external registry information was provided during `zarf init`", component.Name)
+		logging.FromContextOrDiscard(ctx).Info("Skipping deploying the component since external registyr information was provided during init", "component", component.Name)
 		return nil, nil
 	}
 

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -212,7 +213,7 @@ func TestGenerateValuesOverrides(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&types.PackagerConfig{DeployOpts: tt.deployOpts}, WithSource(&sources.TarballSource{}))
+			p, err := New(testutil.TestContext(t), &types.PackagerConfig{DeployOpts: tt.deployOpts}, WithSource(&sources.TarballSource{}))
 			require.NoError(t, err)
 			for k, v := range tt.setVariables {
 				p.variableConfig.SetVariable(k, v, false, false, v1alpha1.RawVariableType)

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
+	"github.com/saferwall/pe/log"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/message"
@@ -95,7 +96,7 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 	}
 
 	// Notify all the things about the successful deployment
-	message.Successf("Zarf dev deployment complete")
+	log.Info("Zarf dev deployment complete")
 
 	message.HorizontalRule()
 	message.Title("Next steps:", "")

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -54,7 +54,7 @@ func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) 
 	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
 		return nil, fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
 	}
-	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
+	logging.FromContextOrDiscard(ctx).Info("Using build directory", "path", p.cfg.CreateOpts.BaseDir)
 
 	c := creator.NewPackageCreator(p.cfg.CreateOpts, cwd)
 
@@ -80,10 +80,7 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 
 	for _, component := range p.cfg.Pkg.Components {
 		if len(component.Repos) > 0 && p.cfg.FindImagesOpts.RepoHelmChartPath == "" {
-			message.Note("This Zarf package contains git repositories, " +
-				"if any repos contain helm charts you want to template and " +
-				"search for images, make sure to specify the helm chart path " +
-				"via the --repo-chart-path flag")
+			log.Info("This Zarf package contains git repositories, if any repos contain helm charts you want to template and search for images, make sure to specify the helm chart path via the --repo-chart-path flag")
 			break
 		}
 	}

--- a/src/pkg/packager/prepare_test.go
+++ b/src/pkg/packager/prepare_test.go
@@ -91,7 +91,7 @@ func TestFindImages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(tt.cfg)
+			p, err := New(ctx, tt.cfg)
 			require.NoError(t, err)
 			images, err := p.FindImages(ctx)
 			if tt.expectedErr != "" {

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
@@ -171,7 +172,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 	onRemove := c.Actions.OnRemove
 	onFailure := func() {
 		if err := actions.Run(ctx, onRemove.Defaults, onRemove.OnFailure, nil); err != nil {
-			message.Debugf("Unable to run the failure action: %s", err)
+			logging.FromContextOrDiscard(ctx).Error("unable to run the failure action", "error", err)
 		}
 	}
 

--- a/src/pkg/packager/sources/split.go
+++ b/src/pkg/packager/sources/split.go
@@ -17,7 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -33,7 +33,7 @@ type SplitTarballSource struct {
 }
 
 // Collect turns a split tarball into a full tarball.
-func (s *SplitTarballSource) Collect(_ context.Context, dir string) (string, error) {
+func (s *SplitTarballSource) Collect(ctx context.Context, dir string) (string, error) {
 	pattern := strings.Replace(s.PackageSource, ".part000", ".part*", 1)
 	fileList, err := filepath.Glob(pattern)
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *SplitTarballSource) Collect(_ context.Context, dir string) (string, err
 	}
 
 	// communicate to the user that the package was reassembled
-	message.Infof("Reassembled package to: %q", reassembled)
+	logging.FromContextOrDiscard(ctx).Info("reassembled package", "path", reassembled)
 
 	return reassembled, nil
 }

--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -17,7 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
@@ -36,7 +36,7 @@ func ValidatePackageSignature(ctx context.Context, paths *layout.PackagePaths, p
 	}
 
 	if publicKeyPath != "" {
-		message.Debugf("Using public key %q for signature validation", publicKeyPath)
+		logging.FromContextOrDiscard(ctx).Debug("using public key for signature validation", "path", publicKeyPath)
 	}
 
 	// Handle situations where there is no signature within the package

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
@@ -37,6 +38,8 @@ import (
 //
 // Forked from https://github.com/sigstore/cosign/blob/v1.7.1/pkg/sget/sget.go
 func Sget(ctx context.Context, image, key string, out io.Writer) error {
+	log := logging.FromContextOrDiscard(ctx)
+
 	message.Warnf(lang.WarnSGetDeprecation)
 
 	// Remove the custom protocol header from the url
@@ -131,11 +134,11 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 
 	for _, sig := range sp {
 		if cert, err := sig.Cert(); err == nil && cert != nil {
-			message.Debugf("Certificate subject: %s", cert.Subject)
+			log.Info("Certificate subject", "subject", cert.Subject)
 
 			ce := cosign.CertExtensions{Cert: cert}
 			if issuerURL := ce.GetIssuer(); issuerURL != "" {
-				message.Debugf("Certificate issuer URL: %s", issuerURL)
+				log.Debug("Certificate issues", "url", issuerURL)
 			}
 		}
 
@@ -144,7 +147,7 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 			spinner.Errorf(err, "Error getting payload")
 			return err
 		}
-		message.Debug(string(p))
+		log.Debug(string(p))
 	}
 
 	// TODO(mattmoor): Depending on what this is, use the higher-level stuff.

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logging"
 	"github.com/zarf-dev/zarf/src/pkg/message"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
@@ -185,7 +186,7 @@ func CosignVerifyBlob(ctx context.Context, blobRef string, sigRef string, keyPat
 	}
 	err := cmd.Exec(ctx, blobRef)
 	if err == nil {
-		message.Successf("Package signature validated!")
+		log.FromContext(ctx).Info("Package signature validated")
 	}
 
 	return err

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -56,7 +56,7 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+r.Repo().Reference.String())
 
 	layerSize := oci.SumDescsSize(layersToPull)
-	go utils.RenderProgressBarForLocalDirWrite(destinationDir, layerSize, doneSaving, "Pulling", successText)
+	go utils.RenderProgressBarForLocalDirWrite(ctx, destinationDir, layerSize, doneSaving, "Pulling", successText)
 
 	dst, err := file.New(destinationDir)
 	if err != nil {


### PR DESCRIPTION
## Description

This change replaces the message.Info, message.Note and message.Success with context logger.

## Related Issue

Depends on #2842 
Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
