### PR TITLE
refactor: remove connect strings from packager property

### DIFF
--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -36,7 +36,6 @@ type Packager struct {
 	cluster        *cluster.Cluster
 	layout         *layout.PackagePaths
 	hpaModified    bool
-	connectStrings types.ConnectStrings
 	source         sources.PackageSource
 }
 

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -16,7 +16,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 // DevDeploy creates + deploys a package in one shot
@@ -74,8 +73,6 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 	}
 
 	message.HeaderInfof("📦 PACKAGE DEPLOY %s", p.cfg.Pkg.Metadata.Name)
-
-	p.connectStrings = make(types.ConnectStrings)
 
 	if !p.cfg.CreateOpts.NoYOLO {
 		p.cfg.Pkg.Metadata.YOLO = true

--- a/src/types/k8s.go
+++ b/src/types/k8s.go
@@ -119,8 +119,9 @@ type Webhook struct {
 
 // InstalledChart contains information about a Helm Chart that has been deployed to a cluster.
 type InstalledChart struct {
-	Namespace string `json:"namespace"`
-	ChartName string `json:"chartName"`
+	Namespace      string         `json:"namespace"`
+	ChartName      string         `json:"chartName"`
+	ConnectStrings ConnectStrings `json:"connectStrings,omitempty"`
 }
 
 // GitServerInfo contains information Zarf uses to communicate with a git repository to push/pull repositories to.


### PR DESCRIPTION
## Description

This change moves the connect strings map to the installed charts struct. This removes potential race conditions that could be caused by multiple threads writing to the same struct property.

## Related Issue

Depends on #2940
Relates to #2576

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
