### PR TITLE
refactor: trim named returns in pkg #2950

### DIFF
--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -193,12 +193,14 @@ func (c *Cluster) InitZarfState(ctx context.Context, initOptions types.ZarfInitO
 }
 
 // LoadZarfState returns the current zarf/zarf-state secret data or an empty ZarfState.
-func (c *Cluster) LoadZarfState(ctx context.Context) (state *types.ZarfState, err error) {
+func (c *Cluster) LoadZarfState(ctx context.Context) (*types.ZarfState, error) {
 	stateErr := errors.New("failed to load the Zarf State from the cluster, has Zarf been initiated?")
 	secret, err := c.Clientset.CoreV1().Secrets(ZarfNamespaceName).Get(ctx, ZarfStateSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
+
+	state := &types.ZarfState{}
 	err = json.Unmarshal(secret.Data[ZarfStateDataKey], &state)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)

--- a/src/pkg/cluster/zarf_test.go
+++ b/src/pkg/cluster/zarf_test.go
@@ -30,7 +30,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 		deployedPackage *types.DeployedPackage
 		component       v1alpha1.ZarfComponent
 		skipWebhooks    bool
-		needsWait       bool
 		waitSeconds     int
 		hookName        string
 	}
@@ -49,7 +48,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 				Name:              packageName,
 				ComponentWebhooks: map[string]map[string]types.Webhook{},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -67,7 +65,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   true,
 			waitSeconds: 10,
 			hookName:    webhookName,
 		},
@@ -86,7 +83,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -103,7 +99,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -120,7 +115,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -137,7 +131,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -160,7 +153,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -179,7 +171,6 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
-			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -193,9 +184,8 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 
 			c := &Cluster{}
 
-			needsWait, waitSeconds, hookName := c.PackageSecretNeedsWait(testCase.deployedPackage, testCase.component, testCase.skipWebhooks)
+			waitSeconds, hookName := c.PackageSecretNeedsWait(testCase.deployedPackage, testCase.component, testCase.skipWebhooks)
 
-			require.Equal(t, testCase.needsWait, needsWait)
 			require.Equal(t, testCase.waitSeconds, waitSeconds)
 			require.Equal(t, testCase.hookName, hookName)
 		})

--- a/src/pkg/cluster/zarf_test.go
+++ b/src/pkg/cluster/zarf_test.go
@@ -30,6 +30,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 		deployedPackage *types.DeployedPackage
 		component       v1alpha1.ZarfComponent
 		skipWebhooks    bool
+		needsWait       bool
 		waitSeconds     int
 		hookName        string
 	}
@@ -48,6 +49,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 				Name:              packageName,
 				ComponentWebhooks: map[string]map[string]types.Webhook{},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -65,6 +67,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   true,
 			waitSeconds: 10,
 			hookName:    webhookName,
 		},
@@ -83,6 +86,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -99,6 +103,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -115,6 +120,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -131,6 +137,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -153,6 +160,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -171,6 +179,7 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 					},
 				},
 			},
+			needsWait:   false,
 			waitSeconds: 0,
 			hookName:    "",
 		},
@@ -184,8 +193,9 @@ func TestPackageSecretNeedsWait(t *testing.T) {
 
 			c := &Cluster{}
 
-			waitSeconds, hookName := c.PackageSecretNeedsWait(testCase.deployedPackage, testCase.component, testCase.skipWebhooks)
+			needsWait, waitSeconds, hookName := c.PackageSecretNeedsWait(testCase.deployedPackage, testCase.component, testCase.skipWebhooks)
 
+			require.Equal(t, testCase.needsWait, needsWait)
 			require.Equal(t, testCase.waitSeconds, waitSeconds)
 			require.Equal(t, testCase.hookName, hookName)
 		})

