### PR TITLE
fix: imported helm overrides

### DIFF
--- a/src/pkg/packager/composer/list_test.go
+++ b/src/pkg/packager/composer/list_test.go
@@ -150,12 +150,31 @@ func TestCompose(t *testing.T) {
 							fmt.Sprintf("%s%svalues.yaml", finalDirectory, string(os.PathSeparator)),
 							"values.yaml",
 						},
+						Variables: []v1alpha1.ZarfChartVariable{
+							{
+								Name:        "var-today",
+								Description: "var description",
+								Path:        "path",
+							},
+							{
+								Name:        "var-hello",
+								Description: "var description",
+								Path:        "path",
+							},
+						},
 					},
 					{
 						Name:      "world",
 						LocalPath: fmt.Sprintf("%s%schart", firstDirectory, string(os.PathSeparator)),
 						ValuesFiles: []string{
 							fmt.Sprintf("%s%svalues.yaml", firstDirectory, string(os.PathSeparator)),
+						},
+						Variables: []v1alpha1.ZarfChartVariable{
+							{
+								Name:        "var-world",
+								Description: "var description",
+								Path:        "path",
+							},
 						},
 					},
 				},
@@ -504,6 +523,13 @@ func createDummyComponent(t *testing.T, name, importDir, subName string) v1alpha
 				LocalPath: "chart",
 				ValuesFiles: []string{
 					"values.yaml",
+				},
+				Variables: []v1alpha1.ZarfChartVariable{
+					{
+						Name:        fmt.Sprintf("var-%s", name),
+						Description: "var description",
+						Path:        "path",
+					},
 				},
 			},
 		},

--- a/src/pkg/packager/composer/override.go
+++ b/src/pkg/packager/composer/override.go
@@ -95,6 +95,7 @@ func overrideResources(c *v1alpha1.ZarfComponent, override v1alpha1.ZarfComponen
 					c.Charts[idx].ReleaseName = overrideChart.ReleaseName
 				}
 				c.Charts[idx].ValuesFiles = append(c.Charts[idx].ValuesFiles, overrideChart.ValuesFiles...)
+				c.Charts[idx].Variables = append(c.Charts[idx].Variables, overrideChart.Variables...)
 				existing = true
 			}
 		}


### PR DESCRIPTION
## Description
Ensures imported components merge Helm override variables, similar to the existing behavior with `valueFiles`.

Also updated the hint behavior to only add hints on root level keys, which was causing an issue when accounting for [this hint](https://github.com/zarf-dev/zarf/blob/main/src/pkg/packager/interactive.go#L111) which I believe was erroneously appearing in the tests alongside Helm overrides `variables`.

## Related Issue
Fixes https://github.com/zarf-dev/zarf/issues/2966

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
