### PR TITLE
feat: expose Helm skip schema validation option in Zarf schema

### DIFF
--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -157,7 +157,7 @@ type ZarfChart struct {
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 	// [alpha] List of variables to set in the Helm chart.
 	Variables []ZarfChartVariable `json:"variables,omitempty"`
-	// Whether or not to validate the schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet.
+	// Whether or not to validate the values.yaml schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet.
 	SchemaValidation *bool `json:"schemaValidation,omitempty"`
 }
 

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -161,8 +161,8 @@ type ZarfChart struct {
 	SchemaValidation *bool `json:"schemaValidation,omitempty"`
 }
 
-// RunSchemaValidation returns if Helm schema validation should be run or not
-func (zc ZarfChart) RunSchemaValidation() bool {
+// ShouldRunSchemaValidation returns if Helm schema validation should be run or not
+func (zc ZarfChart) ShouldRunSchemaValidation() bool {
 	if zc.SchemaValidation != nil {
 		return *zc.SchemaValidation
 	}

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -157,6 +157,8 @@ type ZarfChart struct {
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 	// [alpha] List of variables to set in the Helm chart.
 	Variables []ZarfChartVariable `json:"variables,omitempty"`
+	// Prevents Helm from validating the values against the JSON schema. Useful in the airgap when the JSON Schema references the internet.
+	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
 }
 
 // ZarfChartVariable represents a variable that can be set for a Helm chart overrides.

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -157,8 +157,16 @@ type ZarfChart struct {
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 	// [alpha] List of variables to set in the Helm chart.
 	Variables []ZarfChartVariable `json:"variables,omitempty"`
-	// Prevents Helm from validating the values against the JSON schema. Necessary in the air-gap when the JSON Schema references the resources on the internet.
-	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
+	// Whether or not to validate the schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet.
+	SchemaValidation *bool `json:"schemaValidation,omitempty"`
+}
+
+// RunSchemaValidation returns if Helm schema validation should be run or not
+func (zc ZarfChart) RunSchemaValidation() bool {
+	if zc.SchemaValidation != nil {
+		return *zc.SchemaValidation
+	}
+	return true
 }
 
 // ZarfChartVariable represents a variable that can be set for a Helm chart overrides.

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -157,7 +157,7 @@ type ZarfChart struct {
 	ValuesFiles []string `json:"valuesFiles,omitempty"`
 	// [alpha] List of variables to set in the Helm chart.
 	Variables []ZarfChartVariable `json:"variables,omitempty"`
-	// Prevents Helm from validating the values against the JSON schema. Useful in the airgap when the JSON Schema references the internet.
+	// Prevents Helm from validating the values against the JSON schema. Necessary in the air-gap when the JSON Schema references the resources on the internet.
 	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
 }
 

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -294,7 +294,7 @@ func (h *Helm) installChart(ctx context.Context, postRender *renderer) (*release
 	// Must be unique per-namespace and < 53 characters. @todo: restrict helm loadedChart name to this.
 	client.ReleaseName = h.chart.ReleaseName
 
-	client.SkipSchemaValidation = h.chart.SkipSchemaValidation
+	client.SkipSchemaValidation = !h.chart.RunSchemaValidation()
 
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace
@@ -329,7 +329,7 @@ func (h *Helm) upgradeChart(ctx context.Context, lastRelease *release.Release, p
 
 	client.SkipCRDs = true
 
-	client.SkipSchemaValidation = h.chart.SkipSchemaValidation
+	client.SkipSchemaValidation = !h.chart.RunSchemaValidation()
 
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -294,6 +294,8 @@ func (h *Helm) installChart(ctx context.Context, postRender *renderer) (*release
 	// Must be unique per-namespace and < 53 characters. @todo: restrict helm loadedChart name to this.
 	client.ReleaseName = h.chart.ReleaseName
 
+	client.SkipSchemaValidation = h.chart.SkipSchemaValidation
+
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace
 
@@ -326,6 +328,8 @@ func (h *Helm) upgradeChart(ctx context.Context, lastRelease *release.Release, p
 	client.Wait = !h.chart.NoWait
 
 	client.SkipCRDs = true
+
+	client.SkipSchemaValidation = h.chart.SkipSchemaValidation
 
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -294,7 +294,7 @@ func (h *Helm) installChart(ctx context.Context, postRender *renderer) (*release
 	// Must be unique per-namespace and < 53 characters. @todo: restrict helm loadedChart name to this.
 	client.ReleaseName = h.chart.ReleaseName
 
-	client.SkipSchemaValidation = !h.chart.RunSchemaValidation()
+	client.SkipSchemaValidation = !h.chart.ShouldRunSchemaValidation()
 
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace
@@ -329,7 +329,7 @@ func (h *Helm) upgradeChart(ctx context.Context, lastRelease *release.Release, p
 
 	client.SkipCRDs = true
 
-	client.SkipSchemaValidation = !h.chart.RunSchemaValidation()
+	client.SkipSchemaValidation = !h.chart.ShouldRunSchemaValidation()
 
 	// Namespace must be specified.
 	client.Namespace = h.chart.Namespace

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -378,9 +378,9 @@
           "type": "array",
           "description": "[alpha] List of variables to set in the Helm chart."
         },
-        "skipSchemaValidation": {
+        "schemaValidation": {
           "type": "boolean",
-          "description": "Prevents Helm from validating the values against the JSON schema. Necessary in the air-gap when the JSON Schema references the resources on the internet."
+          "description": "Whether or not to validate the schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet."
         }
       },
       "additionalProperties": false,

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -380,7 +380,7 @@
         },
         "schemaValidation": {
           "type": "boolean",
-          "description": "Whether or not to validate the schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet."
+          "description": "Whether or not to validate the values.yaml schema, defaults to true. Necessary in the air-gap when the JSON Schema references resources on the internet."
         }
       },
       "additionalProperties": false,

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -377,6 +377,10 @@
           },
           "type": "array",
           "description": "[alpha] List of variables to set in the Helm chart."
+        },
+        "skipSchemaValidation": {
+          "type": "boolean",
+          "description": "Prevents Helm from validating the values file against it's JSON schema. Useful in the airgap when the JSON Schema references the internet."
         }
       },
       "additionalProperties": false,

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -380,7 +380,7 @@
         },
         "skipSchemaValidation": {
           "type": "boolean",
-          "description": "Prevents Helm from validating the values file against it's JSON schema. Useful in the airgap when the JSON Schema references the internet."
+          "description": "Prevents Helm from validating the values against the JSON schema. Useful in the airgap when the JSON Schema references the internet."
         }
       },
       "additionalProperties": false,

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -380,7 +380,7 @@
         },
         "skipSchemaValidation": {
           "type": "boolean",
-          "description": "Prevents Helm from validating the values against the JSON schema. Useful in the airgap when the JSON Schema references the internet."
+          "description": "Prevents Helm from validating the values against the JSON schema. Necessary in the air-gap when the JSON Schema references the resources on the internet."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Description

This introduces the `SchemaValidation` in the Zarf Helm Chart schema. This is important for the airgap use case. If a helm values schema reaches out to the internet it will break in the airgap

## Related Issue

Fixes #3123
Fixes #3118

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
