### PR TITLE
fix: add shasum flag and test for https pull

### DIFF
--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -28,7 +28,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
   -h, --help                        help for deploy
       --retries int                 Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
       --set stringToString          Specify deployment variables to set on the command line (KEY=value) (default [])
-      --shasum string               Shasum of the package to deploy. Required if deploying a remote package.
+      --shasum string               Shasum of the package to deploy. Required if deploying a remote https package.
       --skip-signature-validation   Skip validating the signature of the Zarf package
       --skip-webhooks               [alpha] Skip waiting for external webhooks to execute as each package component is deployed
       --timeout duration            Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -31,9 +31,9 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 ### Options
 
 ```
-  -h, --help                      help for pull
-  -o, --output-directory string   Specify the output directory for the pulled Zarf package
-      --shasum string             Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>
+  -h, --help                              help for pull
+  -o, --output-directory string           Specify the output directory for the pulled Zarf package
+      --shasum zarf dev sha256sum <url>   Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -33,6 +33,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 ```
   -h, --help                      help for pull
   -o, --output-directory string   Specify the output directory for the pulled Zarf package
+      --shasum string             Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -31,9 +31,9 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 ### Options
 
 ```
-  -h, --help                              help for pull
-  -o, --output-directory string           Specify the output directory for the pulled Zarf package
-      --shasum zarf dev sha256sum <url>   Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>
+  -h, --help                      help for pull
+  -o, --output-directory string   Specify the output directory for the pulled Zarf package
+      --shasum string             Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -518,5 +518,6 @@ func bindPublishFlags(v *viper.Viper) {
 
 func bindPullFlags(v *viper.Viper) {
 	pullFlags := packagePullCmd.Flags()
+	pullFlags.StringVar(&pkgConfig.PkgOpts.Shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	pullFlags.StringVarP(&pkgConfig.PullOpts.OutputDirectory, "output-directory", "o", v.GetString(common.VPkgPullOutputDir), lang.CmdPackagePullFlagOutputDirectory)
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -317,7 +317,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a ar
 # Pull a skeleton package
 $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a skeleton`
 	CmdPackagePullFlagOutputDirectory = "Specify the output directory for the pulled Zarf package"
-	CmdPackagePullFlagShasum          = "Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>"
+	CmdPackagePullFlagShasum          = "Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using `zarf dev sha256sum <url>`"
 
 	CmdPackageChoose                = "Choose or type the package file"
 	CmdPackageClusterSourceFallback = "%q does not satisfy any current sources, assuming it is a package deployed to a cluster"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -317,7 +317,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a ar
 # Pull a skeleton package
 $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a skeleton`
 	CmdPackagePullFlagOutputDirectory = "Specify the output directory for the pulled Zarf package"
-	CmdPackagePullFlagShasum          = "Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using `zarf dev sha256sum <url>`"
+	CmdPackagePullFlagShasum          = "Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'"
 
 	CmdPackageChoose                = "Choose or type the package file"
 	CmdPackageClusterSourceFallback = "%q does not satisfy any current sources, assuming it is a package deployed to a cluster"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -276,7 +276,7 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageDeployFlagAdoptExistingResources         = "Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover."
 	CmdPackageDeployFlagSet                            = "Specify deployment variables to set on the command line (KEY=value)"
 	CmdPackageDeployFlagComponents                     = "Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported."
-	CmdPackageDeployFlagShasum                         = "Shasum of the package to deploy. Required if deploying a remote package."
+	CmdPackageDeployFlagShasum                         = "Shasum of the package to deploy. Required if deploying a remote https package."
 	CmdPackageDeployFlagSget                           = "[Deprecated] Path to public sget key file for remote packages signed via cosign. This flag will be removed in v1.0.0 please use the --key flag instead."
 	CmdPackageDeployFlagSkipWebhooks                   = "[alpha] Skip waiting for external webhooks to execute as each package component is deployed"
 	CmdPackageDeployFlagTimeout                        = "Timeout for health checks and Helm operations such as installs and rollbacks"
@@ -317,6 +317,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a ar
 # Pull a skeleton package
 $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a skeleton`
 	CmdPackagePullFlagOutputDirectory = "Specify the output directory for the pulled Zarf package"
+	CmdPackagePullFlagShasum          = "Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using zarf dev sha256sum <url>"
 
 	CmdPackageChoose                = "Choose or type the package file"
 	CmdPackageClusterSourceFallback = "%q does not satisfy any current sources, assuming it is a package deployed to a cluster"

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -50,6 +50,17 @@ func TestUseCLI(t *testing.T) {
 		require.Contains(t, stdOut, expectedShasum, "The expected SHASUM should equal the actual SHASUM")
 	})
 
+	t.Run("zarf package pull https", func(t *testing.T) {
+		t.Parallel()
+		packageShasum := "690799dbe8414238e11d4488754eee52ec264c1584cd0265e3b91e3e251e8b1a"
+		packageName := "zarf-init-amd64-v0.39.0.tar.zst"
+		_, _, err := e2e.Zarf(t, "package", "pull", fmt.Sprintf("https://github.com/zarf-dev/zarf/releases/download/v0.39.0/%s", packageName), "--shasum", packageShasum)
+		require.NoError(t, err)
+		require.FileExists(t, packageName)
+		err = os.Remove(packageName)
+		require.NoError(t, err)
+	})
+
 	t.Run("zarf version", func(t *testing.T) {
 		t.Parallel()
 		// Test `zarf version`


### PR DESCRIPTION
## Description

Currently the `zarf package pull <https-url>` has no shasum flag, since we recently removed the insecure functionality in #2936 this means it's impossible to pull a package with an https url on main. This PR adds the shasum flag as well as a test.

## Related Issue

Fixes #2999 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
