### PR TITLE
fix(ci): test-imports workflow breaks when called from a fork

### DIFF
--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -30,8 +30,7 @@ jobs:
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          # go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
-          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@9f442cea1f989c62b0ec29ed6d8aded0f747f94e
+          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@$COMMIT_SHA
           go mod tidy
           cat go.mod
           cat go.mod | grep -q ${COMMIT_SHA:0:12}

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -28,7 +28,7 @@ jobs:
           cd $(mktemp -d)
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@$COMMIT_SHA
+          go mod edit -replace github.com/zarf-dev/zarf=github.com/${{ github.event.pull_request.head.repo.full_name }}@${COMMIT_SHA:0:12}
           go mod tidy
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Run test Go program that imports Zarf
         run: |
-          cd $(mktemp -d)
+          cd ..
+          mkdir test-import
+          cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go mod edit -replace github.com/zarf-dev/zarf=github.com/${{ github.repository }}@${COMMIT_SHA:0:12}
+          go mod edit -replace github.com/zarf-dev/zarf=../zarf
           go mod tidy
-          cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go
         env:
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           GO_MAIN: |
             package main
 

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -25,15 +25,18 @@ jobs:
 
       - name: Run test Go program that imports Zarf
         run: |
+          # 9f442cea1f989c62b0ec29ed6d8aded0f747f94e
           cd ..
           mkdir test-import
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go mod edit -replace github.com/zarf-dev/zarf=../zarf
+          go get {{ github.event.pull_request.head.repo.name }}@{{ github.event.pull_request.head.sha}}
           go mod tidy
+          cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go
         env:
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           GO_MAIN: |
             package main
 

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -25,14 +25,15 @@ jobs:
 
       - name: Run test Go program that imports Zarf
         run: |
-          # 9f442cea1f989c62b0ec29ed6d8aded0f747f94e
           cd ..
           mkdir test-import
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
+          # go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
+          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@9f442cea1f989c62b0ec29ed6d8aded0f747f94e
           go mod tidy
+          cat go.mod
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go
         env:

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -31,7 +31,7 @@ jobs:
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go get ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
+          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
           go mod tidy
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -31,7 +31,7 @@ jobs:
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go get ${{ github.event.pull_request.head.repo.name }}@${{ github.event.pull_request.head.sha }}
+          go get ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
           go mod tidy
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -25,14 +25,11 @@ jobs:
 
       - name: Run test Go program that imports Zarf
         run: |
-          cd ..
-          mkdir test-import
-          cd test-import
+          cd $(mktemp -d)
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
           go get github.com/${{ github.event.pull_request.head.repo.full_name }}@$COMMIT_SHA
           go mod tidy
-          cat go.mod
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go
         env:

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -31,7 +31,7 @@ jobs:
           cd test-import
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go get {{ github.event.pull_request.head.repo.name }}@{{ github.event.pull_request.head.sha}}
+          go get ${{ github.event.pull_request.head.repo.name }}@${{ github.event.pull_request.head.sha }}
           go mod tidy
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go


### PR DESCRIPTION
## Description
The test-imports workflows break when called from a fork

## Related issue
fixes #2952

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
