### PR TITLE
feat: add `metadata.annotations` to `v1alpha1` schema

### DIFF
--- a/src/api/v1alpha1/package.go
+++ b/src/api/v1alpha1/package.go
@@ -170,6 +170,9 @@ type ZarfMetadata struct {
 	Vendor string `json:"vendor,omitempty"`
 	// Checksum of a checksums.txt file that contains checksums all the layers within the package.
 	AggregateChecksum string `json:"aggregateChecksum,omitempty"`
+	// Annotations contains arbitrary metadata about the package.
+	// Users are encouraged to follow OCI image-spec [annotation rules](https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md).
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ZarfBuildData is written during the packager.Create() operation to track details of the created package.

--- a/src/api/v1beta1/package.go
+++ b/src/api/v1beta1/package.go
@@ -145,7 +145,8 @@ type ZarfMetadata struct {
 	Architecture string `json:"architecture,omitempty" jsonschema:"example=arm64,example=amd64"`
 	// Default to true, when false components cannot have images or git repos as they will be pulled from the internet
 	Airgap *bool `json:"airgap,omitempty"`
-	// Annotations are key-value pairs that can be used to store metadata about the package.
+	// Annotations contains arbitrary metadata about the package.
+	// Users are encouraged to follow OCI image-spec [annotation rules](https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md).
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/src/pkg/zoci/push.go
+++ b/src/pkg/zoci/push.go
@@ -7,6 +7,7 @@ package zoci
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -109,6 +110,9 @@ func annotationsFromMetadata(metadata *v1alpha1.ZarfMetadata) map[string]string 
 	if vendor := metadata.Vendor; vendor != "" {
 		annotations[ocispec.AnnotationVendor] = vendor
 	}
+
+	// annotations explicitly defined in `metadata.annotations` take precedence over legacy fields
+	maps.Copy(annotations, metadata.Annotations)
 
 	return annotations
 }

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -1129,6 +1129,13 @@
         "aggregateChecksum": {
           "type": "string",
           "description": "Checksum of a checksums.txt file that contains checksums all the layers within the package."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations contains arbitrary metadata about the package.\nUsers are encouraged to follow OCI image-spec [annotation rules](https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md)."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Description

This adds `metadata.annotations` from `v1beta1` to the existing `v1alpha1` schema. It also adds them to the OCI config descriptor and image manifests.

## Related Issue

Relates to https://github.com/zarf-dev/zarf/issues/2976.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
