### PR TITLE
Introducing Zarf Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Zarf Documentation](https://img.shields.io/badge/docs-docs.zarf.dev-775ba1)](https://docs.zarf.dev/)
 [![Zarf Slack Channel](https://img.shields.io/badge/k8s%20slack-zarf-40a3dd)](https://kubernetes.slack.com/archives/C03B6BJAUJ3)
 [![Community Meetups](https://img.shields.io/badge/community-meetups-22aebb)](https://github.com/zarf-dev/zarf/issues/2202)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Zarf%20Guru-006BFF)](https://gurubase.io/g/zarf)
 
 Zarf eliminates the [complexity of air gap software delivery](https://www.itopstimes.com/contain/air-gap-kubernetes-considerations-for-running-cloud-native-applications-without-the-cloud/) for Kubernetes clusters and cloud-native workloads using a declarative packaging strategy to support DevSecOps in offline and semi-connected environments.
 


### PR DESCRIPTION
Hello Zarf team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Zarf Guru](https://gurubase.io/g/zarf) to Gurubase. Zarf Guru uses the data from this repo and data from the [docs](https://docs.zarf.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Zarf Guru" badge, which highlights that Zarf now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Zarf Guru in Gurubase, just let me know that's totally fine.