### PR TITLE
docs: update docs item in update Q2 roadmap

### DIFF
--- a/site/src/content/docs/roadmap.mdx
+++ b/site/src/content/docs/roadmap.mdx
@@ -21,7 +21,7 @@ We also accept contributions from the community (regardless of where a particula
 ### Q2 Consistency, Docs and Donation to OpenSSF
 
 - [ ] - Consolidate and improve consistency around features such as Zarf `variables` and component `required` schema.
-- [ ] - Move [docs website](https://docs.zarf.dev) from Docusaurus to a different framework to improve maintainability going forward.
+- [X] - Move [docs website](https://docs.zarf.dev) from Docusaurus to a different framework to improve maintainability going forward.
 - [ ] - Finalize and submit Zarf's `sandbox` application to officially join the OpenSSF.
 
 ### Q3: Transfer Project, Stabilize and Extend


### PR DESCRIPTION
## Description

Reading the roadmap it appears the docs site is built with [astro](https://astro.build/) not [docusaurus](https://docusaurus.io/).

This PR marks the item as checked on the docs page.

Requires confirmation!

## Related Issue

no issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