--- a/src/pkg/interactive/components.go
+++ b/src/pkg/interactive/components.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SelectOptionalComponent prompts to confirm optional components
-func SelectOptionalComponent(component v1alpha1.ZarfComponent) (confirm bool, err error) {
+func SelectOptionalComponent(component v1alpha1.ZarfComponent) (bool, error) {
 	message.HorizontalRule()
 
 	displayComponent := component
@@ -30,6 +30,8 @@ func SelectOptionalComponent(component v1alpha1.ZarfComponent) (confirm bool, er
 		Default: component.Default,
 	}
 
+	// REVIEW(mkcp): Can confirm be true here? It's not clear to me if survey.AskOne will ever flip a boolean
+	var confirm bool
 	return confirm, survey.AskOne(prompt, &confirm)
 }
 

--- a/src/pkg/interactive/components.go
+++ b/src/pkg/interactive/components.go
@@ -30,9 +30,12 @@ func SelectOptionalComponent(component v1alpha1.ZarfComponent) (bool, error) {
 		Default: component.Default,
 	}
 
-	// REVIEW(mkcp): Can confirm be true here? It's not clear to me if survey.AskOne will ever flip a boolean
 	var confirm bool
-	return confirm, survey.AskOne(prompt, &confirm)
+	err := survey.AskOne(prompt, &confirm)
+	if err != nil {
+		return false, err
+	}
+	return confirm, nil
 }
 
 // SelectChoiceGroup prompts to select component groups

--- a/src/pkg/interactive/prompt.go
+++ b/src/pkg/interactive/prompt.go
@@ -19,11 +19,15 @@ func PromptSigPassword() ([]byte, error) {
 	prompt := &survey.Password{
 		Message: "Private key password (empty for no password): ",
 	}
-	return []byte(password), survey.AskOne(prompt, &password)
+	err := survey.AskOne(prompt, &password)
+	if err != nil {
+		return []byte{}, err
+	}
+	return []byte(password), nil
 }
 
 // PromptVariable prompts the user for a value for a variable
