### PR TITLE
fix: passing context into packager

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -57,7 +57,7 @@ var devDeployCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig, packager.WithContext(ctx))
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ var devGenerateCmd = &cobra.Command{
 		pkgConfig.CreateOpts.BaseDir = "."
 		pkgConfig.FindImagesOpts.RepoHelmChartPath = pkgConfig.GenerateOpts.GitPath
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig, packager.WithContext(cmd.Context()))
 		if err != nil {
 			return err
 		}
@@ -252,7 +252,7 @@ var devFindImagesCmd = &cobra.Command{
 			v.GetStringMapString(common.VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig, packager.WithContext(cmd.Context()))
 		if err != nil {
 			return err
 		}

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -61,7 +61,7 @@ var initCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig, packager.WithSource(src))
+		pkgClient, err := packager.New(&pkgConfig, packager.WithSource(src), packager.WithContext(ctx))
 		if err != nil {
 			return err
 		}

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -110,7 +110,7 @@ var packageDeployCmd = &cobra.Command{
 		pkgConfig.PkgOpts.SetVariables = helpers.TransformAndMergeMap(
 			v.GetStringMapString(common.VPkgDeploySet), pkgConfig.PkgOpts.SetVariables, strings.ToUpper)
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig, packager.WithContext(cmd.Context()))
 		if err != nil {
 			return err
 		}
@@ -360,7 +360,7 @@ var packagePublishCmd = &cobra.Command{
 
 		pkgConfig.PublishOpts.PackageDestination = ref.String()
 
-		pkgClient, err := packager.New(&pkgConfig)
+		pkgClient, err := packager.New(&pkgConfig, packager.WithContext(cmd.Context()))
 		if err != nil {
 			return err
 		}

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -32,6 +32,7 @@ import (
 
 // Packager is the main struct for managing packages.
 type Packager struct {
+	// NOTE(mkcp): Storing ctx on structs is not recommended, but this is intended as a temporary workaround.
 	ctx            context.Context
 	cfg            *types.PackagerConfig
 	variableConfig *variables.VariableConfig

--- a/src/types/packager.go
+++ b/src/types/packager.go
@@ -5,17 +5,11 @@
 package types
 
 import (
-	"context"
-
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 )
 
 // PackagerConfig is the main struct that the packager uses to hold high-level options.
 type PackagerConfig struct {
-	// Context provides deadlines, cancellations, and values throughout the API.
-	// NOTE(mkcp): Storing ctx on structs is not recommended, but this is intended as a temporary workaround.
-	Context context.Context
-
 	// CreateOpts tracks the user-defined options used to create the package
 	CreateOpts ZarfCreateOptions
 


### PR DESCRIPTION
## Description

There is currently a small bug in the when using the `--log-format` flag that causes not all logs to be seen as context is not passed properly into the packager struct. 

Passing context into structs is not ideal, this was done to avoid breaking changes. The packager struct will be removed once #2969 is completed

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
