### PR TITLE
feat: allow init packages to be explicitly versioned

### DIFF
--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -302,7 +302,7 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 	hostname, _ := os.Hostname()
 	pkg.Build.Terminal = hostname
 
-	if pkg.IsInitConfig() {
+	if pkg.IsInitConfig() && pkg.Metadata.Version == "" {
 		pkg.Metadata.Version = config.CLIVersion
 	}
 


### PR DESCRIPTION
## Description

In #3169 we allowed Zarf init packages to be explicitly versioned rather than always being the binary version. This behavior was not brought over to packager2

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
