### PR TITLE
fix: gittributes to ignore image file endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 * text eol=lf
+
+*.png binary
+*.jpg binary
+*.gif binary
+*.zst binary
+*.tar binary
+*.part00* binary


### PR DESCRIPTION
This change adds configuration to .gitattributes that was previously removed.