### PR TITLE
chore: fix spelling in cosign error message

### DIFF
--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -317,7 +317,7 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 					spinner.Updatef("Looking up cosign artifacts for discovered images (%d/%d)", idx+1, len(imagesMap[component.Name]))
 					cosignArtifacts, err := utils.GetCosignArtifacts(image)
 					if err != nil {
-						return nil, fmt.Errorf("could not lookup the cosing artifacts for image %s: %w", image, err)
+						return nil, fmt.Errorf("could not lookup the cosign artifacts for image %s: %w", image, err)
 					}
 					cosignArtifactList = append(cosignArtifactList, cosignArtifacts...)
 				}


### PR DESCRIPTION
## Description

Minor spelling mistake in Error message when `zarf dev find-images` fails to pull cosign artifacts.

(note, there isn't a test case to check for this error and I haven't added one)

## Related Issue

no related issue.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
