### PR TITLE
test: remove bad remote image test

### DIFF
--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -116,16 +116,6 @@ func TestUseCLI(t *testing.T) {
 		require.Contains(t, stdErr, expectedOutString, "The log level should be changed to 'debug'")
 	})
 
-	t.Run("zarf package to test bad remote images", func(t *testing.T) {
-		_, stdErr, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-remote-pull-fail", "--confirm")
-		// expecting zarf to have an error and output to stderr
-		require.Error(t, err)
-		// Make sure we print the get request error (only look for GET since the actual error changes based on login status)
-		require.Contains(t, stdErr, "failed to find the manifest on a remote: GET")
-		// And the docker error
-		require.Contains(t, stdErr, "response from daemon: No such image")
-	})
-
 	t.Run("zarf package to test archive path", func(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "packages/distros/eks", "--confirm")

--- a/src/test/packages/00-remote-pull-fail/zarf.yaml
+++ b/src/test/packages/00-remote-pull-fail/zarf.yaml
@@ -1,8 +1,0 @@
-kind: ZarfPackageConfig
-metadata:
-  name: doesnotexist
-components:
-  - name: doesnotexist-docker
-    required: true
-    images:
-      - ghcr.io/zarf-dev/doesnotexist:1.3.3.7


### PR DESCRIPTION
## Description

Testing that Zarf will fail when a remote image is pulled is unnecessary

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
