### PR TITLE
feat: migrate package create to slog

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,9 @@ linters-settings:
       - (*github.com/spf13/cobra.Command).MarkFlagRequired
       - (*github.com/spf13/pflag.FlagSet).MarkHidden
       - (*github.com/spf13/pflag.FlagSet).MarkDeprecated
+  sloglint:
+    no-mixed-args: true
+    key-naming-case: camel
 issues:
   # Revive rules that are disabled by default.
   include:

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
+	github.com/golang-cz/devslog v0.0.11 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/goccy/go-yaml v1.12.0
 	github.com/gofrs/flock v0.12.1
+	github.com/golang-cz/devslog v0.0.11
 	github.com/google/go-containerregistry v0.20.2
 	github.com/gosuri/uitable v0.0.4
 	github.com/invopop/jsonschema v0.12.0
@@ -85,7 +86,6 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
-	github.com/golang-cz/devslog v0.0.11 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
@@ -96,6 +96,7 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/onsi/gomega v1.34.1 // indirect
+	github.com/phsym/console-slog v0.3.1 // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/v9 v9.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/moby/moby v27.3.1+incompatible
 	github.com/opencontainers/image-spec v1.1.0
+	github.com/phsym/console-slog v0.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.4
 	github.com/pterm/pterm v0.12.79
@@ -96,7 +97,6 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/onsi/gomega v1.34.1 // indirect
-	github.com/phsym/console-slog v0.3.1 // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/v9 v9.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1422,6 +1422,8 @@ github.com/petergtz/pegomock v2.9.0+incompatible h1:BKfb5XfkJfehe5T+O1xD4Zm26Sb9
 github.com/petergtz/pegomock v2.9.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