-func PromptVariable(variable v1alpha1.InteractiveVariable) (value string, err error) {
+func PromptVariable(variable v1alpha1.InteractiveVariable) (string, error) {
 	if variable.Description != "" {
 		message.Question(variable.Description)
 	}
@@ -33,5 +37,10 @@ func PromptVariable(variable v1alpha1.InteractiveVariable) (value string, err er
 		Default: variable.Default,
 	}
 
-	return value, survey.AskOne(prompt, &value)
+	var value string
+	err := survey.AskOne(prompt, &value)
+	if err != nil {
+		return "", err
+	}
+	return value, nil
 }

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -39,7 +39,7 @@ type Components struct {
 var ErrNotLoaded = fmt.Errorf("not loaded")
 
 // Archive archives a component.
-func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool) (err error) {
+func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool) error {
 	name := component.Name
 	if _, ok := c.Dirs[name]; !ok {
 		return &fs.PathError{
@@ -75,7 +75,7 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 }
 
 // Unarchive unarchives a component.
-func (c *Components) Unarchive(component v1alpha1.ZarfComponent) (err error) {
+func (c *Components) Unarchive(component v1alpha1.ZarfComponent) error {
 	name := component.Name
 	tb, ok := c.Tarballs[name]
 	if !ok {
@@ -138,7 +138,7 @@ func (c *Components) Unarchive(component v1alpha1.ZarfComponent) (err error) {
 }
 
 // Create creates a new component directory structure.
-func (c *Components) Create(component v1alpha1.ZarfComponent) (cp *ComponentPaths, err error) {
+func (c *Components) Create(component v1alpha1.ZarfComponent) (*ComponentPaths, error) {
 	name := component.Name
 
 	_, ok := c.Tarballs[name]
@@ -150,41 +150,41 @@ func (c *Components) Create(component v1alpha1.ZarfComponent) (cp *ComponentPath
 		}
 	}
 
-	if err = helpers.CreateDirectory(c.Base, helpers.ReadWriteExecuteUser); err != nil {
+	if err := helpers.CreateDirectory(c.Base, helpers.ReadWriteExecuteUser); err != nil {
 		return nil, err
 	}
 
 	base := filepath.Join(c.Base, name)
 
-	if err = helpers.CreateDirectory(base, helpers.ReadWriteExecuteUser); err != nil {
+	if err := helpers.CreateDirectory(base, helpers.ReadWriteExecuteUser); err != nil {
 		return nil, err
 	}
 
-	cp = &ComponentPaths{
+	cp := &ComponentPaths{
 		Base: base,
 	}
 
 	cp.Temp = filepath.Join(base, TempDir)
-	if err = helpers.CreateDirectory(cp.Temp, helpers.ReadWriteExecuteUser); err != nil {
+	if err := helpers.CreateDirectory(cp.Temp, helpers.ReadWriteExecuteUser); err != nil {
 		return nil, err
 	}
 
 	if len(component.Files) > 0 {
 		cp.Files = filepath.Join(base, FilesDir)
-		if err = helpers.CreateDirectory(cp.Files, helpers.ReadWriteExecuteUser); err != nil {
+		if err := helpers.CreateDirectory(cp.Files, helpers.ReadWriteExecuteUser); err != nil {
 			return nil, err
 		}
 	}
 
 	if len(component.Charts) > 0 {
 		cp.Charts = filepath.Join(base, ChartsDir)
-		if err = helpers.CreateDirectory(cp.Charts, helpers.ReadWriteExecuteUser); err != nil {
+		if err := helpers.CreateDirectory(cp.Charts, helpers.ReadWriteExecuteUser); err != nil {
 			return nil, err
 		}
 		for _, chart := range component.Charts {
 			cp.Values = filepath.Join(base, ValuesDir)
 			if len(chart.ValuesFiles) > 0 {
-				if err = helpers.CreateDirectory(cp.Values, helpers.ReadWriteExecuteUser); err != nil {
+				if err := helpers.CreateDirectory(cp.Values, helpers.ReadWriteExecuteUser); err != nil {
 					return nil, err
 				}
 				break
@@ -194,21 +194,21 @@ func (c *Components) Create(component v1alpha1.ZarfComponent) (cp *ComponentPath
 
 	if len(component.Repos) > 0 {
 		cp.Repos = filepath.Join(base, ReposDir)
-		if err = helpers.CreateDirectory(cp.Repos, helpers.ReadWriteExecuteUser); err != nil {
+		if err := helpers.CreateDirectory(cp.Repos, helpers.ReadWriteExecuteUser); err != nil {
 			return nil, err
 		}
 	}
 
 	if len(component.Manifests) > 0 {
 		cp.Manifests = filepath.Join(base, ManifestsDir)
-		if err = helpers.CreateDirectory(cp.Manifests, helpers.ReadWriteExecuteUser); err != nil {
+		if err := helpers.CreateDirectory(cp.Manifests, helpers.ReadWriteExecuteUser); err != nil {
 			return nil, err
 		}
 	}
 
 	if len(component.DataInjections) > 0 {
 		cp.DataInjections = filepath.Join(base, DataInjectionsDir)
-		if err = helpers.CreateDirectory(cp.DataInjections, helpers.ReadWriteExecuteUser); err != nil {
+		if err := helpers.CreateDirectory(cp.DataInjections, helpers.ReadWriteExecuteUser); err != nil {
 			return nil, err
 		}
 	}

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -52,11 +52,14 @@ func New(baseDir string) *PackagePaths {
 
 // ReadZarfYAML reads a zarf.yaml file into memory,
 // checks if it's using the legacy layout, and migrates deprecated component configs.
-func (pp *PackagePaths) ReadZarfYAML() (pkg v1alpha1.ZarfPackage, warnings []string, err error) {
+func (pp *PackagePaths) ReadZarfYAML() (v1alpha1.ZarfPackage, []string, error) {
+	var pkg v1alpha1.ZarfPackage
+
 	if err := utils.ReadYaml(pp.ZarfYAML, &pkg); err != nil {
 		return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("unable to read zarf.yaml: %w", err)
 	}
 
+	warnings := make([]string, 0)
 	if pp.IsLegacyLayout() {
 		warnings = append(warnings, "Detected deprecated package layout, migrating to new layout - support for this package will be dropped in v1.0.0")
 	}
@@ -74,7 +77,7 @@ func (pp *PackagePaths) ReadZarfYAML() (pkg v1alpha1.ZarfPackage, warnings []str
 }
 
 // MigrateLegacy migrates a legacy package layout to the new layout.
-func (pp *PackagePaths) MigrateLegacy() (err error) {
+func (pp *PackagePaths) MigrateLegacy() error {
 	var pkg v1alpha1.ZarfPackage
 	base := pp.Base
 

--- a/src/pkg/lint/validate.go
+++ b/src/pkg/lint/validate.go
@@ -234,7 +234,7 @@ func validateAction(action v1alpha1.ZarfComponentAction) error {
 
 // validateReleaseName validates a release name against DNS 1035 spec, using chartName as fallback.
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
-func validateReleaseName(chartName, releaseName string) (err error) {
+func validateReleaseName(chartName, releaseName string) error {
 	// Fallback to chartName if releaseName is empty
 	// NOTE: Similar fallback mechanism happens in src/internal/packager/helm/chart.go:InstallOrUpgradeChart
 	if releaseName == "" {
@@ -243,16 +243,15 @@ func validateReleaseName(chartName, releaseName string) (err error) {
 
 	// Check if the final releaseName is empty and return an error if so
 	if releaseName == "" {
-		err = errors.New(errChartReleaseNameEmpty)
-		return
+		return errors.New(errChartReleaseNameEmpty)
 	}
 
 	// Validate the releaseName against DNS 1035 label spec
 	if errs := validation.IsDNS1035Label(releaseName); len(errs) > 0 {
-		err = fmt.Errorf("invalid release name '%s': %s", releaseName, strings.Join(errs, "; "))
+		return fmt.Errorf("invalid release name '%s': %s", releaseName, strings.Join(errs, "; "))
 	}
 
-	return
+	return nil
 }
 
 // validateChart runs all validation checks on a chart.

--- a/src/pkg/message/pausable.go
+++ b/src/pkg/message/pausable.go
@@ -29,6 +29,6 @@ func (pw *PausableWriter) Resume() {
 }
 
 // Write writes the data to the underlying output writer
-func (pw *PausableWriter) Write(p []byte) (n int, err error) {
+func (pw *PausableWriter) Write(p []byte) (int, error) {
 	return pw.out.Write(p)
 }

--- a/src/pkg/utils/bytes.go
+++ b/src/pkg/utils/bytes.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2024-Present The Zarf Authors
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
 // forked from https://www.socketloop.com/tutorials/golang-byte-format-example
 

--- a/src/pkg/utils/bytes.go
+++ b/src/pkg/utils/bytes.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+// SPDX-FileCopyrightText: 2024-Present The Zarf Authors
 
 // forked from https://www.socketloop.com/tutorials/golang-byte-format-example
 
@@ -16,25 +16,25 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
-type Unit struct {
+type unit struct {
 	name string
 	size float64
 }
 
 var (
-	gigabyte = Unit{
+	gigabyte = unit{
 		name: "GB",
 		size: 1000000000,
 	}
-	megabyte = Unit{
+	megabyte = unit{
 		name: "MB",
 		size: 1000000,
 	}
-	kilobyte = Unit{
+	kilobyte = unit{
 		name: "KB",
 		size: 1000,
 	}
-	unitByte = Unit{
+	unitByte = unit{
 		name: "Byte",
 	}
 )
@@ -47,42 +47,38 @@ func RoundUp(input float64, places int) float64 {
 	return round / pow
 }
 
-// ByteFormat formats a number of bytes into a human readable string.
+// ByteFormat formats a number of bytes into a human-readable string.
 func ByteFormat(in float64, precision int) string {
 	if precision <= 0 {
 		precision = 1
 	}
 
-	var unit string
-	var val float64
+	var v float64
+	var u string
 
 	// https://www.techtarget.com/searchstorage/definition/mebibyte-MiB
 	switch {
 	case gigabyte.size <= in:
-		val = RoundUp(in/gigabyte.size, precision)
-		unit = gigabyte.name
-		break
-	case 1000000 <= in:
-		val = RoundUp(in/1000000, precision)
-		unit = megabyte.name
-		break
-	case 1000 <= in:
-		val = RoundUp(in/1000, precision)
-		unit = kilobyte.name
-		break
+		v = RoundUp(in/gigabyte.size, precision)
+		u = gigabyte.name
+	case megabyte.size <= in:
+		v = RoundUp(in/megabyte.size, precision)
+		u = megabyte.name
+	case kilobyte.size <= in:
+		v = RoundUp(in/kilobyte.size, precision)
+		u = kilobyte.name
 	default:
-		val = in
-		unit = unitByte.name
-		break
+		v = in
+		u = unitByte.name
 	}
 
 	// NOTE(mkcp): Negative bytes are nonsense, but it's more robust for inputs without erroring.
-	if val < -1 || 1 < val {
-		unit += "s"
+	if v < -1 || 1 < v {
+		u += "s"
 	}
 
-	vFmt := strconv.FormatFloat(val, 'f', precision, 64)
-	return vFmt + " " + unit
+	vFmt := strconv.FormatFloat(v, 'f', precision, 64)
+	return vFmt + " " + u
 }
 
 // RenderProgressBarForLocalDirWrite creates a progress bar that continuously tracks the progress of writing files to a local directory and all of its subdirectories.

--- a/src/pkg/utils/bytes_test.go
+++ b/src/pkg/utils/bytes_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2024-Present The Zarf Authors
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
 // Package utils provides generic utility functions.
 package utils

--- a/src/pkg/utils/bytes_test.go
+++ b/src/pkg/utils/bytes_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-Present The Zarf Authors
+
+// Package utils provides generic utility functions.
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestByteFormat(t *testing.T) {
+	t.Parallel()
+	tt := []struct {
+		name      string
+		in        float64
+		precision int
+		expect    string
+	}{
+		{
+			name:   "accepts empty",
+			expect: "0.0 Byte",
+		},
+		{
+			name:      "accepts empty bytes with precision",
+			precision: 1,
+			expect:    "0.0 Byte",
+		},
+		{
+			name:      "accepts empty bytes with meaningful precision",
+			precision: 3,
+			expect:    "0.000 Byte",
+		},
+		{
+			name:   "formats negative byte with empty precision",
+			in:     -1,
+			expect: "-1.0 Byte",
+		},
+		{
+			name:   "formats negative bytes with empty precision",
+			in:     -2,
+			expect: "-2.0 Bytes",
+		},
+		{
+			name:   "formats kilobyte",
+			in:     1000,
+			expect: "1.0 KB",
+		},
+		{
+			name:   "formats kilobytes",
+			in:     1100,
+			expect: "1.1 KBs",
+		},
+		{
+			name:   "formats megabytes",
+			in:     10000000,
+			expect: "10.0 MBs",
+		},
+		{
+			name:   "formats gigabytes",
+			in:     100000000000,
+			expect: "100.0 GBs",
+		},
+		{
+			name:      "formats arbitrary in",
+			in:        4238970784923,
+			precision: 99,
+			expect:    "4238.970784922999882837757468223571777343750000000000000000000000000000000000000000000000000000000000000 GBs",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ByteFormat(tc.in, tc.precision)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}

--- a/src/pkg/utils/network.go
+++ b/src/pkg/utils/network.go
@@ -39,7 +39,7 @@ func parseChecksum(src string) (string, string, error) {
 }
 
 // DownloadToFile downloads a given URL to the target filepath (including the cosign key if necessary).
-func DownloadToFile(ctx context.Context, src string, dst string, cosignKeyPath string) (err error) {
+func DownloadToFile(ctx context.Context, src, dst, cosignKeyPath string) error {
 	// check if the parsed URL has a checksum
 	// if so, remove it and use the checksum to validate the file
 	src, checksum, err := parseChecksum(src)
@@ -69,9 +69,6 @@ func DownloadToFile(ctx context.Context, src string, dst string, cosignKeyPath s
 		if err != nil {
 			return fmt.Errorf("unable to download file with sget: %s: %w", src, err)
 		}
-		if err != nil {
-			return err
-		}
 	} else {
 		err = httpGetFile(src, file)
 		if err != nil {
@@ -80,7 +77,7 @@ func DownloadToFile(ctx context.Context, src string, dst string, cosignKeyPath s
 	}
 
 	// If the file has a checksum, validate it
-	if len(checksum) > 0 {
+	if 0 < len(checksum) {
 		received, err := helpers.GetSHA256OfFile(dst)
 		if err != nil {
 			return err

--- a/src/pkg/variables/variables.go
+++ b/src/pkg/variables/variables.go
@@ -15,8 +15,8 @@ import (
 type SetVariableMap map[string]*v1alpha1.SetVariable
 
 // GetSetVariable gets a variable set within a VariableConfig by its name
-func (vc *VariableConfig) GetSetVariable(name string) (variable *v1alpha1.SetVariable, ok bool) {
-	variable, ok = vc.setVariableMap[name]
+func (vc *VariableConfig) GetSetVariable(name string) (*v1alpha1.SetVariable, bool) {
+	variable, ok := vc.setVariableMap[name]
 	return variable, ok
 }
 

--- a/src/pkg/variables/variables_test.go
+++ b/src/pkg/variables/variables_test.go
@@ -20,7 +20,7 @@ func TestPopulateVariables(t *testing.T) {
 		wantVars SetVariableMap
 	}
 
-	prompt := func(_ v1alpha1.InteractiveVariable) (value string, err error) { return "Prompt", nil }
+	prompt := func(_ v1alpha1.InteractiveVariable) (string, error) { return "Prompt", nil }
 
 	tests := []test{
 		{

--- a/src/pkg/zoci/fetch.go
+++ b/src/pkg/zoci/fetch.go
@@ -14,19 +14,27 @@ import (
 )
 
 // FetchZarfYAML fetches the zarf.yaml file from the remote repository.
-func (r *Remote) FetchZarfYAML(ctx context.Context) (pkg v1alpha1.ZarfPackage, err error) {
+func (r *Remote) FetchZarfYAML(ctx context.Context) (v1alpha1.ZarfPackage, error) {
 	manifest, err := r.FetchRoot(ctx)
 	if err != nil {
-		return pkg, err
+		return v1alpha1.ZarfPackage{}, err
 	}
-	return oci.FetchYAMLFile[v1alpha1.ZarfPackage](ctx, r.FetchLayer, manifest, layout.ZarfYAML)
+	result, err := oci.FetchYAMLFile[v1alpha1.ZarfPackage](ctx, r.FetchLayer, manifest, layout.ZarfYAML)
+	if err != nil {
+		return v1alpha1.ZarfPackage{}, err
+	}
+	return result, nil
 }
 
 // FetchImagesIndex fetches the images/index.json file from the remote repository.
-func (r *Remote) FetchImagesIndex(ctx context.Context) (index *ocispec.Index, err error) {
+func (r *Remote) FetchImagesIndex(ctx context.Context) (*ocispec.Index, error) {
 	manifest, err := r.FetchRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return oci.FetchJSONFile[*ocispec.Index](ctx, r.FetchLayer, manifest, layout.IndexPath)
+	result, err := oci.FetchJSONFile[*ocispec.Index](ctx, r.FetchLayer, manifest, layout.IndexPath)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -76,7 +76,9 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 // LayersFromRequestedComponents returns the descriptors for the given components from the root manifest.
 //
 // It also retrieves the descriptors for all image layers that are required by the components.
-func (r *Remote) LayersFromRequestedComponents(ctx context.Context, requestedComponents []v1alpha1.ZarfComponent) (layers []ocispec.Descriptor, err error) {
+func (r *Remote) LayersFromRequestedComponents(ctx context.Context, requestedComponents []v1alpha1.ZarfComponent) ([]ocispec.Descriptor, error) {
+	layers := make([]ocispec.Descriptor, 0)
+
 	root, err := r.FetchRoot(ctx)
 	if err != nil {
 		return nil, err
@@ -98,7 +100,8 @@ func (r *Remote) LayersFromRequestedComponents(ctx context.Context, requestedCom
 		for _, image := range component.Images {
 			images[image] = true
 		}
-		layers = append(layers, root.Locate(filepath.Join(layout.ComponentsDir, fmt.Sprintf(tarballFormat, component.Name))))
+		desc := root.Locate(filepath.Join(layout.ComponentsDir, fmt.Sprintf(tarballFormat, component.Name)))
+		layers = append(layers, desc)
 	}
 	// Append the sboms.tar layer if it exists
 	//


### PR DESCRIPTION
## Description

This PR is intended to remove unnecessary named returns and clean up/refactor some nearby functions. Substantial refactors should also be accompanied by tests. This intentionally ignores packager directories to avoid too much churn alongside packager refactoring.

Run `golangci-lint run --disable-all -E nonamedreturns --exclude-dirs='packager' ./src/pkg/...` prior to these fixes to see the intended scope of fixes here. The remaining items outside of pkg #2950 will be fully addressed in another PR. This one was starting to sprawl.

## Related Issue

Partially fixes #2950 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
