### PR TITLE
fix: htpasswd mount issues

### DIFF
--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -56,13 +56,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:
+{{- if .Values.persistence.enabled }}
             - name: REGISTRY_AUTH
               value: "htpasswd"
             - name: REGISTRY_AUTH_HTPASSWD_REALM
               value: "Registry Realm"
             - name: REGISTRY_AUTH_HTPASSWD_PATH
               value: "/etc/docker/registry/htpasswd"
-{{- if .Values.persistence.enabled }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
 {{- end }}
@@ -111,6 +111,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       volumes:
+{{- if .Values.persistence.enabled }}
         - name: config
           secret:
             secretName: {{ template "docker-registry.fullname" . }}-secret
@@ -119,7 +120,6 @@ spec:
               path: config.yml
             - key: htpasswd
               path: htpasswd
-{{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}


### PR DESCRIPTION
## Description
Adjusting the location of `{{- if .Values.persistence.enabled }}` to cover all the needed configs. When you are using an external registry you do not need to mount the `zarf-docker-registry-secret` secret or set any `htpasswd` env vars. 

## Related Issue
#3107 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