+github.com/phsym/console-slog v0.3.1 h1:Fuzcrjr40xTc004S9Kni8XfNsk+qrptQmyR+wZw9/7A=
+github.com/phsym/console-slog v0.3.1/go.mod h1:oJskjp/X6e6c0mGpfP8ELkfKUsrkDifYRAqJQgmdDS0=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-cz/devslog v0.0.11 h1:v4Yb9o0ZpuZ/D8ZrtVw1f9q5XrjnkxwHF1XmWwO8IHg=
+github.com/golang-cz/devslog v0.0.11/go.mod h1:bSe5bm0A7Nyfqtijf1OMNgVJHlWEuVSXnkuASiE1vV8=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -73,7 +73,7 @@ var packageCreateCmd = &cobra.Command{
 		// TODO(mkcp): Finish migrating packager.Create
 		err = pkgClient.Create()
 
-		// TODO(mkcp): Migrate linterrs to logger
+		// NOTE(mkcp): LintErrors are rendered with a table
 		var lintErr *lint.LintError
 		if errors.As(err, &lintErr) {
 			common.PrintFindings(lintErr)

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -54,6 +54,8 @@ var packageCreateCmd = &cobra.Command{
 
 		var isCleanPathRegex = regexp.MustCompile(`^[a-zA-Z0-9\_\-\/\.\~\\:]+$`)
 		if !isCleanPathRegex.MatchString(config.CommonOptions.CachePath) {
+			// TODO(mkcp): Remove message on logger release
+			message.Warnf(lang.CmdPackageCreateCleanPathErr, config.ZarfDefaultCachePath)
 			l.Warn("invalid characters in Zarf cache path, using default", "cfg", config.ZarfDefaultCachePath, "default", config.ZarfDefaultCachePath)
 			config.CommonOptions.CachePath = config.ZarfDefaultCachePath
 		}
@@ -70,8 +72,7 @@ var packageCreateCmd = &cobra.Command{
 		}
 		defer pkgClient.ClearTempPaths()
 
-		// TODO(mkcp): Finish migrating packager.Create
-		err = pkgClient.Create()
+		err = pkgClient.Create(cmd.Context())
 
 		// NOTE(mkcp): LintErrors are rendered with a table
 		var lintErr *lint.LintError

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/spf13/cobra"
@@ -47,11 +49,12 @@ var packageCreateCmd = &cobra.Command{
 	Short:   lang.CmdPackageCreateShort,
 	Long:    lang.CmdPackageCreateLong,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		l := logger.From(cmd.Context())
 		pkgConfig.CreateOpts.BaseDir = setBaseDirectory(args)
 
 		var isCleanPathRegex = regexp.MustCompile(`^[a-zA-Z0-9\_\-\/\.\~\\:]+$`)
 		if !isCleanPathRegex.MatchString(config.CommonOptions.CachePath) {
-			message.Warnf(lang.CmdPackageCreateCleanPathErr, config.ZarfDefaultCachePath)
+			l.Warn("invalid characters in Zarf cache path, using default", "cfg", config.ZarfDefaultCachePath, "default", config.ZarfDefaultCachePath)
 			config.CommonOptions.CachePath = config.ZarfDefaultCachePath
 		}
 
@@ -59,13 +62,18 @@ var packageCreateCmd = &cobra.Command{
 		pkgConfig.CreateOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig,
+			packager.WithContext(cmd.Context()),
+		)
 		if err != nil {
 			return err
 		}
 		defer pkgClient.ClearTempPaths()
 
-		err = pkgClient.Create(cmd.Context())
+		// TODO(mkcp): Finish migrating packager.Create
+		err = pkgClient.Create()
+
+		// TODO(mkcp): Migrate linterrs to logger
 		var lintErr *lint.LintError
 		if errors.As(err, &lintErr) {
 			common.PrintFindings(lintErr)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -82,6 +82,8 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	if cmd.Parent() == nil {
 		skipLogFile = true
 	}
+
+	// Configure the global message instance.
 	err := setupMessage(LogLevelCLI, skipLogFile, NoColor)
 	if err != nil {
 		return err

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -127,14 +127,22 @@ func Execute(ctx context.Context) {
 	if err == nil {
 		return
 	}
+
+	// Check if we need to use the default err printer
 	defaultPrintCmds := []string{"helm", "yq", "kubectl"}
 	comps := strings.Split(cmd.CommandPath(), " ")
 	if len(comps) > 1 && comps[1] == "tools" && slices.Contains(defaultPrintCmds, comps[2]) {
 		cmd.PrintErrln(cmd.ErrPrefix(), err.Error())
-	} else {
-		errParagraph := message.Paragraph(err.Error())
-		pterm.Error.Println(errParagraph)
+		os.Exit(1)
 	}
+
+	// TODO(mkcp): Remove message on logger release
+	errParagraph := message.Paragraph(err.Error())
+	pterm.Error.Println(errParagraph)
+
+	// NOTE(mkcp): The default logger is set with user flags downstream in rootCmd's preRun func, so we don't have
+	// access to it on Execute's ctx.
+	logger.Default().Error(err.Error())
 	os.Exit(1)
 }
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -208,7 +208,12 @@ func setupMessage(cfg messageCfg) error {
 	// HACK(mkcp): Discard message logs if feature is disabled. message calls InitializePTerm once in its init() fn so
 	//             this ends up being a messy solution.
 	if cfg.featureDisabled {
+		// Discard all* PTerm messages. *see below
 		message.InitializePTerm(io.Discard)
+		// Disable all progress bars and spinners
+		message.NoProgress = true
+		// Ensures no user input is needed while we maintain backwards compatibility with message
+		config.CommonOptions.Confirm = true
 		return nil
 	}
 

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -173,7 +173,7 @@ var updateCredsCmd = &cobra.Command{
 			}
 
 			// Update Zarf 'init' component Helm releases if present
-			h := helm.NewClusterOnly(&types.PackagerConfig{}, template.GetZarfVariableConfig(), newState, c)
+			h := helm.NewClusterOnly(&types.PackagerConfig{}, template.GetZarfVariableConfig(cmd.Context()), newState, c)
 
 			if slices.Contains(args, message.RegistryKey) && newState.RegistryInfo.IsInternal() {
 				err = h.UpdateZarfRegistryValues(ctx)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -270,7 +270,6 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageCreateFlagDifferential          = "[beta] Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package"
 	CmdPackageCreateFlagRegistryOverride      = "Specify a map of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)"
 	CmdPackageCreateFlagFlavor                = "The flavor of components to include in the resulting package (i.e. have a matching or empty \"only.flavor\" key)"
-	CmdPackageCreateCleanPathErr              = "Invalid characters in Zarf cache path, defaulting to %s"
 
 	CmdPackageDeployFlagConfirm                        = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdPackageDeployFlagAdoptExistingResources         = "Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover."

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -270,6 +270,7 @@ $ zarf package mirror-resources <your-package.tar.zst> \
 	CmdPackageCreateFlagDifferential          = "[beta] Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package"
 	CmdPackageCreateFlagRegistryOverride      = "Specify a map of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)"
 	CmdPackageCreateFlagFlavor                = "The flavor of components to include in the resulting package (i.e. have a matching or empty \"only.flavor\" key)"
+	CmdPackageCreateCleanPathErr              = "Invalid characters in Zarf cache path, defaulting to %s"
 
 	CmdPackageDeployFlagConfirm                        = "Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdPackageDeployFlagAdoptExistingResources         = "Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover."

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -40,6 +40,8 @@ func (h *Helm) PackageChart(ctx context.Context, cosignKeyPath string) error {
 		// check if the chart is a git url with a ref (if an error is returned url will be empty)
 		isGitURL := strings.HasSuffix(url, ".git")
 		if err != nil {
+			// TODO(mkcp): Remove message on logger release
+			message.Debugf("unable to parse the url, continuing with %s", h.chart.URL)
 			logger.From(ctx).Debug("unable to parse the url, continuing", "url", h.chart.URL)
 		}
 
@@ -76,6 +78,9 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 		"version", h.chart.Version,
 		"path", h.chart.LocalPath,
 	)
+	// TODO(mkcp): Remove message on logger release
+	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from %s", h.chart.Name, h.chart.Version, h.chart.LocalPath)
+	defer spinner.Stop()
 
 	// Load and validate the chart
 	cl, _, err := h.loadAndValidateChart(h.chart.LocalPath)
@@ -87,7 +92,7 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 	var saved string
 	temp := filepath.Join(h.chartPath, "temp")
 	if _, ok := cl.(loader.DirLoader); ok {
-		err = h.buildChartDependencies(ctx)
+		err = h.buildChartDependencies()
 		if err != nil {
 			return fmt.Errorf("unable to build dependencies for the chart: %w", err)
 		}
@@ -117,6 +122,8 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 		return err
 	}
 
+	spinner.Success()
+
 	l.Debug("done processing local helm chart",
 		"name", h.chart.Name,
 		"version", h.chart.Version,
@@ -125,55 +132,13 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 	return nil
 }
 
-// PackageChartFromLocalFilesSpinner creates a chart archive from a path to a chart on the host os. It displays a spinner.
-func (h *Helm) PackageChartFromLocalFilesSpinner(ctx context.Context, cosignKeyPath string) error {
-	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from %s", h.chart.Name, h.chart.Version, h.chart.LocalPath)
-	defer spinner.Stop()
-
-	// Load and validate the chart
-	cl, _, err := h.loadAndValidateChart(h.chart.LocalPath)
-	if err != nil {
-		return err
-	}
-
-	// Handle the chart directory or tarball
-	var saved string
-	temp := filepath.Join(h.chartPath, "temp")
-	if _, ok := cl.(loader.DirLoader); ok {
-		err = h.buildChartDependencies(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to build dependencies for the chart: %w", err)
-		}
-
-		client := action.NewPackage()
-
-		client.Destination = temp
-		saved, err = client.Run(h.chart.LocalPath, nil)
-	} else {
-		saved = filepath.Join(temp, filepath.Base(h.chart.LocalPath))
-		err = helpers.CreatePathAndCopy(h.chart.LocalPath, saved)
-	}
-	defer os.RemoveAll(temp)
-
-	if err != nil {
-		return fmt.Errorf("unable to save the archive and create the package %s: %w", saved, err)
-	}
-
-	// Finalize the chart
-	err = h.finalizeChartPackage(ctx, saved, cosignKeyPath)
-	if err != nil {
-		return err
-	}
-
-	spinner.Success()
-
-	return nil
-}
-
 // PackageChartFromGit is a special implementation of chart archiving that supports the https://p1.dso.mil/#/products/big-bang/ model.
 func (h *Helm) PackageChartFromGit(ctx context.Context, cosignKeyPath string) error {
 	l := logger.From(ctx)
 	l.Info("processing helm chart", "name", h.chart.Name)
+	// TODO(mkcp): Remove message on logger release
+	spinner := message.NewProgressSpinner("Processing helm chart %s", h.chart.Name)
+	defer spinner.Stop()
 
 	// Retrieve the repo containing the chart
 	gitPath, err := DownloadChartFromGitToTemp(ctx, h.chart.URL)
@@ -191,24 +156,6 @@ func (h *Helm) PackageChartFromGit(ctx context.Context, cosignKeyPath string) er
 	return h.PackageChartFromLocalFiles(ctx, cosignKeyPath)
 }
 
-// PackageChartFromGitSpinner is a special implementation of chart archiving that supports the https://p1.dso.mil/#/products/big-bang/ model.
-// It includes a CLI spinner.
-func (h *Helm) PackageChartFromGitSpinner(ctx context.Context, cosignKeyPath string) error {
-	spinner := message.NewProgressSpinner("Processing helm chart %s", h.chart.Name)
-	defer spinner.Stop()
-
-	// Retrieve the repo containing the chart
-	gitPath, err := DownloadChartFromGitToTemp(ctx, h.chart.URL)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(gitPath)
-
-	// Set the directory for the chart and package it
-	h.chart.LocalPath = filepath.Join(gitPath, h.chart.GitPath)
-	return h.PackageChartFromLocalFiles(ctx, cosignKeyPath)
-}
-
 // DownloadPublishedChart loads a specific chart version from a remote repo.
 func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string) error {
 	l := logger.From(ctx)
@@ -217,110 +164,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 		"version", h.chart.Version,
 		"repo", h.chart.URL,
 	)
-
-	// Set up the helm pull config
-	pull := action.NewPull()
-	pull.Settings = cli.New()
-
-	var (
-		regClient *registry.Client
-		chartURL  string
-		err       error
-	)
-	repoFile, err := repo.LoadFile(pull.Settings.RepositoryConfig)
-
-	// Not returning the error here since the repo file is only needed if we are pulling from a repo that requires authentication
-	if err != nil {
-		l.Debug("unable to load the repo file",
-			"path", pull.Settings.RepositoryConfig,
-			"error", err.Error(),
-		)
-	}
-
-	var username string
-	var password string
-
-	// Handle OCI registries
-	if registry.IsOCI(h.chart.URL) {
-		regClient, err = registry.NewClient(registry.ClientOptEnableCache(true))
-		if err != nil {
-			return fmt.Errorf("unable to create the new registry client: %w", err)
-		}
-		chartURL = h.chart.URL
-		// Explicitly set the pull version for OCI
-		pull.Version = h.chart.Version
-	} else {
-		chartName := h.chart.Name
-		if h.chart.RepoName != "" {
-			chartName = h.chart.RepoName
-		}
-
-		if repoFile != nil {
-			// TODO: @AustinAbro321 Currently this selects the last repo with the same url
-			// We should introduce a new field in zarf to allow users to specify the local repo they want
-			for _, r := range repoFile.Repositories {
-				if r.URL == h.chart.URL {
-					username = r.Username
-					password = r.Password
-				}
-			}
-		}
-
-		chartURL, err = repo.FindChartInAuthRepoURL(h.chart.URL, username, password, chartName, h.chart.Version, pull.CertFile, pull.KeyFile, pull.CaFile, getter.All(pull.Settings))
-		if err != nil {
-			return fmt.Errorf("unable to pull the helm chart: %w", err)
-		}
-	}
-
-	// Set up the chart chartDownloader
-	chartDownloader := downloader.ChartDownloader{
-		Out:            logger.DestinationDefault,
-		RegistryClient: regClient,
-		// TODO: Further research this with regular/OCI charts
-		Verify:  downloader.VerifyNever,
-		Getters: getter.All(pull.Settings),
-		Options: []getter.Option{
-			getter.WithInsecureSkipVerifyTLS(config.CommonOptions.InsecureSkipTLSVerify),
-			getter.WithBasicAuth(username, password),
-		},
-	}
-
-	// Download the file into a temp directory since we don't control what name helm creates here
-	temp := filepath.Join(h.chartPath, "temp")
-	if err = helpers.CreateDirectory(temp, helpers.ReadWriteExecuteUser); err != nil {
-		return fmt.Errorf("unable to create helm chart temp directory: %w", err)
-	}
-	defer func(l *slog.Logger) {
-		err := os.RemoveAll(temp)
-		if err != nil {
-			l.Error(err.Error())
-		}
-	}(l)
-
-	saved, _, err := chartDownloader.DownloadTo(chartURL, pull.Version, temp)
-	if err != nil {
-		return fmt.Errorf("unable to download the helm chart: %w", err)
-	}
-
-	// Validate the chart
-	_, _, err = h.loadAndValidateChart(saved)
-	if err != nil {
-		return err
-	}
-
-	// Finalize the chart
-	err = h.finalizeChartPackage(ctx, saved, cosignKeyPath)
-	if err != nil {
-		return err
-	}
-
-	l.Debug("done downloading helm chart")
-
-	return nil
-}
-
-// DownloadPublishedChartSpinner loads a specific chart version from a remote repo and renders it with a spinner.
-func (h *Helm) DownloadPublishedChartSpinner(ctx context.Context, cosignKeyPath string) error {
+	// TODO(mkcp): Remove message on logger release
 	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from repo %s", h.chart.Name, h.chart.Version, h.chart.URL)
 	defer spinner.Stop()
 
@@ -337,7 +181,12 @@ func (h *Helm) DownloadPublishedChartSpinner(ctx context.Context, cosignKeyPath 
 
 	// Not returning the error here since the repo file is only needed if we are pulling from a repo that requires authentication
 	if err != nil {
+		// TODO(mkcp): Remove message on logger release
 		message.Debugf("Unable to load the repo file at %q: %s", pull.Settings.RepositoryConfig, err.Error())
+		l.Debug("unable to load the repo file",
+			"path", pull.Settings.RepositoryConfig,
+			"error", err.Error(),
+		)
 	}
 
 	var username string
@@ -393,7 +242,12 @@ func (h *Helm) DownloadPublishedChartSpinner(ctx context.Context, cosignKeyPath 
 	if err = helpers.CreateDirectory(temp, helpers.ReadWriteExecuteUser); err != nil {
 		return fmt.Errorf("unable to create helm chart temp directory: %w", err)
 	}
-	defer os.RemoveAll(temp)
+	defer func(l *slog.Logger) {
+		err := os.RemoveAll(temp)
+		if err != nil {
+			l.Error(err.Error())
+		}
+	}(l)
 
 	saved, _, err := chartDownloader.DownloadTo(chartURL, pull.Version, temp)
 	if err != nil {
@@ -413,7 +267,7 @@ func (h *Helm) DownloadPublishedChartSpinner(ctx context.Context, cosignKeyPath 
 	}
 
 	spinner.Success()
-
+	l.Debug("done downloading helm chart")
 	return nil
 }
 
@@ -464,8 +318,7 @@ func (h *Helm) packageValues(ctx context.Context, cosignKeyPath string) error {
 }
 
 // buildChartDependencies builds the helm chart dependencies
-func (h *Helm) buildChartDependencies(ctx context.Context) error {
-	l := logger.From(ctx)
+func (h *Helm) buildChartDependencies() error {
 	// Download and build the specified dependencies
 	regClient, err := registry.NewClient(registry.ClientOptEnableCache(true))
 	if err != nil {
@@ -479,7 +332,7 @@ func (h *Helm) buildChartDependencies(ctx context.Context) error {
 	}
 
 	man := &downloader.Manager{
-		Out:            logger.DestinationDefault,
+		Out:            &message.DebugWriter{},
 		ChartPath:      h.chart.LocalPath,
 		Getters:        getter.All(h.settings),
 		RegistryClient: regClient,
@@ -496,14 +349,18 @@ func (h *Helm) buildChartDependencies(ctx context.Context) error {
 	var notFoundErr *downloader.ErrRepoNotFound
 	if errors.As(err, &notFoundErr) {
 		// If we encounter a repo not found error point the user to `zarf tools helm repo add`
-		l.Warn(fmt.Sprintf("%s. please add the missing repo(s) via the following: %s", notFoundErr.Error()))
+		// TODO(mkcp): Remove message on logger release
+		message.Warnf("%s. Please add the missing repo(s) via the following:", notFoundErr.Error())
 		for _, repository := range notFoundErr.Repos {
-			l.Warn(fmt.Sprintf("'$zarf tools helm repo add <your-repo-name> %s'", repository))
+			// TODO(mkcp): Remove message on logger release
+			message.ZarfCommand(fmt.Sprintf("tools helm repo add <your-repo-name> %s", repository))
 		}
 		return err
 	}
 	if err != nil {
-		l.Warn("unable to perform a rebuild of Helm dependencies, try running '$zarf tools helm dependency build --verify'", "error", err.Error())
+		// TODO(mkcp): Remove message on logger release
+		message.ZarfCommand("tools helm dependency build --verify")
+		message.Warnf("Unable to perform a rebuild of Helm dependencies: %s", err.Error())
 		return err
 	}
 	return nil

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +40,7 @@ func (h *Helm) PackageChart(ctx context.Context, cosignKeyPath string) error {
 		// check if the chart is a git url with a ref (if an error is returned url will be empty)
 		isGitURL := strings.HasSuffix(url, ".git")
 		if err != nil {
-			message.Debugf("unable to parse the url, continuing with %s", h.chart.URL)
+			logger.From(ctx).Debug("unable to parse the url, continuing", "url", h.chart.URL)
 		}
 
 		if isGitURL {
@@ -68,6 +70,63 @@ func (h *Helm) PackageChart(ctx context.Context, cosignKeyPath string) error {
 
 // PackageChartFromLocalFiles creates a chart archive from a path to a chart on the host os.
 func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath string) error {
+	l := logger.From(ctx)
+	l.Info("processing local helm chart",
+		"name", h.chart.Name,
+		"version", h.chart.Version,
+		"path", h.chart.LocalPath,
+	)
+
+	// Load and validate the chart
+	cl, _, err := h.loadAndValidateChart(h.chart.LocalPath)
+	if err != nil {
+		return err
+	}
+
+	// Handle the chart directory or tarball
+	var saved string
+	temp := filepath.Join(h.chartPath, "temp")
+	if _, ok := cl.(loader.DirLoader); ok {
+		err = h.buildChartDependencies(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to build dependencies for the chart: %w", err)
+		}
+
+		client := action.NewPackage()
+
+		client.Destination = temp
+		saved, err = client.Run(h.chart.LocalPath, nil)
+	} else {
+		saved = filepath.Join(temp, filepath.Base(h.chart.LocalPath))
+		err = helpers.CreatePathAndCopy(h.chart.LocalPath, saved)
+	}
+	defer func(l *slog.Logger) {
+		err := os.RemoveAll(temp)
+		if err != nil {
+			l.Error(err.Error())
+		}
+	}(l)
+
+	if err != nil {
+		return fmt.Errorf("unable to save the archive and create the package %s: %w", saved, err)
+	}
+
+	// Finalize the chart
+	err = h.finalizeChartPackage(ctx, saved, cosignKeyPath)
+	if err != nil {
+		return err
+	}
+
+	l.Debug("done processing local helm chart",
+		"name", h.chart.Name,
+		"version", h.chart.Version,
+		"path", h.chart.LocalPath,
+	)
+	return nil
+}
+
+// PackageChartFromLocalFilesSpinner creates a chart archive from a path to a chart on the host os. It displays a spinner.
+func (h *Helm) PackageChartFromLocalFilesSpinner(ctx context.Context, cosignKeyPath string) error {
 	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from %s", h.chart.Name, h.chart.Version, h.chart.LocalPath)
 	defer spinner.Stop()
 
@@ -81,7 +140,7 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 	var saved string
 	temp := filepath.Join(h.chartPath, "temp")
 	if _, ok := cl.(loader.DirLoader); ok {
-		err = h.buildChartDependencies()
+		err = h.buildChartDependencies(ctx)
 		if err != nil {
 			return fmt.Errorf("unable to build dependencies for the chart: %w", err)
 		}
@@ -113,6 +172,28 @@ func (h *Helm) PackageChartFromLocalFiles(ctx context.Context, cosignKeyPath str
 
 // PackageChartFromGit is a special implementation of chart archiving that supports the https://p1.dso.mil/#/products/big-bang/ model.
 func (h *Helm) PackageChartFromGit(ctx context.Context, cosignKeyPath string) error {
+	l := logger.From(ctx)
+	l.Info("processing helm chart", "name", h.chart.Name)
+
+	// Retrieve the repo containing the chart
+	gitPath, err := DownloadChartFromGitToTemp(ctx, h.chart.URL)
+	if err != nil {
+		return err
+	}
+	defer func(l *slog.Logger) {
+		if err := os.RemoveAll(gitPath); err != nil {
+			l.Error(err.Error())
+		}
+	}(l)
+
+	// Set the directory for the chart and package it
+	h.chart.LocalPath = filepath.Join(gitPath, h.chart.GitPath)
+	return h.PackageChartFromLocalFiles(ctx, cosignKeyPath)
+}
+
+// PackageChartFromGitSpinner is a special implementation of chart archiving that supports the https://p1.dso.mil/#/products/big-bang/ model.
+// It includes a CLI spinner.
+func (h *Helm) PackageChartFromGitSpinner(ctx context.Context, cosignKeyPath string) error {
 	spinner := message.NewProgressSpinner("Processing helm chart %s", h.chart.Name)
 	defer spinner.Stop()
 
@@ -130,6 +211,116 @@ func (h *Helm) PackageChartFromGit(ctx context.Context, cosignKeyPath string) er
 
 // DownloadPublishedChart loads a specific chart version from a remote repo.
 func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string) error {
+	l := logger.From(ctx)
+	l.Info("processing helm chart",
+		"name", h.chart.Name,
+		"version", h.chart.Version,
+		"repo", h.chart.URL,
+	)
+
+	// Set up the helm pull config
+	pull := action.NewPull()
+	pull.Settings = cli.New()
+
+	var (
+		regClient *registry.Client
+		chartURL  string
+		err       error
+	)
+	repoFile, err := repo.LoadFile(pull.Settings.RepositoryConfig)
+
+	// Not returning the error here since the repo file is only needed if we are pulling from a repo that requires authentication
+	if err != nil {
+		l.Debug("unable to load the repo file",
+			"path", pull.Settings.RepositoryConfig,
+			"error", err.Error(),
+		)
+	}
+
+	var username string
+	var password string
+
+	// Handle OCI registries
+	if registry.IsOCI(h.chart.URL) {
+		regClient, err = registry.NewClient(registry.ClientOptEnableCache(true))
+		if err != nil {
+			return fmt.Errorf("unable to create the new registry client: %w", err)
+		}
+		chartURL = h.chart.URL
+		// Explicitly set the pull version for OCI
+		pull.Version = h.chart.Version
+	} else {
+		chartName := h.chart.Name
+		if h.chart.RepoName != "" {
+			chartName = h.chart.RepoName
+		}
+
+		if repoFile != nil {
+			// TODO: @AustinAbro321 Currently this selects the last repo with the same url
+			// We should introduce a new field in zarf to allow users to specify the local repo they want
+			for _, r := range repoFile.Repositories {
+				if r.URL == h.chart.URL {
+					username = r.Username
+					password = r.Password
+				}
+			}
+		}
+
+		chartURL, err = repo.FindChartInAuthRepoURL(h.chart.URL, username, password, chartName, h.chart.Version, pull.CertFile, pull.KeyFile, pull.CaFile, getter.All(pull.Settings))
+		if err != nil {
+			return fmt.Errorf("unable to pull the helm chart: %w", err)
+		}
+	}
+
+	// Set up the chart chartDownloader
+	chartDownloader := downloader.ChartDownloader{
+		Out:            logger.DestinationDefault,
+		RegistryClient: regClient,
+		// TODO: Further research this with regular/OCI charts
+		Verify:  downloader.VerifyNever,
+		Getters: getter.All(pull.Settings),
+		Options: []getter.Option{
+			getter.WithInsecureSkipVerifyTLS(config.CommonOptions.InsecureSkipTLSVerify),
+			getter.WithBasicAuth(username, password),
+		},
+	}
+
+	// Download the file into a temp directory since we don't control what name helm creates here
+	temp := filepath.Join(h.chartPath, "temp")
+	if err = helpers.CreateDirectory(temp, helpers.ReadWriteExecuteUser); err != nil {
+		return fmt.Errorf("unable to create helm chart temp directory: %w", err)
+	}
+	defer func(l *slog.Logger) {
+		err := os.RemoveAll(temp)
+		if err != nil {
+			l.Error(err.Error())
+		}
+	}(l)
+
+	saved, _, err := chartDownloader.DownloadTo(chartURL, pull.Version, temp)
+	if err != nil {
+		return fmt.Errorf("unable to download the helm chart: %w", err)
+	}
+
+	// Validate the chart
+	_, _, err = h.loadAndValidateChart(saved)
+	if err != nil {
+		return err
+	}
+
+	// Finalize the chart
+	err = h.finalizeChartPackage(ctx, saved, cosignKeyPath)
+	if err != nil {
+		return err
+	}
+
+	l.Debug("done downloading helm chart")
+
+	return nil
+}
+
+// DownloadPublishedChartSpinner loads a specific chart version from a remote repo and renders it with a spinner.
+func (h *Helm) DownloadPublishedChartSpinner(ctx context.Context, cosignKeyPath string) error {
 	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from repo %s", h.chart.Name, h.chart.Version, h.chart.URL)
 	defer spinner.Stop()
 
@@ -273,7 +464,8 @@ func (h *Helm) packageValues(ctx context.Context, cosignKeyPath string) error {
 }
 
 // buildChartDependencies builds the helm chart dependencies
-func (h *Helm) buildChartDependencies() error {
+func (h *Helm) buildChartDependencies(ctx context.Context) error {
+	l := logger.From(ctx)
 	// Download and build the specified dependencies
 	regClient, err := registry.NewClient(registry.ClientOptEnableCache(true))
 	if err != nil {
@@ -287,7 +479,7 @@ func (h *Helm) buildChartDependencies() error {
 	}
 
 	man := &downloader.Manager{
-		Out:            &message.DebugWriter{},
+		Out:            logger.DestinationDefault,
 		ChartPath:      h.chart.LocalPath,
 		Getters:        getter.All(h.settings),
 		RegistryClient: regClient,
@@ -304,15 +496,14 @@ func (h *Helm) buildChartDependencies() error {
 	var notFoundErr *downloader.ErrRepoNotFound
 	if errors.As(err, &notFoundErr) {
 		// If we encounter a repo not found error point the user to `zarf tools helm repo add`
-		message.Warnf("%s. Please add the missing repo(s) via the following:", notFoundErr.Error())
+		l.Warn(fmt.Sprintf("%s. please add the missing repo(s) via the following: %s", notFoundErr.Error()))
 		for _, repository := range notFoundErr.Repos {
-			message.ZarfCommand(fmt.Sprintf("tools helm repo add <your-repo-name> %s", repository))
+			l.Warn(fmt.Sprintf("'$zarf tools helm repo add <your-repo-name> %s'", repository))
 		}
 		return err
 	}
 	if err != nil {
-		message.ZarfCommand("tools helm dependency build --verify")
-		message.Warnf("Unable to perform a rebuild of Helm dependencies: %s", err.Error())
+		l.Warn("unable to perform a rebuild of Helm dependencies, try running '$zarf tools helm dependency build --verify'", "error", err.Error())
 		return err
 	}
 	return nil

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"helm.sh/helm/v3/pkg/action"
@@ -164,6 +165,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 		"version", h.chart.Version,
 		"repo", h.chart.URL,
 	)
+	start := time.Now()
 	// TODO(mkcp): Remove message on logger release
 	spinner := message.NewProgressSpinner("Processing helm chart %s:%s from repo %s", h.chart.Name, h.chart.Version, h.chart.URL)
 	defer spinner.Stop()
@@ -267,7 +269,12 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 	}
 
 	spinner.Success()
-	l.Debug("done downloading helm chart")
+	l.Debug("done downloading helm chart",
+		"name", h.chart.Name,
+		"version", h.chart.Version,
+		"repo", h.chart.URL,
+		"duration", time.Since(start),
+	)
 	return nil
 }
 

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -93,10 +93,8 @@ func Pull(ctx context.Context, cfg PullConfig) (map[transform.Image]v1.Image, er
 	switch c := len(cfg.ImageList); {
 	case c > 15:
 		l.Info("fetching info for images. This step may take a couple of minutes to complete", "count", c, "destination", cfg.DestinationDirectory)
-		break
 	case c > 5:
 		l.Info("fetching info for images. This step may take several seconds to complete", "count", c, "destination", cfg.DestinationDirectory)
-		break
 	default:
 		l.Info("fetching info for images", "count", c, "destination", cfg.DestinationDirectory)
 	}

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -78,8 +78,7 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 	if err != nil {
 		// TODO(mkcp): Remove message on logger release
 		builder.spinner.Errorf(err, "Unable to generate the SBOM image list")
-		l.Error("unable to generate the SBOM image list", "error", err.Error())
-		return err
+		return fmt.Errorf("unable to generate the SBOM image list: %w", err)
 	}
 	builder.jsonList = json
 
@@ -96,28 +95,20 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 		if err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to load the image to generate an SBOM")
-			l.Error("unable to load the image to generate an SBOM", "error", err.Error())
-			return err
+			return fmt.Errorf("unable to load the image to generate an SBOM: %w", err)
 		}
 
 		jsonData, err := builder.createImageSBOM(ctx, img, refInfo.Reference)
 		if err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to create SBOM for image %s", refInfo.Reference)
-			l.Error("unable to create SBOM for image",
-				"reference", refInfo.Reference,
-				"error", err.Error(),
-			)
-			return err
+			return fmt.Errorf("unable to create SBOM for image=%s: %w", refInfo.Reference, err)
 		}
 
 		if err = builder.createSBOMViewerAsset(refInfo.Reference, jsonData); err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to create SBOM viewer for image %s", refInfo.Reference)
-			l.Error("unable to create SBOM viewer for image",
-				"reference", refInfo.Reference,
-			)
-			return err
+			return fmt.Errorf("unable to create SBOM viewer for image=%s: %w", refInfo.Reference, err)
 		}
 
 		currImage++
@@ -143,15 +134,13 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 		if err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to create SBOM for component %s", component)
-			l.Error("unable to create SBOM for component", "component", component, "error", err.Error())
-			return err
+			return fmt.Errorf("unable to create SBOM for component=%s: %w", component, err)
 		}
 
 		if err = builder.createSBOMViewerAsset(fmt.Sprintf("%s%s", componentPrefix, component), jsonData); err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to create SBOM viewer for component %s", component)
-			l.Error("unable to create SBOM for component", "component", component, "error", err.Error())
-			return err
+			return fmt.Errorf("unable to create SBOM for component=%s: %w", component, err)
 		}
 
 		currComponent++
@@ -162,16 +151,14 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 		if err := builder.createSBOMCompareAsset(); err != nil {
 			// TODO(mkcp): Remove message on logger release
 			builder.spinner.Errorf(err, "Unable to create SBOM compare tool")
-			l.Error("unable to create SBOM compare tool", "error", err.Error())
-			return err
+			return fmt.Errorf("unable to create SBOM compare tool: %w", err)
 		}
 	}
 
 	if err := paths.SBOMs.Archive(); err != nil {
 		// TODO(mkcp): Remove message on logger release
 		builder.spinner.Errorf(err, "Unable to archive SBOMs")
-		l.Error("unable to archive SBOMs", "error", err.Error())
-		return err
+		return fmt.Errorf("unable to archive SBOMs: %w", err)
 	}
 
 	// TODO(mkcp): Remove message on logger release

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -69,7 +69,6 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 		outputDir:  paths.SBOMs.Path,
 	}
 	defer builder.spinner.Stop()
-	l.Info("creating SBOMs for images and components with files", "images", imageCount, "components", componentCount)
 
 	// Ensure the sbom directory exists
 	_ = helpers.CreateDirectory(builder.outputDir, helpers.ReadWriteExecuteUser)
@@ -86,7 +85,7 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 
 	// Generate SBOM for each image
 	currImage := 1
-	l.Info("creating SBOMs for images", "images", imageCount)
+	l.Info("creating SBOMs for images", "count", imageCount)
 	for _, refInfo := range imageList {
 		// TODO(mkcp): Remove message on logger release
 		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, refInfo.Reference)
@@ -127,7 +126,7 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 	currComponent := 1
 
 	// Generate SBOM for each component
-	l.Info("creating SBOMs for components", "components", componentCount)
+	l.Info("creating SBOMs for components", "count", componentCount)
 	for component := range componentSBOMs {
 		// TODO(mkcp): Remove message on logger release
 		builder.spinner.Updatef("Creating component file SBOMs (%d of %d): %s", currComponent, componentCount, component)

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -17,6 +16,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -5,9 +5,10 @@
 package template
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
-	"log/slog"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -26,7 +27,7 @@ const (
 )
 
 // GetZarfVariableConfig gets a variable configuration specific to Zarf
-func GetZarfVariableConfig() *variables.VariableConfig {
+func GetZarfVariableConfig(ctx context.Context) *variables.VariableConfig {
 	prompt := func(variable v1alpha1.InteractiveVariable) (value string, err error) {
 		if config.CommonOptions.Confirm {
 			return variable.Default, nil
@@ -34,10 +35,7 @@ func GetZarfVariableConfig() *variables.VariableConfig {
 		return interactive.PromptVariable(variable)
 	}
 
-	return variables.New(
-		"zarf",
-		prompt,
-		slog.New(message.ZarfHandler{}))
+	return variables.New("zarf", prompt, logger.From(ctx))
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -11,11 +11,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/zarf-dev/zarf/src/pkg/logger"
-
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/mholt/archiver/v3"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
@@ -65,6 +64,8 @@ func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfCompone
 	}
 	if size > 0 {
 		tb := fmt.Sprintf("%s.tar", base)
+		// TODO(mkcp): Remove message on logger release
+		message.Debugf("Archiving %q", name)
 		l.Debug("archiving component", "name", name)
 		if err := helpers.CreateReproducibleTarballFromDir(base, name, tb); err != nil {
 			return err
@@ -74,6 +75,8 @@ func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfCompone
 		}
 		c.Tarballs[name] = tb
 	} else {
+		// TODO(mkcp): Remove message on logger release
+		message.Debugf("Component %q is empty, skipping archiving", name)
 		l.Debug("component is empty, skipping archiving", "name", name)
 	}
 

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -5,7 +5,9 @@
 package layout
 
 import (
+	"context"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -39,7 +41,8 @@ type Components struct {
 var ErrNotLoaded = fmt.Errorf("not loaded")
 
 // Archive archives a component.
-func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool) error {
+func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfComponent, cleanupTemp bool) error {
+	l := logger.From(ctx)
 	name := component.Name
 	if _, ok := c.Dirs[name]; !ok {
 		return &fs.PathError{
@@ -61,7 +64,7 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 	}
 	if size > 0 {
 		tb := fmt.Sprintf("%s.tar", base)
-		message.Debugf("Archiving %q", name)
+		l.Debug("archiving component", "name", name)
 		if err := helpers.CreateReproducibleTarballFromDir(base, name, tb); err != nil {
 			return err
 		}
@@ -70,7 +73,7 @@ func (c *Components) Archive(component v1alpha1.ZarfComponent, cleanupTemp bool)
 		}
 		c.Tarballs[name] = tb
 	} else {
-		message.Debugf("Component %q is empty, skipping archiving", name)
+		l.Debug("component is empty, skipping archiving", "name", name)
 	}
 
 	delete(c.Dirs, name)

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -7,10 +7,11 @@ package layout
 import (
 	"context"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/mholt/archiver/v3"

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -13,8 +13,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/zarf-dev/zarf/src/pkg/logger"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -22,6 +20,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/deprecated"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -230,6 +229,9 @@ func (pp *PackagePaths) GenerateChecksums() (string, error) {
 // ArchivePackage creates an archive for a Zarf package.
 func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball string, maxPackageSizeMB int) error {
 	l := logger.From(ctx)
+	// TODO(mkcp): Remove message on logger release
+	spinner := message.NewProgressSpinner("Writing %s to %s", pp.Base, destinationTarball)
+	defer spinner.Stop()
 	l.Info("archiving zarf package", "base", pp.Base, "destination", destinationTarball)
 
 	// Make the archive
@@ -237,13 +239,16 @@ func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball s
 	if err := archiver.Archive(archiveSrc, destinationTarball); err != nil {
 		return fmt.Errorf("unable to create package: %w", err)
 	}
+	// TODO(mkcp): Remove message on logger release
+	spinner.Updatef("Wrote %s to %s", pp.Base, destinationTarball)
 	l.Debug("ArchivePackage wrote", "base", pp.Base, "destination", destinationTarball)
 
 	fi, err := os.Stat(destinationTarball)
 	if err != nil {
 		return fmt.Errorf("unable to read the package archive: %w", err)
 	}
-
+	// TODO(mkcp): Remove message on logger release
+	spinner.Successf("Package saved to %q", destinationTarball)
 	l.Debug("package saved", "destination", destinationTarball)
 
 	// Convert Megabytes to bytes.
@@ -254,42 +259,8 @@ func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball s
 		if fi.Size()/int64(chunkSize) > 999 {
 			return fmt.Errorf("unable to split the package archive into multiple files: must be less than 1,000 files")
 		}
-		l.Info("package is larger than max, splitting into multiple files", "maxPackageSize", maxPackageSizeMB)
-		err := splitFile(destinationTarball, chunkSize)
-		if err != nil {
-			return fmt.Errorf("unable to split the package archive into multiple files: %w", err)
-		}
-	}
-	return nil
-}
-
-// ArchivePackageSpinner creates an archive for a Zarf package and handles displaying a spinner
-func (pp *PackagePaths) ArchivePackageSpinner(destinationTarball string, maxPackageSizeMB int) error {
-	spinner := message.NewProgressSpinner("Writing %s to %s", pp.Base, destinationTarball)
-	defer spinner.Stop()
-
-	// Make the archive
-	archiveSrc := []string{pp.Base + string(os.PathSeparator)}
-	if err := archiver.Archive(archiveSrc, destinationTarball); err != nil {
-		return fmt.Errorf("unable to create package: %w", err)
-	}
-	spinner.Updatef("Wrote %s to %s", pp.Base, destinationTarball)
-
-	fi, err := os.Stat(destinationTarball)
-	if err != nil {
-		return fmt.Errorf("unable to read the package archive: %w", err)
-	}
-	spinner.Successf("Package saved to %q", destinationTarball)
-
-	// Convert Megabytes to bytes.
-	chunkSize := maxPackageSizeMB * 1000 * 1000
-
-	// If a chunk size was specified and the package is larger than the chunk size, split it into chunks.
-	if maxPackageSizeMB > 0 && fi.Size() > int64(chunkSize) {
-		if fi.Size()/int64(chunkSize) > 999 {
-			return fmt.Errorf("unable to split the package archive into multiple files: must be less than 1,000 files")
-		}
 		message.Notef("Package is larger than %dMB, splitting into multiple files", maxPackageSizeMB)
+		l.Info("package is larger than max, splitting into multiple files", "maxPackageSize", maxPackageSizeMB)
 		err := splitFile(destinationTarball, chunkSize)
 		if err != nil {
 			return fmt.Errorf("unable to split the package archive into multiple files: %w", err)

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/defenseunicorns/pkg/helpers/v2"

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -176,11 +176,14 @@ func WithContext(ctx context.Context, logger *slog.Logger) context.Context {
 // From takes a context and reads out a *slog.Logger. If From does not find a value it will return a discarding logger
 // similar to log-format "none".
 func From(ctx context.Context) *slog.Logger {
+	// Check that we have a ctx
+	if ctx == nil {
+		return newEmpty()
+	}
 	// Grab value from key
 	log := ctx.Value(defaultCtxKey)
 	if log == nil {
-		h := slog.NewTextHandler(DestinationNone, &slog.HandlerOptions{})
-		return slog.New(h)
+		return newEmpty()
 	}
 
 	// Ensure our value is a *slog.Logger before we cast.
@@ -191,6 +194,12 @@ func From(ctx context.Context) *slog.Logger {
 		// Not reached
 		panic(fmt.Sprintf("unexpected value type on context key: %T", log))
 	}
+}
+
+// newDiscard returns a logger without any settings that goes to io.Discard
+func newEmpty() *slog.Logger {
+	h := slog.NewTextHandler(DestinationNone, &slog.HandlerOptions{})
+	return slog.New(h)
 }
 
 // Default retrieves a logger from the package default. This is intended as a fallback when a logger cannot easily be

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -7,12 +7,13 @@ package logger
 import (
 	"context"
 	"fmt"
-	"github.com/golang-cz/devslog"
 	"io"
 	"log/slog"
 	"os"
 	"strings"
 	"sync/atomic"
+
+	"github.com/golang-cz/devslog"
 )
 
 var defaultLogger atomic.Pointer[slog.Logger]
@@ -137,7 +138,10 @@ func New(cfg Config) (*slog.Logger, error) {
 		handler = slog.NewJSONHandler(cfg.Destination, &opts)
 	case FormatDev:
 		opts.AddSource = true
-		handler = devslog.NewHandler(DestinationDefault, &devslog.Options{HandlerOptions: &opts})
+		handler = devslog.NewHandler(DestinationDefault, &devslog.Options{
+			HandlerOptions:  &opts,
+			NewLineAfterLog: true,
+		})
 	case FormatNone:
 		handler = slog.NewTextHandler(DestinationNone, &slog.HandlerOptions{})
 	// Format not found, let's error out

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -7,6 +7,7 @@ package logger
 import (
 	"context"
 	"fmt"
+	"github.com/golang-cz/devslog"
 	"io"
 	"log/slog"
 	"os"
@@ -76,6 +77,8 @@ var (
 	FormatText Format = "text"
 	// FormatJSON uses the standard slog JSONHandler
 	FormatJSON Format = "json"
+	// FormatDev uses a verbose and prettyprinting devslog handler
+	FormatDev Format = "dev"
 	// FormatNone sends log writes to DestinationNone / io.Discard
 	FormatNone Format = "none"
 )
@@ -132,11 +135,9 @@ func New(cfg Config) (*slog.Logger, error) {
 		handler = slog.NewTextHandler(cfg.Destination, &opts)
 	case FormatJSON:
 		handler = slog.NewJSONHandler(cfg.Destination, &opts)
-	// TODO(mkcp): Add dev format
-	// case FormatDev:
-	// 	handler = slog.NewTextHandler(DestinationNone, &slog.HandlerOptions{
-	//		AddSource: true,
-	//	})
+	case FormatDev:
+		opts.AddSource = true
+		handler = devslog.NewHandler(DestinationDefault, &devslog.Options{HandlerOptions: &opts})
 	case FormatNone:
 		handler = slog.NewTextHandler(DestinationNone, &slog.HandlerOptions{})
 	// Format not found, let's error out

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -89,9 +89,6 @@ var (
 	FormatNone Format = "none"
 )
 
-// More printers would be great, like dev format https://github.com/golang-cz/devslog
-// and a pretty console slog https://github.com/phsym/console-slog
-
 // Destination declares an io.Writer to send logs to.
 type Destination io.Writer
 

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -67,8 +67,7 @@ func ParseLevel(s string) (Level, error) {
 
 // Format declares the kind of logging handler to use.
 // NOTE(mkcp): An empty Format defaults to "none" while logger is being worked on, but this is intended to use "text"
-//
-//	on release.
+// on release.
 type Format string
 
 // ToLower takes a Format string and converts it to lowercase for case-agnostic validation. Users shouldn't have to care

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -7,6 +7,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"regexp"
 	"runtime"
 	"strings"
@@ -23,7 +24,7 @@ import (
 
 // Run runs all provided actions.
 func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
-	// FIXME(mkcp): Interactive
+	// TODO(mkcp): Remove interactive on logger release
 	if variableConfig == nil {
 		variableConfig = template.GetZarfVariableConfig(ctx)
 	}
@@ -37,12 +38,13 @@ func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, a
 }
 
 // Run commands that a component has provided.
-// TODO(mkcp): Migrate actions to logger
 func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
 	var cmdEscaped string
 	var out string
 	var err error
 	cmd := action.Cmd
+	l := logger.From(ctx)
+	start := time.Now()
 
 	// If the action is a wait, convert it to a command.
 	if action.Wait != nil {
@@ -78,14 +80,17 @@ func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefau
 		cmdEscaped = helpers.Truncate(cmd, 60, false)
 	}
 
+	// TODO(mkcp): Remove message on logger release
 	spinner := message.NewProgressSpinner("Running \"%s\"", cmdEscaped)
 	// Persist the spinner output so it doesn't get overwritten by the command output.
 	spinner.EnablePreserveWrites()
+	l.Info("running command", "cmd", cmdEscaped)
 
 	actionDefaults := actionGetCfg(ctx, defaultCfg, action, variableConfig.GetAllTemplates())
 
 	if cmd, err = actionCmdMutation(ctx, cmd, actionDefaults.Shell); err != nil {
 		spinner.Errorf(err, "Error mutating command: %s", cmdEscaped)
+		l.Error("error mutating command", "cmd", cmdEscaped, "err", err.Error())
 	}
 
 	duration := time.Duration(actionDefaults.MaxTotalSeconds) * time.Second
@@ -115,9 +120,12 @@ retryCmd:
 			// If the action has a wait, change the spinner message to reflect that on success.
 			if action.Wait != nil {
 				spinner.Successf("Wait for \"%s\" succeeded", cmdEscaped)
-			} else {
-				spinner.Successf("Completed \"%s\"", cmdEscaped)
+				l.Debug("wait for action succeeded", "cmd", cmdEscaped, "duration", time.Since(start))
+				return nil
 			}
+
+			spinner.Successf("Completed \"%s\"", cmdEscaped)
+			l.Debug("completed action", "cmd", cmdEscaped, "duration", time.Since(start))
 
 			// If the command ran successfully, continue to the next action.
 			return nil
@@ -126,6 +134,7 @@ retryCmd:
 		// If no timeout is set, run the command and return or continue retrying.
 		if actionDefaults.MaxTotalSeconds < 1 {
 			spinner.Updatef("Waiting for \"%s\" (no timeout)", cmdEscaped)
+			l.Info("waiting for action (no timeout)", "cmd", cmdEscaped)
 			//TODO (schristoff): Make it so tryCmd can take a normal ctx
 			if err := tryCmd(context.Background()); err != nil {
 				continue retryCmd
@@ -136,6 +145,7 @@ retryCmd:
 
 		// Run the command on repeat until success or timeout.
 		spinner.Updatef("Waiting for \"%s\" (timeout: %ds)", cmdEscaped, actionDefaults.MaxTotalSeconds)
+		l.Info("waiting for action", "cmd", cmdEscaped, "timeout", actionDefaults.MaxTotalSeconds)
 		select {
 		// On timeout break the loop to abort.
 		case <-timeout:
@@ -204,7 +214,7 @@ func convertWaitToCmd(_ context.Context, wait v1alpha1.ZarfComponentActionWait, 
 }
 
 // Perform some basic string mutations to make commands more useful.
-func actionCmdMutation(_ context.Context, cmd string, shellPref v1alpha1.Shell) (string, error) {
+func actionCmdMutation(ctx context.Context, cmd string, shellPref v1alpha1.Shell) (string, error) {
 	zarfCommand, err := utils.GetFinalExecutableCommand()
 	if err != nil {
 		return cmd, err
@@ -226,7 +236,9 @@ func actionCmdMutation(_ context.Context, cmd string, shellPref v1alpha1.Shell) 
 		get, err := helpers.MatchRegex(envVarRegex, cmd)
 		if err == nil {
 			newCmd := strings.ReplaceAll(cmd, get("envIndicator"), fmt.Sprintf("$Env:%s", get("varName")))
+			// TODO(mkcp): Remove message on logger release
 			message.Debugf("Converted command \"%s\" to \"%s\" t", cmd, newCmd)
+			logger.From(ctx).Debug("converted command", "cmd", cmd, "newCmd", newCmd)
 			cmd = newCmd
 		}
 	}
@@ -275,9 +287,12 @@ func actionGetCfg(_ context.Context, cfg v1alpha1.ZarfComponentActionDefaults, a
 }
 
 func actionRun(ctx context.Context, cfg v1alpha1.ZarfComponentActionDefaults, cmd string, shellPref v1alpha1.Shell, spinner *message.Spinner) (string, error) {
+	l := logger.From(ctx)
 	shell, shellArgs := exec.GetOSShell(shellPref)
 
+	// TODO(mkcp): Remove message on logger release
 	message.Debugf("Running command in %s: %s", shell, cmd)
+	l.Debug("running command", "shell", shell, "cmd", cmd)
 
 	execCfg := exec.Config{
 		Env: cfg.Env,
@@ -292,7 +307,9 @@ func actionRun(ctx context.Context, cfg v1alpha1.ZarfComponentActionDefaults, cm
 	out, errOut, err := exec.CmdWithContext(ctx, execCfg, shell, append(shellArgs, cmd)...)
 	// Dump final complete output (respect mute to prevent sensitive values from hitting the logs).
 	if !cfg.Mute {
+		// TODO(mkcp): Remove message on logger release
 		message.Debug(cmd, out, errOut)
+		l.Debug("action complete", "cmd", cmd, "out", out, "errOut", errOut)
 	}
 
 	return out, err

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -7,6 +7,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"regexp"
 	"runtime"
 	"strings"
@@ -24,7 +25,7 @@ import (
 // Run runs all provided actions.
 func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
 	if variableConfig == nil {
-		variableConfig = template.GetZarfVariableConfig()
+		variableConfig = template.GetZarfVariableConfig(ctx)
 	}
 
 	for _, a := range actions {
@@ -37,13 +38,13 @@ func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, a
 
 // Run commands that a component has provided.
 func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
-	var (
-		cmdEscaped string
-		out        string
-		err        error
+	var cmdEscaped string
+	var out string
+	var err error
+	l := logger.From(ctx)
+	cmd := action.Cmd
 
-		cmd = action.Cmd
-	)
+	l.Error("TODO: Refactor runAction")
 
 	// If the action is a wait, convert it to a command.
 	if action.Wait != nil {

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -7,7 +7,6 @@ package actions
 import (
 	"context"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"regexp"
 	"runtime"
 	"strings"
@@ -24,6 +23,7 @@ import (
 
 // Run runs all provided actions.
 func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
+	// FIXME(mkcp): Interactive
 	if variableConfig == nil {
 		variableConfig = template.GetZarfVariableConfig(ctx)
 	}
@@ -37,14 +37,12 @@ func Run(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, a
 }
 
 // Run commands that a component has provided.
+// TODO(mkcp): Migrate actions to logger
 func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig) error {
 	var cmdEscaped string
 	var out string
 	var err error
-	l := logger.From(ctx)
 	cmd := action.Cmd
-
-	l.Error("TODO: Refactor runAction")
 
 	// If the action is a wait, convert it to a command.
 	if action.Wait != nil {

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"os"
 	"slices"
 	"strings"
@@ -30,6 +31,7 @@ import (
 
 // Packager is the main struct for managing packages.
 type Packager struct {
+	ctx            context.Context
 	cfg            *types.PackagerConfig
 	variableConfig *variables.VariableConfig
 	state          *types.ZarfState
@@ -65,34 +67,39 @@ func WithTemp(base string) Modifier {
 	}
 }
 
+// WithContext sets the packager's context
+func WithContext(ctx context.Context) Modifier {
+	return func(p *Packager) {
+		p.ctx = ctx
+	}
+}
+
 /*
 New creates a new package instance with the provided config.
 
 Note: This function creates a tmp directory that should be cleaned up with p.ClearTempPaths().
 */
 func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
+	var err error
 	if cfg == nil {
 		return nil, fmt.Errorf("no config provided")
 	}
 
-	var (
-		err  error
-		pkgr = &Packager{
-			cfg: cfg,
-		}
-	)
-
-	pkgr.variableConfig = template.GetZarfVariableConfig()
-
-	if config.CommonOptions.TempDirectory != "" {
-		// If the cache directory is within the temp directory, warn the user
-		if strings.HasPrefix(config.CommonOptions.CachePath, config.CommonOptions.TempDirectory) {
-			message.Warnf("The cache directory (%q) is within the temp directory (%q) and will be removed when the temp directory is cleaned up", config.CommonOptions.CachePath, config.CommonOptions.TempDirectory)
-		}
-	}
-
+	pkgr := &Packager{cfg: cfg}
 	for _, mod := range mods {
 		mod(pkgr)
+	}
+
+	l := logger.From(pkgr.ctx)
+
+	pkgr.variableConfig = template.GetZarfVariableConfig(pkgr.ctx)
+	cacheDir := config.CommonOptions.CachePath
+	tmpDir := config.CommonOptions.TempDirectory
+	if config.CommonOptions.TempDirectory != "" {
+		// If the cache directory is within the temp directory, warn the user
+		if strings.HasPrefix(cacheDir, tmpDir) {
+			l.Warn("the cache directory is within the temp directory and will be removed when the temp directory is cleaned up", "cacheDir", cacheDir, "tmpDir", tmpDir)
+		}
 	}
 
 	// Fill the source if it wasn't provided - note source can be nil if the package is being created
@@ -109,7 +116,7 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create package temp paths: %w", err)
 		}
-		message.Debug("Using temporary directory:", dir)
+		l.Debug("using temporary directory", "tmpDir", dir)
 		pkgr.layout = layout.New(dir)
 	}
 
@@ -119,8 +126,16 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 // ClearTempPaths removes the temp directory and any files within it.
 func (p *Packager) ClearTempPaths() {
 	// Remove the temp directory, but don't throw an error if it fails
-	_ = os.RemoveAll(p.layout.Base)
-	_ = os.RemoveAll(layout.SBOMDir)
+	l := logger.From(p.ctx)
+	l.Debug("clearing temp paths")
+	err := os.RemoveAll(p.layout.Base)
+	if err != nil {
+		l.Error(err.Error(), "basePath", p.layout.Base)
+	}
+	err2 := os.RemoveAll(layout.SBOMDir)
+	if err2 != nil {
+		l.Error(err2.Error(), "SBOMDir", layout.SBOMDir)
+	}
 }
 
 // GetVariableConfig returns the variable configuration for the packager.

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -125,7 +125,7 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 
 // ClearTempPaths removes the temp directory and any files within it.
 func (p *Packager) ClearTempPaths() {
-	// Remove the temp directory, but don't throw an error if it fails
+	// Remove the temp directory
 	l := logger.From(p.ctx)
 	l.Debug("clearing temp paths")
 	err := os.RemoveAll(p.layout.Base)

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -131,7 +131,10 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 func (p *Packager) ClearTempPaths() {
 	// Remove the temp directory
 	l := logger.From(p.ctx)
-	l.Debug("clearing temp paths")
+	l.Debug("clearing temp paths",
+		"basePath", p.layout.Base,
+		"SBOMDir", layout.SBOMDir,
+	)
 	err := os.RemoveAll(p.layout.Base)
 	if err != nil {
 		l.Error(err.Error(), "basePath", p.layout.Base)

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -98,6 +98,8 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 	if config.CommonOptions.TempDirectory != "" {
 		// If the cache directory is within the temp directory, warn the user
 		if strings.HasPrefix(cacheDir, tmpDir) {
+			// TODO(mkcp): Remove message on logger release
+			message.Warnf("The cache directory (%q) is within the temp directory (%q) and will be removed when the temp directory is cleaned up", config.CommonOptions.CachePath, config.CommonOptions.TempDirectory)
 			l.Warn("the cache directory is within the temp directory and will be removed when the temp directory is cleaned up", "cacheDir", cacheDir, "tmpDir", tmpDir)
 		}
 	}
@@ -116,6 +118,8 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create package temp paths: %w", err)
 		}
+		// TODO(mkcp): Remove message on logger release
+		message.Debug("Using temporary directory:", dir)
 		l.Debug("using temporary directory", "tmpDir", dir)
 		pkgr.layout = layout.New(dir)
 	}

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -75,7 +75,7 @@ func (p *Packager) Create(ctx context.Context) error {
 	if err := pc.Assemble(ctx, p.layout, pkg.Components, pkg.Metadata.Architecture); err != nil {
 		return err
 	}
-	l.Debug("done package assembly", "kind", pkg.Kind, "duration", time.Since(aStart))
+	l.Debug("done assembling package", "kind", pkg.Kind, "duration", time.Since(aStart))
 
 	// cd back for output
 	if err := os.Chdir(cwd); err != nil {

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -56,8 +56,8 @@ func (p *Packager) Create(ctx context.Context) error {
 	}
 	//  Store on packager config
 	p.cfg.Pkg = pkg
-	if len(warnings) > 0 {
-		l.Warn("warnings found when loading package definition", "warnings", warnings)
+	for _, warning := range warnings {
+		l.Warn(warning)
 	}
 	l.Info("package loaded",
 		"kind", pkg.Kind,

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -5,47 +5,53 @@
 package packager
 
 import (
-	"context"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"os"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 )
 
 // Create generates a Zarf package tarball for a given PackageConfig and optional base directory.
-func (p *Packager) Create(ctx context.Context) error {
+func (p *Packager) Create() error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
+	l := logger.From(p.ctx)
 
-	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
-		return fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
+	// Set basedir
+	baseDir := p.cfg.CreateOpts.BaseDir
+	if err := os.Chdir(baseDir); err != nil {
+		return fmt.Errorf("unable to access directory %q: %w", baseDir, err)
 	}
+	l.Info("using build directory", "baseDir", baseDir)
 
-	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
-
+	// Setup package creator
 	pc := creator.NewPackageCreator(p.cfg.CreateOpts, cwd)
-
 	if err := helpers.CreatePathAndCopy(layout.ZarfYAML, p.layout.ZarfYAML); err != nil {
 		return err
 	}
 
-	pkg, warnings, err := pc.LoadPackageDefinition(ctx, p.layout)
+	// Load package def and store on packager config
+	// TODO(mkcp): Migrate to logger
+	pkg, warnings, err := pc.LoadPackageDefinition(p.ctx, p.layout)
 	if err != nil {
 		return err
 	}
 	p.cfg.Pkg = pkg
 
+	// TODO(mkcp): Interactive isolate with slog
+	//			   Maybe just comment this out point at
 	if !p.confirmAction(config.ZarfCreateStage, warnings, nil) {
 		return fmt.Errorf("package creation canceled")
 	}
 
-	if err := pc.Assemble(ctx, p.layout, p.cfg.Pkg.Components, p.cfg.Pkg.Metadata.Architecture); err != nil {
+	// TODO(mkcp): Migrate to logger
+	if err := pc.Assemble(p.ctx, p.layout, p.cfg.Pkg.Components, p.cfg.Pkg.Metadata.Architecture); err != nil {
 		return err
 	}
 
@@ -54,5 +60,9 @@ func (p *Packager) Create(ctx context.Context) error {
 		return err
 	}
 
-	return pc.Output(ctx, p.layout, &p.cfg.Pkg)
+	// TODO(mkcp): migrate pc.Output to logger
+	if err = pc.Output(p.ctx, p.layout, &p.cfg.Pkg); err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -5,9 +5,12 @@
 package packager
 
 import (
+	"context"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"os"
+
+	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
@@ -15,8 +18,8 @@ import (
 )
 
 // Create generates a Zarf package tarball for a given PackageConfig and optional base directory.
-func (p *Packager) Create() error {
-	l := logger.From(p.ctx)
+func (p *Packager) Create(ctx context.Context) error {
+	l := logger.From(ctx)
 	l.Info("starting package create")
 	// Begin setup
 	cwd, err := os.Getwd()
@@ -57,10 +60,10 @@ func (p *Packager) Create() error {
 		"description", pkg.Metadata.Description,
 	)
 
-	// TODO(mkcp): Interactive
-	// if !p.confirmAction(config.ZarfCreateStage, warnings, nil) {
-	// 	return fmt.Errorf("package creation canceled")
-	// }
+	// TODO(mkcp): Remove interactive when
+	if !p.confirmAction(config.ZarfCreateStage, warnings, nil) {
+		return fmt.Errorf("package creation canceled")
+	}
 
 	l.Debug("starting package assembly", "kind", pkg.Kind)
 	// TODO(mkcp): Migrate to logger

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -480,7 +480,7 @@ func (pc *PackageCreator) addComponent(ctx context.Context, component v1alpha1.Z
 			}
 		}
 		spinner.Success()
-		l.Debug("done loading data injections", "duration", injectStart)
+		l.Debug("done loading data injections", "duration", time.Since(injectStart))
 	}
 
 	// Process k8s manifests
@@ -536,7 +536,7 @@ func (pc *PackageCreator) addComponent(ctx context.Context, component v1alpha1.Z
 			}
 		}
 		spinner.Success()
-		l.Debug("done building k8s manifests",
+		l.Debug("done processing k8s manifests",
 			"component", component.Name,
 			"duration", time.Since(manifestStart))
 	}

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -96,9 +96,9 @@ func (sc *SkeletonCreator) Assemble(_ context.Context, dst *layout.PackagePaths,
 // - writes the loaded zarf.yaml to disk
 //
 // - signs the package
-func (sc *SkeletonCreator) Output(_ context.Context, dst *layout.PackagePaths, pkg *v1alpha1.ZarfPackage) (err error) {
+func (sc *SkeletonCreator) Output(ctx context.Context, dst *layout.PackagePaths, pkg *v1alpha1.ZarfPackage) (err error) {
 	for _, component := range pkg.Components {
-		if err := dst.Components.Archive(component, false); err != nil {
+		if err := dst.Components.Archive(ctx, component, false); err != nil {
 			return err
 		}
 	}

--- a/src/pkg/utils/network.go
+++ b/src/pkg/utils/network.go
@@ -125,8 +125,7 @@ func httpGetFile(ctx context.Context, url string, destinationFile *os.File) (err
 	// Copy response body to file
 	if _, err = io.Copy(destinationFile, reader); err != nil {
 		progressBar.Failf("Unable to save the file %s: %s", destinationFile.Name(), err.Error())
-		l.Error("unable to save the file %s: %s", destinationFile.Name(), err.Error())
-		return err
+		return fmt.Errorf("unable to save the file %s: %w", destinationFile.Name(), err)
 	}
 	progressBar.Successf("Downloaded %s", url)
 	l.Debug("download successful", "url", url, "size", resp.ContentLength, "duration", time.Since(start))

--- a/src/pkg/utils/network.go
+++ b/src/pkg/utils/network.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"io"
 	"net/http"
 	"net/url"
@@ -16,9 +15,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config/lang"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 func parseChecksum(src string) (string, string, error) {
@@ -93,36 +93,6 @@ func DownloadToFile(ctx context.Context, src, dst, cosignKeyPath string) (err er
 		}
 	}
 
-	return nil
-}
-
-func httpGetFileProgress(url string, destinationFile *os.File) (err error) {
-	// Get the data
-	resp, err := http.Get(url)
-	if err != nil {
-		return fmt.Errorf("unable to download the file %s", url)
-	}
-	defer func() {
-		err2 := resp.Body.Close()
-		err = errors.Join(err, err2)
-	}()
-
-	// Check server response
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad HTTP status: %s", resp.Status)
-	}
-
-	// Writer the body to file
-	title := fmt.Sprintf("Downloading %s", filepath.Base(url))
-	progressBar := message.NewProgressBar(resp.ContentLength, title)
-
-	if _, err = io.Copy(destinationFile, io.TeeReader(resp.Body, progressBar)); err != nil {
-		progressBar.Failf("Unable to save the file %s: %s", destinationFile.Name(), err.Error())
-		return err
-	}
-
-	title = fmt.Sprintf("Downloaded %s", url)
-	progressBar.Successf("%s", title)
 	return nil
 }
 

--- a/src/types/packager.go
+++ b/src/types/packager.go
@@ -13,6 +13,7 @@ import (
 // PackagerConfig is the main struct that the packager uses to hold high-level options.
 type PackagerConfig struct {
 	// Context provides deadlines, cancellations, and values throughout the API.
+	// NOTE(mkcp): Storing ctx on structs is not recommended, but this is intended as a temporary workaround.
 	Context context.Context
 
 	// CreateOpts tracks the user-defined options used to create the package

--- a/src/types/packager.go
+++ b/src/types/packager.go
@@ -4,10 +4,17 @@
 // Package types contains all the types used by Zarf.
 package types
 
-import "github.com/zarf-dev/zarf/src/api/v1alpha1"
+import (
+	"context"
+
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
 
 // PackagerConfig is the main struct that the packager uses to hold high-level options.
 type PackagerConfig struct {
+	// Context provides deadlines, cancellations, and values throughout the API.
+	Context context.Context
+
 	// CreateOpts tracks the user-defined options used to create the package
 	CreateOpts ZarfCreateOptions
 


### PR DESCRIPTION
## Description
This PR:
- Adds contributor QOL improvements:
  - `sloglint`
  -  New formats: `devslog` (via `--log-format="dev"`) and `console-slog` (via `--log-format="console"`)  
- adds WithContext to `packager.Packager` and stores a context on it so we can log in its New() which has some load bearing logging. This is intended as a workaround.
- Makes an empty log format, the default, `--log-format=""`  == "none. So slog must be directly enabled.
- Adds setup functions for both message and logger in `cmd/root` and feature flagging for disabling message and using logger.
  - When a log-format is provided, `setupMessage()` ensures PTerm output is discarded and sets the values for `--no-progress`, and `--confirm`.
- Adds structured logging outputs throughout `zarf package create`
- Marks TODOS on message calls in Create stating they're deprecated

## Related Issue
Relates to #2576

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
