### PR TITLE
chore: add logger to zarf destroy

### DIFF
--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -213,12 +214,13 @@ func (h *Helm) TemplateChart(ctx context.Context) (manifest string, chartValues 
 }
 
 // RemoveChart removes a chart from the cluster.
-func (h *Helm) RemoveChart(namespace string, name string, spinner *message.Spinner) error {
+func (h *Helm) RemoveChart(ctx context.Context, namespace string, name string, spinner *message.Spinner) error {
 	// Establish a new actionConfig for the namespace.
 	_ = h.createActionConfig(namespace, spinner)
 	// Perform the uninstall.
 	response, err := h.uninstallChart(name)
 	message.Debug(response)
+	logger.From(ctx).Debug("chart uninstalled", "response", response)
 	return err
 }
 

--- a/src/internal/packager/helm/destroy.go
+++ b/src/internal/packager/helm/destroy.go
@@ -5,17 +5,23 @@
 package helm
 
 import (
+	"context"
 	"regexp"
+	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"helm.sh/helm/v3/pkg/action"
 )
 
 // Destroy removes ZarfInitPackage charts from the cluster and optionally all Zarf-installed charts.
-func Destroy(purgeAllZarfInstallations bool) {
+func Destroy(ctx context.Context, purgeAllZarfInstallations bool) {
+	start := time.Now()
+	l := logger.From(ctx)
 	spinner := message.NewProgressSpinner("Removing Zarf-installed charts")
 	defer spinner.Stop()
+	l.Info("removing Zarf-installed charts")
 
 	h := Helm{}
 
@@ -24,6 +30,7 @@ func Destroy(purgeAllZarfInstallations bool) {
 	if err != nil {
 		// Don't fatal since this is a removal action
 		spinner.Errorf(err, "Unable to initialize the K8s client")
+		l.Error("unable to initialize the K8s client", "error", err.Error())
 		return
 	}
 
@@ -42,6 +49,7 @@ func Destroy(purgeAllZarfInstallations bool) {
 	if err != nil {
 		// Don't fatal since this is a removal action
 		spinner.Errorf(err, "Unable to get the list of installed charts")
+		l.Error("unable to get the list of installed charts", "error", err.Error())
 	}
 
 	// Iterate over all releases
@@ -53,12 +61,15 @@ func Destroy(purgeAllZarfInstallations bool) {
 		// Filter on zarf releases
 		if zarfPrefix.MatchString(release.Name) {
 			spinner.Updatef("Uninstalling helm chart %s/%s", release.Namespace, release.Name)
-			if err = h.RemoveChart(release.Namespace, release.Name, spinner); err != nil {
+			l.Info("uninstalling helm chart", "namespace", release.Namespace, "name", release.Name)
+			if err = h.RemoveChart(ctx, release.Namespace, release.Name, spinner); err != nil {
 				// Don't fatal since this is a removal action
 				spinner.Errorf(err, "Unable to uninstall the chart")
+				l.Error("unable to uninstall the chart", "error", err.Error())
 			}
 		}
 	}
 
 	spinner.Success()
+	l.Debug("done uninstalling charts", "duration", time.Since(start))
 }

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -41,6 +41,7 @@ type Cluster struct {
 
 // NewClusterWithWait creates a new Cluster instance and waits for the given timeout for the cluster to be ready.
 func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
+	start := time.Now()
 	l := logger.From(ctx)
 	spinner := message.NewProgressSpinner("Waiting for cluster connection")
 	defer spinner.Stop()
@@ -74,6 +75,7 @@ func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
 	}
 
 	spinner.Success()
+	l.Debug("done waiting for cluster, connected", "duration", time.Since(start))
 
 	return c, nil
 }

--- a/src/pkg/cluster/namespace.go
+++ b/src/pkg/cluster/namespace.go
@@ -14,13 +14,17 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // DeleteZarfNamespace deletes the Zarf namespace from the connected cluster.
 func (c *Cluster) DeleteZarfNamespace(ctx context.Context) error {
+	start := time.Now()
+	l := logger.From(ctx)
 	spinner := message.NewProgressSpinner("Deleting the zarf namespace from this cluster")
 	defer spinner.Stop()
+	l.Info("deleting the zarf namespace from this cluster")
 
 	err := c.Clientset.CoreV1().Namespaces().Delete(ctx, ZarfNamespaceName, metav1.DeleteOptions{})
 	if kerrors.IsNotFound(err) {
@@ -42,6 +46,8 @@ func (c *Cluster) DeleteZarfNamespace(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	l.Debug("done deleting the zarf namespace from this cluster", "duration", time.Since(start))
 	return nil
 }
 

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/types"
@@ -205,7 +206,7 @@ func (c *Cluster) LoadZarfState(ctx context.Context) (*types.ZarfState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 	return state, nil
 }
 
@@ -230,10 +231,11 @@ func (c *Cluster) sanitizeZarfState(state *types.ZarfState) *types.ZarfState {
 	return state
 }
 
-func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
+func (c *Cluster) debugPrintZarfState(ctx context.Context, state *types.ZarfState) {
 	if state == nil {
 		return
 	}
+
 	// this is a shallow copy, nested pointers WILL NOT be copied
 	oldState := *state
 	sanitized := c.sanitizeZarfState(&oldState)
@@ -242,11 +244,13 @@ func (c *Cluster) debugPrintZarfState(state *types.ZarfState) {
 		return
 	}
 	message.Debugf("ZarfState - %s", string(b))
+
+	logger.From(ctx).Debug("cluster.debugPrintZarfState", "state", sanitized)
 }
 
 // SaveZarfState takes a given state and persists it to the Zarf/zarf-state secret.
 func (c *Cluster) SaveZarfState(ctx context.Context, state *types.ZarfState) error {
-	c.debugPrintZarfState(state)
+	c.debugPrintZarfState(ctx, state)
 
 	data, err := json.Marshal(&state)
 	if err != nil {

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -185,7 +185,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 		spinner.Updatef("Uninstalling chart '%s' from the '%s' component", chart.ChartName, deployedComponent.Name)
 
 		helmCfg := helm.NewClusterOnly(p.cfg, p.variableConfig, p.state, p.cluster)
-		if err := helmCfg.RemoveChart(chart.Namespace, chart.ChartName, spinner); err != nil {
+		if err := helmCfg.RemoveChart(ctx, chart.Namespace, chart.ChartName, spinner); err != nil {
 			if !errors.Is(err, driver.ErrReleaseNotFound) {
 				onFailure()
 				return deployedPackage, fmt.Errorf("unable to uninstall the helm chart %s in the namespace %s: %w",


### PR DESCRIPTION
## Description
Adds logger to `zarf destroy` and the code paths it depends on. As a side note, this cmd is very much in need a refactor and de-nesting. 

## Related Issue
Relates to #2576 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
