### PR TITLE
Refactor templating e2e test to not depend on CLI output

### DIFF
--- a/src/test/e2e/04_create_templating_test.go
+++ b/src/test/e2e/04_create_templating_test.go
@@ -5,53 +5,42 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	layout2 "github.com/zarf-dev/zarf/src/internal/packager2/layout"
 )
 
 func TestCreateTemplating(t *testing.T) {
 	t.Log("E2E: Create Templating")
 
-	// run `zarf package create` with a specified image cache location
-	tmpdir := t.TempDir()
-	decompressPath := filepath.Join(tmpdir, ".package-decompressed")
-	sbomPath := filepath.Join(tmpdir, ".sbom-location")
-
-	pkgName := fmt.Sprintf("zarf-package-templating-%s.tar.zst", e2e.Arch)
+	sbomPath := t.TempDir()
+	outPath := t.TempDir()
+	templatingPath := filepath.Join(outPath, fmt.Sprintf("zarf-package-templating-%s.tar.zst", e2e.Arch))
+	fileFoldersPath := filepath.Join(outPath, fmt.Sprintf("zarf-package-file-folders-templating-sbom-%s.tar.zst", e2e.Arch))
 
 	// Test that not specifying a package variable results in an error
-	_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/04-templating", "--confirm")
+	_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/04-templating", "-o", outPath, "--confirm")
 	require.Error(t, err)
 
 	// Test a simple package variable example with `--set` (will fail to pull an image if this is not set correctly)
-	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "src/test/packages/04-templating", "--set", "PODINFO_VERSION=6.4.0", "--confirm")
-	require.NoError(t, err, stdOut, stdErr)
-
-	stdOut, stdErr, err = e2e.Zarf(t, "t", "archiver", "decompress", pkgName, decompressPath, "--unarchive-all")
-	require.NoError(t, err, stdOut, stdErr)
-
-	// Check that the constant in the zarf.yaml is replaced correctly
-	builtConfig, err := os.ReadFile(decompressPath + "/zarf.yaml")
+	_, _, err = e2e.Zarf(t, "package", "create", "src/test/packages/04-templating", "-o", outPath, "--set", "PODINFO_VERSION=6.4.0", "--confirm")
 	require.NoError(t, err)
-	require.Contains(t, string(builtConfig), "name: PODINFO_VERSION\n  value: 6.4.0")
+
+	pkgLayout, err := layout2.LoadFromTar(context.Background(), templatingPath, layout2.PackageLayoutOptions{})
+	require.NoError(t, err)
+	expectedConstant := v1alpha1.Constant{Name: "PODINFO_VERSION", Value: "6.4.0", Pattern: "^[\\w\\-\\.]+$"}
+	require.Contains(t, pkgLayout.Pkg.Constants, expectedConstant)
 
 	// Test that files and file folders template and handle SBOMs correctly
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "create", "src/test/packages/04-file-folders-templating-sbom/", "--sbom-out", sbomPath, "--confirm")
-	require.NoError(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "Creating SBOMs for 0 images and 2 components with files.")
-
-	fileFoldersPkgName := fmt.Sprintf("zarf-package-file-folders-templating-sbom-%s.tar.zst", e2e.Arch)
-
-	// Deploy the package and look for the variables in the output
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", fileFoldersPkgName, "--set", "DOGGO=doggy", "--set", "KITTEH=meowza", "--set", "PANDA=pandemonium", "--confirm")
-	require.NoError(t, err, stdOut, stdErr)
-	require.Contains(t, stdErr, "A doggy barks!")
-	require.Contains(t, stdErr, "  - meowza")
-	require.Contains(t, stdErr, "# Total pandemonium")
+	_, _, err = e2e.Zarf(t, "package", "create", "src/test/packages/04-file-folders-templating-sbom/", "-o", outPath, "--sbom-out", sbomPath, "--confirm")
+	require.NoError(t, err)
 
 	// Ensure that the `requirements.txt` files are discovered correctly
 	require.FileExists(t, filepath.Join(sbomPath, "file-folders-templating-sbom", "compare.html"))
@@ -65,5 +54,20 @@ func TestCreateTemplating(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(filesJSON), "pandas")
 
-	e2e.CleanFiles(t, pkgName, fileFoldersPkgName)
+	// Deploy the package and look for the variables in the output
+	workingPath := t.TempDir()
+	_, _, err = e2e.ZarfInDir(t, workingPath, "package", "deploy", fileFoldersPath, "--set", "DOGGO=doggy", "--set", "KITTEH=meowza", "--set", "PANDA=pandemonium", "--confirm")
+	require.NoError(t, err)
+
+	b, err := os.ReadFile(filepath.Join(workingPath, "temp", "requirements.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "# Total pandemonium\npandas==1.5.0\n", string(b))
+
+	b, err = os.ReadFile(filepath.Join(workingPath, "temp", "include-files", "simple.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "A doggy barks!\n", string(b))
+
+	b, err = os.ReadFile(filepath.Join(workingPath, "temp", "include-files", "something.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "something:\n  - a\n  - meowza\n  - meows\n", string(b))
 }

--- a/src/test/packages/04-file-folders-templating-sbom/zarf.yaml
+++ b/src/test/packages/04-file-folders-templating-sbom/zarf.yaml
@@ -18,7 +18,6 @@ components:
         after:
           - cmd: cat temp/include-files/simple.txt
           - cmd: cat temp/include-files/something.yaml
-          - cmd: rm -r temp
   - name: files
     required: true
     files:
@@ -28,4 +27,3 @@ components:
       onDeploy:
         after:
           - cmd: cat temp/requirements.txt
-          - cmd: rm -r temp


### PR DESCRIPTION
## Description

This change removes any use of CLI output for templating e2e tests. This enables the refactoring of log output without breaking the e2e tests.

## Related Issue

Relates to #2576 
Relates to #2969

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
