### PR TITLE
Refactor flavor e2e test to not depend on CLI output

### DIFF
--- a/src/test/e2e/10_component_flavor_test.go
+++ b/src/test/e2e/10_component_flavor_test.go
@@ -5,120 +5,76 @@
 package test
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+
+	layout2 "github.com/zarf-dev/zarf/src/internal/packager2/layout"
 )
 
-type FlavorSuite struct {
-	suite.Suite
-	*require.Assertions
+func TestFlavorExample(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	flavorExample := filepath.Join("examples", "package-flavors")
+	_, _, err := e2e.Zarf(t, "package", "create", flavorExample, "-o", tmpDir, "--flavor", "oracle-cookie-crunch", "--no-color", "--confirm")
+	require.NoError(t, err)
+
+	tarPath := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-package-flavors-%s-1.0.0.tar.zst", e2e.Arch))
+	pkgLayout, err := layout2.LoadFromTar(context.Background(), tarPath, layout2.PackageLayoutOptions{})
+	require.NoError(t, err)
+	pkgLayout.Pkg.Metadata.Description = "The pod that runs the specified flavor of Enterprise Linux"
+	imgs := []string{}
+	for _, comp := range pkgLayout.Pkg.Components {
+		imgs = append(imgs, comp.Images...)
+	}
+	require.ElementsMatch(t, imgs, []string{"oraclelinux:9-slim"})
 }
 
-var (
-	flavorExample     = filepath.Join("examples", "package-flavors")
-	flavorTest        = filepath.Join("src", "test", "packages", "10-package-flavors")
-	flavorExamplePath string
-	flavorTestAMDPath = filepath.Join("build", "zarf-package-test-package-flavors-amd64.tar.zst")
-	flavorTestARMPath = filepath.Join("build", "zarf-package-test-package-flavors-arm64.tar.zst")
-)
+func TestFlavorArchFiltering(t *testing.T) {
+	t.Parallel()
 
-func (suite *FlavorSuite) SetupSuite() {
-	suite.Assertions = require.New(suite.T())
+	tests := []struct {
+		arch        string
+		flavor      string
+		expectedIDs []string
+	}{
+		{
+			arch:        "amd64",
+			flavor:      "vanilla",
+			expectedIDs: []string{"combined-vanilla-amd", "via-import-vanilla-amd"},
+		},
+		{
+			arch:        "amd64",
+			flavor:      "chocolate",
+			expectedIDs: []string{"combined-chocolate-amd", "via-import-chocolate-amd"},
+		},
+		{
+			arch:        "arm64",
+			flavor:      "chocolate",
+			expectedIDs: []string{"combined-chocolate-arm", "via-import-chocolate-arm"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.arch+"-"+tt.flavor, func(t *testing.T) {
+			t.Parallel()
 
-	// Setup the example package path after e2e has been initialized
-	flavorExamplePath = filepath.Join("build", fmt.Sprintf("zarf-package-package-flavors-%s-1.0.0.tar.zst", e2e.Arch))
-}
+			tmpDir := t.TempDir()
+			flavorTest := filepath.Join("src", "test", "packages", "10-package-flavors")
+			_, _, err := e2e.Zarf(t, "package", "create", flavorTest, "-o", tmpDir, "--flavor", tt.flavor, "-a", tt.arch, "--no-color", "--confirm")
+			require.NoError(t, err)
 
-func (suite *FlavorSuite) TearDownSuite() {
-	err := os.RemoveAll(flavorExamplePath)
-	suite.NoError(err)
-	err = os.RemoveAll(flavorTestAMDPath)
-	suite.NoError(err)
-	err = os.RemoveAll(flavorTestARMPath)
-	suite.NoError(err)
-}
-
-func (suite *FlavorSuite) Test_0_FlavorExample() {
-	suite.T().Log("E2E: Package Flavor Example")
-
-	_, stdErr, err := e2e.Zarf(suite.T(), "package", "create", flavorExample, "-o", "build", "--flavor", "oracle-cookie-crunch", "--no-color", "--confirm")
-	suite.NoError(err)
-
-	// Ensure that the oracle image is included
-	suite.Contains(stdErr, `oraclelinux:9-slim`)
-
-	// Ensure that the common pod was included
-	suite.Contains(stdErr, `description: The pod that runs the specified flavor of Enterprise Linux`)
-
-	// Ensure that the other flavors are not included
-	suite.NotContains(stdErr, `rockylinux:9-minimal`)
-	suite.NotContains(stdErr, `almalinux:9-minimal`)
-	suite.NotContains(stdErr, `opensuse/leap:15`)
-}
-
-func (suite *FlavorSuite) Test_1_FlavorArchFiltering() {
-	suite.T().Log("E2E: Package Flavor + Arch Filtering")
-
-	_, stdErr, err := e2e.Zarf(suite.T(), "package", "create", flavorTest, "-o", "build", "--flavor", "vanilla", "-a", "amd64", "--no-color", "--confirm")
-	suite.NoError(err)
-
-	// Ensure that the initial filter was applied
-	suite.Contains(stdErr, `
-- name: combined
-  description: vanilla-amd`)
-
-	// Ensure that the import filter was applied
-	suite.Contains(stdErr, `
-- name: via-import
-  description: vanilla-amd`)
-
-	// Ensure that the other flavors / architectures are not included
-	suite.NotContains(stdErr, `vanilla-arm`)
-	suite.NotContains(stdErr, `chocolate-amd`)
-	suite.NotContains(stdErr, `chocolate-arm`)
-
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "create", flavorTest, "-o", "build", "--flavor", "chocolate", "-a", "amd64", "--no-color", "--confirm")
-	suite.NoError(err)
-
-	// Ensure that the initial filter was applied
-	suite.Contains(stdErr, `
-- name: combined
-  description: chocolate-amd`)
-
-	// Ensure that the import filter was applied
-	suite.Contains(stdErr, `
-- name: via-import
-  description: chocolate-amd`)
-
-	// Ensure that the other flavors / architectures are not included
-	suite.NotContains(stdErr, `vanilla-arm`)
-	suite.NotContains(stdErr, `vanilla-amd`)
-	suite.NotContains(stdErr, `chocolate-arm`)
-
-	_, stdErr, err = e2e.Zarf(suite.T(), "package", "create", flavorTest, "-o", "build", "--flavor", "chocolate", "-a", "arm64", "--no-color", "--confirm")
-	suite.NoError(err)
-
-	// Ensure that the initial filter was applied
-	suite.Contains(stdErr, `
-- name: combined
-  description: chocolate-arm`)
-
-	// Ensure that the import filter was applied
-	suite.Contains(stdErr, `
-- name: via-import
-  description: chocolate-arm`)
-
-	// Ensure that the other flavors / architectures are not included
-	suite.NotContains(stdErr, `vanilla-arm`)
-	suite.NotContains(stdErr, `vanilla-amd`)
-	suite.NotContains(stdErr, `chocolate-amd`)
-}
-
-func TestFlavorSuite(t *testing.T) {
-	suite.Run(t, new(FlavorSuite))
+			tarPath := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-test-package-flavors-%s.tar.zst", tt.arch))
+			pkgLayout, err := layout2.LoadFromTar(context.Background(), tarPath, layout2.PackageLayoutOptions{})
+			require.NoError(t, err)
+			compIDs := []string{}
+			for _, comp := range pkgLayout.Pkg.Components {
+				compIDs = append(compIDs, comp.Name+"-"+comp.Description)
+			}
+			require.ElementsMatch(t, compIDs, tt.expectedIDs)
+		})
+	}
 }


### PR DESCRIPTION
## Description

This change removes any use of CLI output for flavor e2e tests. This enables the refactoring of log output without breaking the e2e tests.

## Related Issue

Relates to #2576 
Relates to #2969

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
