### PR TITLE
chore: feature flag to enable switching between logger for libaries

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -95,6 +95,8 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	var disableMessage bool
 	if LogFormat != "" {
 		disableMessage = true
+		ctx := logger.WithLoggingEnabled(ctx, true)
+		cmd.SetContext(ctx)
 	}
 	err = setupMessage(messageCfg{
 		level:           LogLevelCLI,

--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -144,6 +144,7 @@ func Pull(ctx context.Context, cfg PullConfig) (map[transform.Image]v1.Image, er
 
 					// TODO(mkcp): Remove message on logger release
 					message.Warnf("Falling back to local 'docker', failed to find the manifest on a remote: %s", err.Error())
+					l.Warn("Falling back to local 'docker', failed to find the manifest on a remote", "error", err.Error())
 
 					// Attempt to connect to the local docker daemon.
 					cli, err := client.NewClientWithOpts(client.FromEnv)

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -36,13 +36,10 @@ func GetZarfVariableConfig(ctx context.Context) *variables.VariableConfig {
 		return interactive.PromptVariable(variable)
 	}
 
-	var l *slog.Logger
 	if logger.Enabled(ctx) {
-		l = logger.From(ctx)
-	} else {
-		l = slog.New(message.ZarfHandler{})
+		return variables.New("zarf", prompt, logger.From(ctx))
 	}
-	return variables.New("zarf", prompt, l)
+	return variables.New("zarf", prompt, slog.New(message.ZarfHandler{}))
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -35,7 +36,13 @@ func GetZarfVariableConfig(ctx context.Context) *variables.VariableConfig {
 		return interactive.PromptVariable(variable)
 	}
 
-	return variables.New("zarf", prompt, logger.From(ctx))
+	var l *slog.Logger
+	if logger.Enabled(ctx) {
+		l = logger.From(ctx)
+	} else {
+		l = slog.New(message.ZarfHandler{})
+	}
+	return variables.New("zarf", prompt, l)
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -170,6 +170,29 @@ func WithContext(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, defaultCtxKey, logger)
 }
 
+type ctxKeyEnabled struct{}
+
+var defaultCtxKeyEnabled = ctxKeyEnabled{}
+
+// WithLoggingEnabled allows stores a value to determine whether or not slog logging is enabled
+func WithLoggingEnabled(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, defaultCtxKeyEnabled, enabled)
+}
+
+// Enabled returns true if slog logging is enabled
+func Enabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled := ctx.Value(defaultCtxKeyEnabled)
+	switch v := enabled.(type) {
+	case bool:
+		return v
+	default:
+		return false
+	}
+}
+
 // From takes a context and reads out a *slog.Logger. If From does not find a value it will return a discarding logger
 // similar to log-format "none".
 func From(ctx context.Context) *slog.Logger {

--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -170,6 +170,7 @@ func WithContext(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, defaultCtxKey, logger)
 }
 
+// TODO (@austinabro321) once we switch over to the new logger completely the enabled key & logic should be deleted
 type ctxKeyEnabled struct{}
 
 var defaultCtxKeyEnabled = ctxKeyEnabled{}

--- a/src/pkg/logger/logger_test.go
+++ b/src/pkg/logger/logger_test.go
@@ -224,4 +224,8 @@ func TestContext(t *testing.T) {
 		res := From(ctx)
 		require.NotNil(t, res)
 	})
+	t.Run("can add a flag to the context to determine if enabled", func(t *testing.T) {
+		ctx := WithLoggingEnabled(context.Background(), true)
+		require.True(t, Enabled(ctx))
+	})
 }


### PR DESCRIPTION
## Description

When a library takes in a logger we currently have a way for it to respect the logging feature flag as we move to slog. This PR adds functionality to enable that

## Related Issue

Relates to #2576 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
