### PR TITLE
Fix API Version for Flux resource in docs

### DIFF
--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -88,7 +88,7 @@ When specifying other schemes in Zarf you must change the consuming side as well
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: podinfo


### PR DESCRIPTION
## Description

Small fix to the docs to update the API Version in the examples.

## Related Issue

N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
