### PR TITLE
feat(src/internal/package2/pull.go): Check if package exists for OCI layers

### DIFF
--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -32,6 +33,7 @@ import (
 // TODO: write unit tests
 func CheckIfPackageExists(ctx context.Context, src string, dir string) (bool, error) {
 	newRemote, err := zoci.NewRemote(ctx, src, oci.PlatformForArch(config.GetArch()))
+
 	if err != nil {
 		return false, err
 	}
@@ -76,6 +78,8 @@ func CheckIfPackageExists(ctx context.Context, src string, dir string) (bool, er
 // Pull fetches the Zarf package from the given sources.
 func Pull(ctx context.Context, src, dir, shasum string, filter filters.ComponentFilterStrategy) error {
 	u, err := url.Parse(src)
+	l := logger.From(ctx)
+
 	if err != nil {
 		return err
 	}
@@ -100,6 +104,7 @@ func Pull(ctx context.Context, src, dir, shasum string, filter filters.Component
 			return err
 		}
 		if localPkgExists {
+			l.Info("package already exists locally in directory", "Directory", dir)
 			return nil
 		}
 		_, err = pullOCI(ctx, src, tmpPath, shasum, filter)


### PR DESCRIPTION
## Description
This PR's goal is to check if we have already have an OCI image locally _before_ we pull it again. This should help ensure we don't re-pull each time.  Tests will be done after the upcoming updates to publish are done.


This is the output comparing the execution time from a repeat run (removed other bits of the logging just to denote the pieces that mattered):

<details>
<summary>Output from the script:</summary>


**First Run:**
```bash

└> TIMEFMT=$'%*E total elapsed time\n%*U user CPU time\n%*S system CPU time'
time ./build/zarf-mac-apple package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 --key=https://zarf.dev/cosign.pub -a arm64

5.109 total elapsed time
0.207 user CPU time
0.274 system CPU time
```

**Repeat Run:**
```
└> TIMEFMT=$'%*E total elapsed time\n%*U user CPU time\n%*S system CPU time'
time ./build/zarf-mac-apple package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 --key=https://zarf.dev/cosign.pub -a arm64

0.866 total elapsed time
0.105 user CPU time
0.072 system CPU time
```

</details>

## Related Issue

Fixes #2780 
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
