### PR TITLE
fix: progress bar image name flashes on push

### DIFF
--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -87,11 +87,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			refTruncated := helpers.Truncate(refInfo.Reference, 55, true)
 			progress.Updatef(fmt.Sprintf("Pushing %s", refTruncated))
 
-			size, err := calcImgSize(img)
-			if err != nil {
-				return err
-			}
-
 			// If this is not a no checksum image push it for use with the Zarf agent
 			if !cfg.NoChecksum {
 				offlineNameCRC, err := transform.ImageTransformHost(registryURL, refInfo.Reference)
@@ -102,8 +97,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 				if err = pushImage(img, offlineNameCRC); err != nil {
 					return err
 				}
-
-				totalSize -= size
 			}
 
 			// To allow for other non-zarf workloads to easily see the images upload a non-checksum version
@@ -120,7 +113,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			}
 
 			pushed = append(pushed, refInfo)
-			totalSize -= size
 		}
 		return nil
 	}, retry.Context(ctx), retry.Attempts(uint(cfg.Retries)), retry.Delay(500*time.Millisecond))

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -55,6 +55,7 @@ func Push(ctx context.Context, cfg PushConfig) error {
 
 	progress := message.NewProgressBar(totalSize, fmt.Sprintf("Pushing %d images", len(toPush)))
 	defer progress.Close()
+	pushOptions := createPushOpts(cfg, progress)
 
 	err = retry.Do(func() error {
 		c, _ := cluster.NewCluster()
@@ -67,9 +68,6 @@ func Push(ctx context.Context, cfg PushConfig) error {
 				defer tunnel.Close()
 			}
 		}
-
-		progress = message.NewProgressBar(totalSize, fmt.Sprintf("Pushing %d images", len(toPush)))
-		pushOptions := createPushOpts(cfg, progress)
 
 		pushImage := func(img v1.Image, name string) error {
 			if tunnel != nil {


### PR DESCRIPTION
## Description

This PR fixes the CLI flashing when pushing images. This can be seen in the linked gif in the issue #2651

## Related Issue

Fixes #2651

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
