### PR TITLE
Set Helm max history to limit secret creation

### DIFF
--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -34,6 +34,9 @@ import (
 	"github.com/zarf-dev/zarf/src/types"
 )
 
+// Use same default as Helm CLI does.
+const maxHelmHistory = 10
+
 // InstallOrUpgradeChart performs a helm install of the given chart.
 func (h *Helm) InstallOrUpgradeChart(ctx context.Context) (types.ConnectStrings, string, error) {
 	l := logger.From(ctx)
@@ -349,6 +352,8 @@ func (h *Helm) upgradeChart(ctx context.Context, lastRelease *release.Release, p
 	// Post-processing our manifests to apply vars and run zarf helm logic in cluster
 	client.PostRenderer = postRender
 
+	client.MaxHistory = maxHelmHistory
+
 	loadedChart, chartValues, err := h.loadChartData()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load chart data: %w", err)
@@ -365,6 +370,7 @@ func (h *Helm) rollbackChart(name string, version int) error {
 	client.Wait = true
 	client.Timeout = h.timeout
 	client.Version = version
+	client.MaxHistory = maxHelmHistory
 	return client.Run(name)
 }
 

--- a/src/test/packages/25-helm-release-history/chart/Chart.yaml
+++ b/src/test/packages/25-helm-release-history/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/src/test/packages/25-helm-release-history/chart/templates/configmap.yaml
+++ b/src/test/packages/25-helm-release-history/chart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  foo: bar

--- a/src/test/packages/25-helm-release-history/zarf.yaml
+++ b/src/test/packages/25-helm-release-history/zarf.yaml
@@ -1,0 +1,12 @@
+kind: ZarfPackageConfig
+metadata:
+  name: helm-release-history
+  version: 0.0.1
+components:
+  - name: helm-release-history
+    required: true
+    charts:
+      - name: chart
+        namespace: helm-release-history
+        version: v0.1.0
+        localPath: chart


### PR DESCRIPTION
## Description

This change limits the Helm history secrets to 5 in an attempt to stop massive amounts of secrets to be created over a long time.

## Related Issue

Fixes #3242

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
