### PR TITLE
fix: nightly ecr test

### DIFF
--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -59,10 +59,9 @@ func TestECRPublishing(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Ensure we get a warning when trying to inspect the online published package
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", upstreamPackageURL, keyFlag, "--sbom-out", tmpDir)
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", upstreamPackageURL, keyFlag, "--sbom-out", tmpDir, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
 	require.Contains(t, stdErr, "Validating SBOM checksums")
-	require.Contains(t, stdErr, "Package signature validated!")
 
 	// Validate that we can pull the package down from ECR
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL)

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -61,7 +61,6 @@ func TestECRPublishing(t *testing.T) {
 	// Ensure we get a warning when trying to inspect the online published package
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", upstreamPackageURL, keyFlag, "--sbom-out", tmpDir, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "Validating SBOM checksums")
 
 	// Validate that we can pull the package down from ECR
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL)
@@ -72,11 +71,8 @@ func TestECRPublishing(t *testing.T) {
 	// and the insecure flag
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
-	require.NotContains(t, stdErr, "Validating SBOM checksums")
 
 	// Validate that we get no warnings when inspecting the package while providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, keyFlag)
 	require.NoError(t, err, stdOut, stdErr)
-	require.NotContains(t, stdErr, "Validating SBOM checksums")
-	require.Contains(t, stdErr, "Package signature validated!")
 }


### PR DESCRIPTION
`Packager2`'s Load function doesn't output these anymore. 
I was running my brew installed Zarf binary to test which is from like 2022, rebuilt locally confirmed. 🙃  