### PR TITLE
Group k8s dependabot dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Description

This change groups k8s dependency updates into a single PR to make merging updates faster and easier.

## Related Issue

N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
