### PR TITLE
fix: modify the wait condition according to return values from earlier method call

### DIFF
--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -165,8 +165,8 @@ func (c *Cluster) RecordPackageDeploymentAndWait(ctx context.Context, pkg v1alph
 			return nil, err
 		}
 		packageNeedsWait, _, _ = c.PackageSecretNeedsWait(deployedPackage, component, skipWebhooks)
-		if !packageNeedsWait {
-			return deployedPackage, nil
+		if packageNeedsWait {
+			return nil, errors.New("wait on running webhook")
 		}
 		return deployedPackage, nil
 	}, retry.Context(waitCtx), retry.Attempts(0), retry.DelayType(retry.FixedDelay), retry.Delay(time.Second))


### PR DESCRIPTION
## Description
Discussed on slack, tl;dr is: currently no matter what `PackageSecretNeedsWait` method returns we just return the package, we need to invert the condition to wait, ie. return an error, to give the `retry.DoWithData` to do its job. 

## Related Issue

None

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
