### PR TITLE
chore: finish removing named returns outside of package and extensions #2950

### DIFF
--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -59,7 +59,7 @@ func NewApplicationMutationHook(ctx context.Context, cluster *cluster.Cluster) o
 }
 
 // mutateApplication mutates the git repository url to point to the repository URL defined in the ZarfState.
-func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (result *operations.Result, err error) {
+func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
 	state, err := cluster.LoadZarfState(ctx)
 	if err != nil {
 		return nil, err
@@ -72,8 +72,7 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
 
-	patches := []operations.PatchOperation{}
-
+	patches := make([]operations.PatchOperation, 0)
 	if app.Spec.Source != nil {
 		patchedURL, err := getPatchedRepoURL(app.Spec.Source.RepoURL, state.GitServer, r)
 		if err != nil {

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -47,7 +47,7 @@ func NewRepositorySecretMutationHook(ctx context.Context, cluster *cluster.Clust
 }
 
 // mutateRepositorySecret mutates the git URL in the ArgoCD repository secret to point to the repository URL defined in the ZarfState.
-func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (result *operations.Result, err error) {
+func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
 	isCreate := r.Operation == v1.Create
 	isUpdate := r.Operation == v1.Update
 	var isPatched bool

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -37,7 +37,7 @@ func NewGitRepositoryMutationHook(ctx context.Context, cluster *cluster.Cluster)
 }
 
 // mutateGitRepoCreate mutates the git repository url to point to the repository URL defined in the ZarfState.
-func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (result *operations.Result, err error) {
+func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
 	var (
 		patches   []operations.PatchOperation
 		isPatched bool

--- a/src/test/e2e/28_wait_test.go
+++ b/src/test/e2e/28_wait_test.go
@@ -20,7 +20,8 @@ type zarfCommandResult struct {
 	err    error
 }
 
-func zarfCommandWStruct(t *testing.T, e2e test.ZarfE2ETest, path string) (result zarfCommandResult) {
+func zarfCommandWStruct(t *testing.T, e2e test.ZarfE2ETest, path string) zarfCommandResult {
+	result := zarfCommandResult{}
 	result.stdOut, result.stdErr, result.err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
 	return result
 }


### PR DESCRIPTION
## Description
Continuation of #2979 which finishes the issue. I was intending to keep smaller PRs limited by component, but it turns out the last PR was about 95% of the needed changes. This one's pretty small with an even smaller blast radius.

## Related Issue
Fixes #2950 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
