### PR TITLE
chore: remove deprecated get git password command

### DIFF
--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -17,7 +17,7 @@ Evaluates components in a Zarf file to identify images specified in their helm c
 Components that have repos that host helm charts can be processed by providing the --repo-chart-path.
 
 ```
-zarf dev find-images [ PACKAGE ] [flags]
+zarf dev find-images [ DIRECTORY ] [flags]
 ```
 
 ### Options

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -237,7 +237,7 @@ var devSha256SumCmd = &cobra.Command{
 }
 
 var devFindImagesCmd = &cobra.Command{
-	Use:     "find-images [ PACKAGE ]",
+	Use:     "find-images [ DIRECTORY ]",
 	Aliases: []string{"f"},
 	Args:    cobra.MaximumNArgs(1),
 	Short:   lang.CmdDevFindImagesShort,

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -46,17 +46,6 @@ const (
 	agentKey        = "agent"
 )
 
-var deprecatedGetGitCredsCmd = &cobra.Command{
-	Use:    "get-git-password",
-	Hidden: true,
-	Short:  lang.CmdToolsGetGitPasswdShort,
-	Long:   lang.CmdToolsGetGitPasswdLong,
-	Run: func(_ *cobra.Command, _ []string) {
-		message.Warn(lang.CmdToolsGetGitPasswdDeprecation)
-		getCredsCmd.Run(getCredsCmd, []string{"git"})
-	},
-}
-
 var getCredsCmd = &cobra.Command{
 	Use:     "get-creds",
 	Short:   lang.CmdToolsGetCredsShort,
@@ -416,7 +405,6 @@ var generateKeyCmd = &cobra.Command{
 func init() {
 	v := common.InitViper()
 
-	toolsCmd.AddCommand(deprecatedGetGitCredsCmd)
 	toolsCmd.AddCommand(getCredsCmd)
 
 	toolsCmd.AddCommand(updateCredsCmd)


### PR DESCRIPTION
## Description

This removes the deprecated get git password command which has been deprecated for over a year. It was replaced by `zarf tools get-creds git`. This command was already broken because when the get-creds command was updated to use the `RunE` function, `get-git-password` was not updated so it panic'd

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
