### PR TITLE
Refactor deprecation e2e test to not depend on CLI output

### DIFF
--- a/src/test/common.go
+++ b/src/test/common.go
@@ -55,6 +55,11 @@ func GetCLIName() string {
 
 // Zarf executes a Zarf command.
 func (e2e *ZarfE2ETest) Zarf(t *testing.T, args ...string) (_ string, _ string, err error) {
+	return e2e.ZarfInDir(t, "", args...)
+}
+
+// ZarfInDir executes a Zarf command in specific directory.
+func (e2e *ZarfE2ETest) ZarfInDir(t *testing.T, dir string, args ...string) (_ string, _ string, err error) {
 	if !slices.Contains(args, "--tmpdir") && !slices.Contains(args, "tools") {
 		tmpdir, err := os.MkdirTemp("", "zarf-")
 		if err != nil {
@@ -83,7 +88,9 @@ func (e2e *ZarfE2ETest) Zarf(t *testing.T, args ...string) (_ string, _ string, 
 			err = errors.Join(err, errRemove)
 		}(cacheDir)
 	}
-	return exec.CmdWithTesting(t, exec.PrintCfg(), e2e.ZarfBinPath, args...)
+	cfg := exec.PrintCfg()
+	cfg.Dir = dir
+	return exec.CmdWithTesting(t, cfg, e2e.ZarfBinPath, args...)
 }
 
 // Kubectl executes `zarf tools kubectl ...`

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -35,7 +35,11 @@ func TestMain(m *testing.M) {
 	}
 
 	e2e.Arch = config.GetArch()
-	e2e.ZarfBinPath = filepath.Join("build", test.GetCLIName())
+	zarfBinPath, err := filepath.Abs(filepath.Join("build", test.GetCLIName()))
+	if err != nil {
+		log.Fatal(err)
+	}
+	e2e.ZarfBinPath = zarfBinPath
 	e2e.ApplianceMode = os.Getenv(applianceModeEnvVar) == "true"
 	e2e.ApplianceModeKeep = os.Getenv(applianceModeKeepEnvVar) == "true"
 


### PR DESCRIPTION
## Description

This change removes any use of CLI output for deprecated e2e tests. This enables the refactoring of log output without breaking the e2e tests.

## Related Issue

Relates to #2576 
Relates to #2969

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
