### PR TITLE
Add --update flag to zarf dev find-images

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -363,6 +363,9 @@ func init() {
 
 	devFindImagesCmd.Flags().StringVar(&pkgConfig.FindImagesOpts.RegistryURL, "registry-url", defaultRegistry, lang.CmdDevFlagRegistry)
 
+	// update zarf.yaml with found image in place
+	devFindImagesCmd.Flags().BoolVar(&pkgConfig.FindImagesOpts.UpdatePackageDefinition, "update", false, lang.CmdDevFlagFindImagesUpdate)
+
 	devLintCmd.Flags().StringToStringVar(&pkgConfig.CreateOpts.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdPackageCreateFlagSet)
 	devLintCmd.Flags().StringVarP(&pkgConfig.CreateOpts.Flavor, "flavor", "f", v.GetString(common.VPkgCreateFlavor), lang.CmdPackageCreateFlagFlavor)
 	devTransformGitLinksCmd.Flags().StringVar(&pkgConfig.InitOpts.GitServer.PushUsername, "git-account", types.ZarfGitPushUser, lang.CmdDevFlagGitAccount)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -353,6 +353,7 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 	CmdDevFlagRegistry             = "Override the ###ZARF_REGISTRY### value"
 	CmdDevFlagFindImagesWhy        = "Prints the source manifest for the specified image"
 	CmdDevFlagFindImagesSkipCosign = "Skip searching for cosign artifacts related to discovered images"
+	CmdDevFlagFindImagesUpdate     = "Updates zarf.yaml with found images"
 
 	CmdDevLintShort = "Lints the given package for valid schema and recommended practices"
 	CmdDevLintLong  = "Verifies the package schema, checks if any variables won't be evaluated, and checks for unpinned images/repos/files"

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -68,6 +68,8 @@ type ZarfFindImagesOptions struct {
 	Why string
 	// Optionally skip lookup of cosign artifacts when finding images
 	SkipCosign bool
+	// Update the images in zarf.yaml in place
+	UpdatePackageDefinition bool
 }
 
 // ZarfDeployOptions tracks the user-defined preferences during a package deploy.


### PR DESCRIPTION
## Description

Currently, `zarf dev find-images` just lists the changes needed to be made to `zarf.yaml`. This PR adds `--update` flag
that actually executes the change: it replaces the `images:` list in each of the components with the result of `find-images`. Care is taken to operate on full YAML AST, so that no whitespace or comments in `zarf.yaml` are affected. 

Example:
```
(sie-cluster.anduril.dev) amichalik@amichalik-5680-ubuntu:~/work/zarf/examples/argocd$ git status .
On branch amichalik/find-images-update
Your branch is up to date with 'xyzzyz/amichalik/find-images-update'.

nothing to commit, working tree clean
(sie-cluster.anduril.dev) amichalik@amichalik-5680-ubuntu:~/work/zarf/examples/argocd$ ../../build/zarf dev find-images --update 

<snip...>

components:

  - name: argocd-helm-chart
    images:
      - docker.io/library/redis:7.0.15-alpine
      - quay.io/argoproj/argocd:v2.9.6
      # Cosign artifacts for images - argocd - argocd-helm-chart
      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig
      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.att

(sie-cluster.anduril.dev) amichalik@amichalik-5680-ubuntu:~/work/zarf/examples/argocd$ git status .
On branch amichalik/find-images-update
Your branch is up to date with 'xyzzyz/amichalik/find-images-update'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   zarf.yaml

no changes added to commit (use "git add" and/or "git commit -a")
(sie-cluster.anduril.dev) amichalik@amichalik-5680-ubuntu:~/work/zarf/examples/argocd$ git diff .
diff --git a/examples/argocd/zarf.yaml b/examples/argocd/zarf.yaml
index 8c548465..7fa6dbbd 100644
--- a/examples/argocd/zarf.yaml
+++ b/examples/argocd/zarf.yaml
@@ -16,10 +16,9 @@ components:
           - baseline/values.yaml
     images:
       - docker.io/library/redis:7.0.15-alpine
-      - quay.io/argoproj/argocd:v2.9.6
-      # Cosign artifacts for images - argocd - argocd-helm-chart
-      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig
       - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.att
+      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig
+      - quay.io/argoproj/argocd:v2.9.6
   - name: argocd-apps
     required: true
     charts:
```

Observe that the rest of `zarf.yaml` is completely unchanged.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
