### PR TITLE
chore: only show config file if there is one

### DIFF
--- a/src/cmd/common/viper.go
+++ b/src/cmd/common/viper.go
@@ -175,7 +175,9 @@ func printViperConfigUsed() {
 		message.WarnErrf(vConfigError, lang.CmdViperErrLoadingConfigFile, vConfigError.Error())
 		return
 	}
-	message.Notef(lang.CmdViperInfoUsingConfigFile, v.ConfigFileUsed())
+	if cfgFile := v.ConfigFileUsed(); cfgFile != "" {
+		message.Notef(lang.CmdViperInfoUsingConfigFile, cfgFile)
+	}
 }
 
 func setDefaults() {


### PR DESCRIPTION
## Description
 
Don't output the `NOTE` on config file usage if there is no config file set.

Currently `zarf version` [will not go through the process of setting the configuration file](https://github.com/zarf-dev/zarf/blob/efa306fdcbe605ec6d17f4cf72c707f7227af52a/src/cmd/common/viper.go#L122-L124), but the root cmd code path still has a part where it calls `printViperConfigUsed()` and tries to print it. As a result you get empty output, even if you have a valid config available:

![no_config](https://github.com/user-attachments/assets/e5d3dd55-609b-4b5e-b7ac-2d7367b92bd5)

In this PR we simply omit the config file note if we have no config file set. The [printViperConfigUsed()](https://github.com/zarf-dev/zarf/blob/efa306fdcbe605ec6d17f4cf72c707f7227af52a/src/cmd/common/viper.go#L164) function doesn't accept any parameters and doesn't seem to have access to anything that would tell it what specific command is being run, so I didn't see an easy way to only omit the output if the command is the `version` command. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
