### PR TITLE
fix: maintain agent mutate even when already mutated

### DIFF
--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -44,6 +45,48 @@ func TestArgoAppWebhook(t *testing.T) {
 		{
 			name: "should be mutated",
 			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "https://diff-git-server.com/peanuts"},
+					Sources: []ApplicationSource{
+						{
+							RepoURL: "https://diff-git-server.com/cashews",
+						},
+						{
+							RepoURL: "https://diff-git-server.com/almonds",
+						},
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"https://git-server.com/a-push-user/peanuts-3883081014",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/0/repoURL",
+					"https://git-server.com/a-push-user/cashews-580170494",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/1/repoURL",
+					"https://git-server.com/a-push-user/almonds-640159520",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should mutate even if agent patched",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"zarf-agent": "patched",
+					},
+				},
 				Spec: ApplicationSpec{
 					Source: &ApplicationSource{RepoURL: "https://diff-git-server.com/peanuts"},
 					Sources: []ApplicationSource{

--- a/src/internal/agent/hooks/argocd-repository_test.go
+++ b/src/internal/agent/hooks/argocd-repository_test.go
@@ -84,6 +84,44 @@ func TestArgoRepoWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should mutate even if agent patched",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent": "patched",
+					},
+					Name:      "argo-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url": []byte("https://diff-git-server.com/podinfo"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("https://git-server.com/a-push-user/podinfo-1868163476")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(state.GitServer.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(state.GitServer.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "matching hostname on update should stay the same, but secret should be added",
 			admissionReq: createArgoRepoAdmissionRequest(t, v1.Update, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/src/internal/agent/hooks/flux-gitrepo_test.go
+++ b/src/internal/agent/hooks/flux-gitrepo_test.go
@@ -74,6 +74,37 @@ func TestFluxMutationWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should mutate even if agent patched",
+			admissionReq: createFluxGitRepoAdmissionRequest(t, v1.Create, &flux.GitRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mutate-this",
+					Labels: map[string]string{
+						"zarf-agent": "patched",
+					},
+				},
+				Spec: flux.GitRepositorySpec{
+					URL: "https://github.com/stefanprodan/podinfo.git",
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/url",
+					"https://git-server.com/a-push-user/podinfo-1646971829.git",
+				),
+				operations.AddPatchOperation(
+					"/spec/secretRef",
+					fluxmeta.LocalObjectReference{Name: config.ZarfGitServerSecretName},
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "should not mutate invalid git url",
 			admissionReq: createFluxGitRepoAdmissionRequest(t, v1.Update, &flux.GitRepository{
 				ObjectMeta: metav1.ObjectMeta{

--- a/src/internal/agent/hooks/flux-helmrepo.go
+++ b/src/internal/agent/hooks/flux-helmrepo.go
@@ -47,13 +47,6 @@ func mutateHelmRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluste
 		return &operations.Result{Allowed: true}, nil
 	}
 
-	if src.Labels != nil && src.Labels["zarf-agent"] == "patched" {
-		return &operations.Result{
-			Allowed:  true,
-			PatchOps: nil,
-		}, nil
-	}
-
 	zarfState, err := cluster.LoadZarfState(ctx)
 	if err != nil {
 		return nil, err

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -50,13 +50,6 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		message.Warnf(lang.AgentWarnSemVerRef, src.Spec.Reference.SemVer)
 	}
 
-	if src.Labels != nil && src.Labels["zarf-agent"] == "patched" {
-		return &operations.Result{
-			Allowed:  true,
-			PatchOps: []operations.PatchOperation{},
-		}, nil
-	}
-
 	zarfState, err := cluster.LoadZarfState(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Removes the checks on the agent webhook for effecting already patched gitops related resources:

- `fluxcd-oci-repo`
- `fluxcd-helm-repo`
- `fluxcd-git-repo`
- `argocd-repository`
- `argocd-application`

The reasoning for removing the this check is that during the regular lifecycle of gitops tools is that they will re-apply the manifests to make sure the cluster reflects the correct state; this means that fluxcd will override the mutated repos to point to something outside of `zarf`'s control, e.i. clear web endpoints that might not be accessible.

## Note

So I did not add tests for removing the check on pods... My logic is that pods are static through their lifecycle once they start, so `zarf` would only need to mutate them once.

## Related Issue

Fixes #3146

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
