### PR TITLE
Upgrading to k8s v1.29 for distro k3s package

### DIFF
--- a/packages/distros/k3s/zarf.yaml
+++ b/packages/distros/k3s/zarf.yaml
@@ -31,8 +31,8 @@ components:
         symlinks:
           - /etc/systemd/system/multi-user.target.wants/k3s.service
       # Include the actual K3s binary
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.4+k3s2/k3s
-        shasum: 9014535a4cd20c788282d60398a06279983562093455b53ab76701539ce67acf
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.29.10+k3s1/k3s
+        shasum: 5b82d6964ae1720a2cd5a5198a7732636ae6076321d497f5533502e2e488f53f
         target: /usr/sbin/k3s
         executable: true
         # K3s magic provides these tools when symlinking
@@ -41,8 +41,8 @@ components:
           - /usr/sbin/ctr
           - /usr/sbin/crictl
       # Transfer the K3s images for containerd to pick them up
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.4+k3s2/k3s-airgap-images-amd64.tar.zst
-        shasum: bc4d05bad56a583c80ff443d60e8277a136cc4357dc8527702d38b5cca28880d
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.29.10+k3s1/k3s-airgap-images-amd64.tar.zst
+        shasum: 09e644d380d27a845f5c8028066271cd712d0ac6fcfc283ba44ec532adb2ca6f
         target: /var/lib/rancher/k3s/agent/images/k3s.tar.zst
     actions:
       onDeploy:
@@ -97,8 +97,8 @@ components:
         symlinks:
           - /etc/systemd/system/multi-user.target.wants/k3s.service
       # Include the actual K3s binary
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.4+k3s2/k3s-arm64
-        shasum: 1ae72ca06d3302f3e86ef92e6e8f84e14a084da69564e87d6e2e75f62e72388d
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.29.10+k3s1/k3s-arm64
+        shasum: 0eccc3ce9bbf40b88c897f6a6293dd6aa97ee59b6f2f69c30e2811608e607757
         target: /usr/sbin/k3s
         executable: true
         # K3s magic provides these tools when symlinking
@@ -107,8 +107,8 @@ components:
           - /usr/sbin/ctr
           - /usr/sbin/crictl
       # Transfer the K3s images for containerd to pick them up
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.4+k3s2/k3s-airgap-images-arm64.tar.zst
-        shasum: 50621ae1391aec7fc66ca66a46a0e9fd48ce373a58073000efdc278233adc64b
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.29.10+k3s1/k3s-airgap-images-arm64.tar.zst
+        shasum: 18ab57f41a1c497283a2723a27c3ca5b64975c2873e4f0ed0646753fb2bdc60f
         target: /var/lib/rancher/k3s/agent/images/k3s.tar.zst
     actions:
       onDeploy:

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -85,7 +85,7 @@ func TestZarfInit(t *testing.T) {
 		// make sure that we upgraded `k3s` correctly and are running the correct version - this should match that found in `packages/distros/k3s`
 		kubeletVersion, _, err := e2e.Kubectl(t, "get", "nodes", "-o", "jsonpath={.items[0].status.nodeInfo.kubeletVersion}")
 		require.NoError(t, err)
-		require.Contains(t, kubeletVersion, "v1.28.4+k3s2")
+		require.Contains(t, kubeletVersion, "v1.29.10+k3s1")
 	}
 
 	// Check that the registry is running on the correct NodePort


### PR DESCRIPTION
## Description

This upgrades to use K3S 1.29, which is a strict requirement of Big Bang >= 2.39.0

## Related Issue

N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
