### PR TITLE
chore: make the nightly tests run only in `zarf-dev/zarf`

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   ecr-nightly-test:
+    if: ${{ github.repository == 'zarf-dev/zarf' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-eks.yml
+++ b/.github/workflows/nightly-eks.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   eks-nightly-test:
+    if: ${{ github.repository == 'zarf-dev/zarf' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

Since individual forks are unlikely to have all of the secrets necessary for running these two jobs, it would probably make sense to only limit them to be run in the `zarf-dev/zarf` repository.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
