### PR TITLE
feat: print warnings before confirm with slogger

### DIFF
--- a/src/pkg/logger/logger.go
+++ b/src/pkg/logger/logger.go
@@ -188,7 +188,7 @@ func New(cfg Config) (*slog.Logger, error) {
 		})
 	case FormatDev:
 		opts.AddSource = true
-		handler = devslog.NewHandler(DestinationDefault, &devslog.Options{
+		handler = devslog.NewHandler(cfg.Destination, &devslog.Options{
 			HandlerOptions:  &opts,
 			NewLineAfterLog: true,
 			NoColor:         !bool(cfg.Color),

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -56,9 +56,6 @@ func (p *Packager) Create(ctx context.Context) error {
 	}
 	//  Store on packager config
 	p.cfg.Pkg = pkg
-	for _, warning := range warnings {
-		l.Warn(warning)
-	}
 	l.Info("package loaded",
 		"kind", pkg.Kind,
 		"name", pkg.Metadata.Name,

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -94,18 +94,12 @@ func (p *Packager) Deploy(ctx context.Context) error {
 		return err
 	}
 	warnings = append(warnings, validateWarnings...)
-	for _, warning := range validateWarnings {
-		l.Warn(warning)
-	}
 
 	sbomViewFiles, sbomWarnings, err := p.layout.SBOMs.StageSBOMViewFiles()
 	if err != nil {
 		return err
 	}
 	warnings = append(warnings, sbomWarnings...)
-	for _, warning := range sbomWarnings {
-		l.Warn(warning)
-	}
 
 	// Confirm the overall package deployment
 	if !p.confirmAction(ctx, config.ZarfDeployStage, warnings, sbomViewFiles) {

--- a/src/pkg/packager/interactive.go
+++ b/src/pkg/packager/interactive.go
@@ -23,6 +23,7 @@ import (
 func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []string, sbomViewFiles []string) bool {
 	pterm.Println()
 	message.HeaderInfof("📦 PACKAGE DEFINITION")
+	l := logger.From(ctx)
 	err := utils.ColorPrintYAML(p.cfg.Pkg, p.getPackageYAMLHints(stage), true)
 	if err != nil {
 		message.WarnErr(err, "unable to print yaml")
@@ -52,7 +53,7 @@ func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []s
 				message.Note(msg)
 				pterm.Println(viewNow)
 				pterm.Println(viewLater)
-				logger.From(ctx).Info("this package has SBOMs available for review in a temporary directory", "directory", filepath.Join(cwd, layout.SBOMDir))
+				l.Info("this package has SBOMs available for review in a temporary directory", "directory", filepath.Join(cwd, layout.SBOMDir))
 			} else {
 				message.Warn("This package does NOT contain an SBOM.  If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.")
 			}
@@ -64,6 +65,7 @@ func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []s
 		message.Title("Package Warnings", "the following warnings were flagged while reading the package")
 		for _, warning := range warnings {
 			message.Warn(warning)
+			l.Warn(warning)
 		}
 	}
 


### PR DESCRIPTION
## Description
I realized many warnings before confirm actions weren't being printed. We were printing some of the pre-confirm warnings separately which leads to cleaner code, however practically speaking they are almost impossible to notice for users because everything before the `p.confirmAction` happens quickly and `p.confirmAction` prints out a yaml file. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
