### PR TITLE
fix: nightly by removing logline no longer printed

### DIFF
--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -59,10 +59,9 @@ func TestECRPublishing(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Ensure we get a warning when trying to inspect the online published package
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", upstreamPackageURL, keyFlag, "--sbom-out", tmpDir)
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", upstreamPackageURL, keyFlag, "--sbom-out", tmpDir, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
 	require.Contains(t, stdErr, "Validating SBOM checksums")
-	require.Contains(t, stdErr, "Package signature validated!")
 
 	// Validate that we can pull the package down from ECR
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL)


### PR DESCRIPTION
fixes #3032 


We could `os.Stat` the file, but then we'd have to parse by `tmpDir/fileprefix` and I'm unsure if that is really beneficial over "checking log output" 🤷🏻‍♀️  