### PR TITLE
feat: use console-slogger as text handler

### DIFF
--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -134,7 +134,10 @@ func New(cfg Config) (*slog.Logger, error) {
 
 	switch cfg.Format.ToLower() {
 	case FormatText:
-		handler = slog.NewTextHandler(cfg.Destination, &opts)
+		handler = console.NewHandler(cfg.Destination, &console.HandlerOptions{
+			Level:   slog.Level(cfg.Level),
+			NoColor: true,
+		})
 	case FormatJSON:
 		handler = slog.NewJSONHandler(cfg.Destination, &opts)
 	case FormatConsole:


### PR DESCRIPTION
## Description
The team has discussed the default logging experience in depth and arrived at using console-slog as the intended default "text" handler. No color for now though, but maybe in the future. (delete "console" if we add color to text)

## Related Issue
Relates to #2576 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
