### PR TITLE
test: move lint e2e test to unit test

### DIFF
--- a/examples/helm-charts/zarf.yaml
+++ b/examples/helm-charts/zarf.yaml
@@ -8,50 +8,50 @@ components:
   - name: demo-helm-charts
     required: true
     charts:
-      # Charts are organized in a list with unique chart names per component - note that a Zarf chart name does not need to match the chart name in a Chart.yaml
-      - name: podinfo-local
-        version: 6.4.0
-        namespace: podinfo-from-local-chart
-        # In this case `localPath` will load the podinfo chart that is located in the `chart` directory
-        localPath: chart
-        valuesFiles:
-          - values.yaml
-        # Variables are used to override the default values in the chart
-        # This can be overridden by the user at deployment time with the `--set` flag
-        variables:
-          - name: REPLICA_COUNT
-            description: "Override the number of pod replicas"
-            path: replicaCount
+      # # Charts are organized in a list with unique chart names per component - note that a Zarf chart name does not need to match the chart name in a Chart.yaml
+      # - name: podinfo-local
+      #   version: 6.4.0
+      #   namespace: podinfo-from-local-chart
+      #   # In this case `localPath` will load the podinfo chart that is located in the `chart` directory
+      #   localPath: chart
+      #   valuesFiles:
+      #     - values.yaml
+      #   # Variables are used to override the default values in the chart
+      #   # This can be overridden by the user at deployment time with the `--set` flag
+      #   variables:
+      #     - name: REPLICA_COUNT
+      #       description: "Override the number of pod replicas"
+      #       path: replicaCount
 
-      - name: podinfo-oci
-        version: 6.4.0
-        namespace: podinfo-from-oci
-        # In this case `url` will load the helm chart located in the podinfo OCI repository
-        url: oci://ghcr.io/stefanprodan/charts/podinfo
-        valuesFiles:
-          - values.yaml
+      # - name: podinfo-oci
+      #   version: 6.4.0
+      #   namespace: podinfo-from-oci
+      #   # In this case `url` will load the helm chart located in the podinfo OCI repository
+      #   url: oci://ghcr.io/stefanprodan/charts/podinfo@main
+      #   valuesFiles:
+      #     - values.yaml
 
       - name: podinfo-git
         version: 6.4.0
         namespace: podinfo-from-git
         # In this case `url` will load the helm chart located in the podinfo git repository
-        url: https://github.com/stefanprodan/podinfo.git
+        url: https://github.com/stefanprodan/podinfo.git@refs/heads/master
         # By default git will look in the root of the git repository but you can define a sub directory with `gitPath`
         gitPath: charts/podinfo
         valuesFiles:
           - values.yaml
 
-      - name: podinfo-repo
-        version: 6.4.0
-        namespace: podinfo-from-repo
-        # In this case `url` will load the helm chart located in the podinfo helm repository
-        url: https://stefanprodan.github.io/podinfo
-        # By default the chart `name` will be what is used to search a repository but since Zarf chart names must be unique per-component you can override this with `repoName`
-        repoName: podinfo
-        # By default the release name will be the chart name, but you can override this with the `releaseName` key
-        releaseName: cool-release-name
-        valuesFiles:
-          - values.yaml
+      # - name: podinfo-repo
+      #   version: 6.4.0
+      #   namespace: podinfo-from-repo
+      #   # In this case `url` will load the helm chart located in the podinfo helm repository
+      #   url: https://stefanprodan.github.io/podinfo
+      #   # By default the chart `name` will be what is used to search a repository but since Zarf chart names must be unique per-component you can override this with `repoName`
+      #   repoName: podinfo
+      #   # By default the release name will be the chart name, but you can override this with the `releaseName` key
+      #   releaseName: cool-release-name
+      #   valuesFiles:
+      #     - values.yaml
     images:
       - ghcr.io/stefanprodan/podinfo:6.4.0
       # This is the cosign signature for the podinfo image for image signature verification

--- a/src/pkg/lint/lint.go
+++ b/src/pkg/lint/lint.go
@@ -133,9 +133,6 @@ func templateZarfObj(zarfObj any, setVariables map[string]string) ([]PackageFind
 				})
 			}
 		}
-		// if unSetTemplates {
-
-		// }
 		for key, value := range setVariables {
 			templateMap[fmt.Sprintf("%s%s###", templatePrefix, key)] = value
 		}

--- a/src/pkg/lint/lint.go
+++ b/src/pkg/lint/lint.go
@@ -119,7 +119,6 @@ func templateZarfObj(zarfObj any, setVariables map[string]string) ([]PackageFind
 			return err
 		}
 
-		var unSetTemplates bool
 		for key := range yamlTemplates {
 			if deprecated {
 				findings = append(findings, PackageFinding{
@@ -128,15 +127,15 @@ func templateZarfObj(zarfObj any, setVariables map[string]string) ([]PackageFind
 				})
 			}
 			if _, present := setVariables[key]; !present {
-				unSetTemplates = true
+				findings = append(findings, PackageFinding{
+					Description: fmt.Sprintf("package template %s is not set and won't be evaluated during lint", key),
+					Severity:    SevWarn,
+				})
 			}
 		}
-		if unSetTemplates {
-			findings = append(findings, PackageFinding{
-				Description: lang.UnsetVarLintWarning,
-				Severity:    SevWarn,
-			})
-		}
+		// if unSetTemplates {
+
+		// }
 		for key, value := range setVariables {
 			templateMap[fmt.Sprintf("%s%s###", templatePrefix, key)] = value
 		}

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -7,6 +7,7 @@ package lint
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -77,7 +78,7 @@ func TestFillObjTemplate(t *testing.T) {
 	expectedFindings := []PackageFinding{
 		{
 			Severity:    SevWarn,
-			Description: "There are templates that are not set and won't be evaluated during lint",
+			Description: "package template KEY3 is not set and won't be evaluated during lint",
 		},
 		{
 			Severity:    SevWarn,
@@ -104,7 +105,7 @@ func TestLintPackageWithImports(t *testing.T) {
 	findings := []PackageFinding{
 		{
 			YqPath:              "",
-			Description:         "There are templates that are not set and won't be evaluated during lint",
+			Description:         "package template UNSET is not set and won't be evaluated during lint",
 			Item:                "",
 			PackageNameOverride: "linted-import",
 			PackagePathOverride: "linted-import",
@@ -136,23 +137,7 @@ func TestLintPackageWithImports(t *testing.T) {
 		},
 		{
 			YqPath:              "",
-			Description:         "There are templates that are not set and won't be evaluated during lint",
-			Item:                "",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              "",
-			Description:         `Package template "WHATEVER_IMAGE" is using the deprecated syntax ###ZARF_PKG_VAR_WHATEVER_IMAGE###. This will be removed in Zarf v1.0.0. Please update to ###ZARF_PKG_TMPL_WHATEVER_IMAGE###.`,
-			Item:                "",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              "",
-			Description:         "There are templates that are not set and won't be evaluated during lint",
+			Description:         "package template UBUNTU_IMAGE is not set and won't be evaluated during lint",
 			Item:                "",
 			PackageNameOverride: "lint",
 			PackagePathOverride: ".",
@@ -183,7 +168,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[2].images.[3]",
+			YqPath:              ".components.[2].images.[2]",
 			Description:         "Image not pinned with digest",
 			Item:                "busybox:latest",
 			PackageNameOverride: "lint",
@@ -223,14 +208,13 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevErr,
 		},
 	}
-	// cwd, err := os.Getwd()
-	// require.NoError(t, err)
-	// err = os.Chdir(filepath.Join("testdata", "lint-with-templates"))
-	// require.NoError(t, err)
-	// defer func() {
-	// 	require.NoError(t, os.Chdir(cwd))
-	// }()
-	err := Validate(ctx, "testdata/lint-with-imports", "good-flavor", setVariables)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	// TODO @austinabro321: remove this and parallelize the test once changing the working directory is no longer required
+	defer func() {
+		require.NoError(t, os.Chdir(cwd))
+	}()
+	err = Validate(ctx, "testdata/lint-with-imports", "good-flavor", setVariables)
 	var lintErr *LintError
 	require.ErrorAs(t, err, &lintErr)
 	require.ElementsMatch(t, findings, lintErr.Findings)

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
 func TestLintError(t *testing.T) {
@@ -92,4 +93,145 @@ func TestFillObjTemplate(t *testing.T) {
 	}
 	require.ElementsMatch(t, expectedFindings, findings)
 	require.Equal(t, expectedComponent, component)
+}
+
+func TestLintPackageWithImports(t *testing.T) {
+	ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
+	setVariables := map[string]string{
+		"BUSYBOX_IMAGE": "latest",
+	}
+	ctx := context.Background()
+	findings := []PackageFinding{
+		{
+			YqPath:              "",
+			Description:         "There are templates that are not set and won't be evaluated during lint",
+			Item:                "",
+			PackageNameOverride: "linted-import",
+			PackagePathOverride: "linted-import",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[0].images.[0]",
+			Description:         "Image not pinned with digest",
+			Item:                "ghcr.io/zarf-dev/doom-game:0.0.1",
+			PackageNameOverride: "dos-games",
+			PackagePathOverride: "oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[1].images.[0]",
+			Description:         "Image not pinned with digest",
+			Item:                "registry.com:9001/whatever/image:latest",
+			PackageNameOverride: "linted-import",
+			PackagePathOverride: "linted-import",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[1].images.[2]",
+			Description:         "Image not pinned with digest",
+			Item:                "busybox:latest",
+			PackageNameOverride: "linted-import",
+			PackagePathOverride: "linted-import",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              "",
+			Description:         "There are templates that are not set and won't be evaluated during lint",
+			Item:                "",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              "",
+			Description:         `Package template "WHATEVER_IMAGE" is using the deprecated syntax ###ZARF_PKG_VAR_WHATEVER_IMAGE###. This will be removed in Zarf v1.0.0. Please update to ###ZARF_PKG_TMPL_WHATEVER_IMAGE###.`,
+			Item:                "",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              "",
+			Description:         "There are templates that are not set and won't be evaluated during lint",
+			Item:                "",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[2].repos.[0]",
+			Description:         "Unpinned repository",
+			Item:                "https://github.com/zarf-dev/zarf-public-test.git",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[2].repos.[2]",
+			Description:         "Unpinned repository",
+			Item:                "https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[2].images.[0]",
+			Description:         "Image not pinned with digest",
+			Item:                "registry.com:9001/whatever/image:1.0.0",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[2].images.[3]",
+			Description:         "Image not pinned with digest",
+			Item:                "busybox:latest",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[0].images.[0]",
+			Description:         "Image not pinned with digest",
+			Item:                "ghcr.io/zarf-dev/doom-game:0.0.1",
+			PackageNameOverride: "dos-games",
+			PackagePathOverride: "oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[6].images.[0]",
+			Description:         "Image not pinned with digest",
+			Item:                "image-in-good-flavor-component:unpinned",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              ".components.[0].import",
+			Description:         "Additional property not-path is not allowed",
+			Item:                "",
+			PackageNameOverride: "",
+			PackagePathOverride: "",
+			Severity:            SevErr,
+		},
+		{
+			YqPath:              ".metadata",
+			Description:         "Additional property description1 is not allowed",
+			Item:                "",
+			PackageNameOverride: "",
+			PackagePathOverride: "",
+			Severity:            SevErr,
+		},
+	}
+	// cwd, err := os.Getwd()
+	// require.NoError(t, err)
+	// err = os.Chdir(filepath.Join("testdata", "lint-with-templates"))
+	// require.NoError(t, err)
+	// defer func() {
+	// 	require.NoError(t, os.Chdir(cwd))
+	// }()
+	err := Validate(ctx, "testdata/lint-with-imports", "good-flavor", setVariables)
+	var lintErr *LintError
+	require.ErrorAs(t, err, &lintErr)
+	require.ElementsMatch(t, findings, lintErr.Findings)
 }

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -120,6 +120,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			PackagePathOverride: ".",
 			Severity:            SevWarn,
 		},
+		// Test imported skeleton package lints properly
 		{
 			YqPath:              ".components.[0].images.[0]",
 			Description:         "Image not pinned with digest",
@@ -128,6 +129,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			PackagePathOverride: "oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0",
 			Severity:            SevWarn,
 		},
+		// Test local import lints properly
 		{
 			YqPath:              ".components.[1].images.[0]",
 			Description:         "Image not pinned with digest",
@@ -136,6 +138,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			PackagePathOverride: "linted-import",
 			Severity:            SevWarn,
 		},
+		// Test flavors
 		{
 			YqPath:              ".components.[4].images.[0]",
 			Description:         "Image not pinned with digest",

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -199,14 +199,6 @@ func TestLintPackageWithImports(t *testing.T) {
 			PackagePathOverride: "",
 			Severity:            SevErr,
 		},
-		{
-			YqPath:              ".metadata",
-			Description:         "Additional property description1 is not allowed",
-			Item:                "",
-			PackageNameOverride: "",
-			PackagePathOverride: "",
-			Severity:            SevErr,
-		},
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -103,12 +103,21 @@ func TestLintPackageWithImports(t *testing.T) {
 	}
 	ctx := context.Background()
 	findings := []PackageFinding{
+		// unset exists in both the root and imported package
 		{
 			YqPath:              "",
 			Description:         "package template UNSET is not set and won't be evaluated during lint",
 			Item:                "",
 			PackageNameOverride: "linted-import",
 			PackagePathOverride: "linted-import",
+			Severity:            SevWarn,
+		},
+		{
+			YqPath:              "",
+			Description:         "package template UNSET is not set and won't be evaluated during lint",
+			Item:                "",
+			PackageNameOverride: "lint",
+			PackagePathOverride: ".",
 			Severity:            SevWarn,
 		},
 		{
@@ -122,57 +131,9 @@ func TestLintPackageWithImports(t *testing.T) {
 		{
 			YqPath:              ".components.[1].images.[0]",
 			Description:         "Image not pinned with digest",
-			Item:                "registry.com:9001/whatever/image:latest",
-			PackageNameOverride: "linted-import",
-			PackagePathOverride: "linted-import",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[1].images.[2]",
-			Description:         "Image not pinned with digest",
 			Item:                "busybox:latest",
 			PackageNameOverride: "linted-import",
 			PackagePathOverride: "linted-import",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              "",
-			Description:         "package template UBUNTU_IMAGE is not set and won't be evaluated during lint",
-			Item:                "",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[1].repos.[0]",
-			Description:         "Unpinned repository",
-			Item:                "https://github.com/zarf-dev/zarf-public-test.git",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[1].repos.[2]",
-			Description:         "Unpinned repository",
-			Item:                "https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[1].images.[0]",
-			Description:         "Image not pinned with digest",
-			Item:                "registry.com:9001/whatever/image:1.0.0",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[1].images.[2]",
-			Description:         "Image not pinned with digest",
-			Item:                "busybox:latest",
-			PackageNameOverride: "lint",
-			PackagePathOverride: ".",
 			Severity:            SevWarn,
 		},
 		{

--- a/src/pkg/lint/lint_test.go
+++ b/src/pkg/lint/lint_test.go
@@ -144,7 +144,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[2].repos.[0]",
+			YqPath:              ".components.[1].repos.[0]",
 			Description:         "Unpinned repository",
 			Item:                "https://github.com/zarf-dev/zarf-public-test.git",
 			PackageNameOverride: "lint",
@@ -152,7 +152,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[2].repos.[2]",
+			YqPath:              ".components.[1].repos.[2]",
 			Description:         "Unpinned repository",
 			Item:                "https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads",
 			PackageNameOverride: "lint",
@@ -160,7 +160,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[2].images.[0]",
+			YqPath:              ".components.[1].images.[0]",
 			Description:         "Image not pinned with digest",
 			Item:                "registry.com:9001/whatever/image:1.0.0",
 			PackageNameOverride: "lint",
@@ -168,7 +168,7 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[2].images.[2]",
+			YqPath:              ".components.[1].images.[2]",
 			Description:         "Image not pinned with digest",
 			Item:                "busybox:latest",
 			PackageNameOverride: "lint",
@@ -176,28 +176,12 @@ func TestLintPackageWithImports(t *testing.T) {
 			Severity:            SevWarn,
 		},
 		{
-			YqPath:              ".components.[0].images.[0]",
-			Description:         "Image not pinned with digest",
-			Item:                "ghcr.io/zarf-dev/doom-game:0.0.1",
-			PackageNameOverride: "dos-games",
-			PackagePathOverride: "oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0",
-			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[6].images.[0]",
+			YqPath:              ".components.[4].images.[0]",
 			Description:         "Image not pinned with digest",
 			Item:                "image-in-good-flavor-component:unpinned",
 			PackageNameOverride: "lint",
 			PackagePathOverride: ".",
 			Severity:            SevWarn,
-		},
-		{
-			YqPath:              ".components.[0].import",
-			Description:         "Additional property not-path is not allowed",
-			Item:                "",
-			PackageNameOverride: "",
-			PackagePathOverride: "",
-			Severity:            SevErr,
 		},
 	}
 	cwd, err := os.Getwd()

--- a/src/pkg/lint/schema_test.go
+++ b/src/pkg/lint/schema_test.go
@@ -200,7 +200,7 @@ func TestValidatePackageSchema(t *testing.T) {
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	err = os.Chdir(filepath.Join("testdata", "lint-with-templates"))
+	err = os.Chdir(filepath.Join("testdata", "package-with-templates"))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.Chdir(cwd))

--- a/src/pkg/lint/schema_test.go
+++ b/src/pkg/lint/schema_test.go
@@ -200,7 +200,7 @@ func TestValidatePackageSchema(t *testing.T) {
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	err = os.Chdir(filepath.Join("testdata", "package-with-templates"))
+	err = os.Chdir(filepath.Join("testdata", "lint-with-templates"))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.Chdir(cwd))

--- a/src/pkg/lint/testdata/lint-with-imports/linted-import/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/linted-import/zarf.yaml
@@ -1,0 +1,23 @@
+kind: ZarfPackageConfig
+metadata:
+  name: linted-import
+  description: Testing bad yaml imported
+
+variables:
+  - name: BUSYBOX_IMAGE
+    description: "whatever"
+
+components:
+  - name: dont-care
+
+  - name: import-test
+    images:
+      - registry.com:9001/whatever/image:latest
+      - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
+      - busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###
+      - busybox:###ZARF_PKG_TMPL_UNSET###
+
+  - name: oci-games-url
+    import:
+      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
+      name: baseline

--- a/src/pkg/lint/testdata/lint-with-imports/linted-import/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/linted-import/zarf.yaml
@@ -9,12 +9,13 @@ variables:
 
 components:
   - name: dont-care
+    images:
+    - image-that-should-not-show-up-in-lint:unpinned
 
   - name: import-test
     images:
-      - registry.com:9001/whatever/image:latest
-      - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
       - busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###
+      - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
       - busybox:###ZARF_PKG_TMPL_UNSET###
 
   - name: oci-games-url

--- a/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
@@ -3,10 +3,6 @@ metadata:
   name: lint
 
 components:
-  - name: first-test-component
-    import:
-      not-path: packages/distros/k3s
-
   - name: import-test
     import:
       path: linted-import
@@ -27,11 +23,6 @@ components:
         target: src/
       - source: file-without-shasum.txt
         target: src/
-
-  - name: oci-games-url
-    import:
-      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
-      name: baseline
 
   - name: oci-games-url
     import:

--- a/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
@@ -8,21 +8,9 @@ components:
       path: linted-import
 
   - name: full-repo
-    repos:
-      - https://github.com/zarf-dev/zarf-public-test.git
-      - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1
-      - https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads
     images:
-      - registry.com:9001/whatever/image:1.0.0
       - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
-      - busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###
-      - ubuntu:###ZARF_PKG_TMPL_UBUNTU_IMAGE###
-    files:
-      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.2+k3s1/k3s
-        shasum: 2f041d37a2c6d54d53e106e1c7713bc48f806f3919b0d9e092f5fcbdc55b41cf
-        target: src/
-      - source: file-without-shasum.txt
-        target: src/
+      - busybox:###ZARF_PKG_TMPL_UNSET###
 
   - name: oci-games-url
     import:

--- a/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
@@ -1,7 +1,6 @@
 kind: ZarfPackageConfig
 metadata:
   name: lint
-  description1: Testing bad yaml
 
 components:
   - name: first-test-component

--- a/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
@@ -20,7 +20,6 @@ components:
     images:
       - registry.com:9001/whatever/image:1.0.0
       - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
-      - busybox:###ZARF_PKG_VAR_WHATEVER_IMAGE###
       - busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###
       - ubuntu:###ZARF_PKG_TMPL_UBUNTU_IMAGE###
     files:

--- a/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
+++ b/src/pkg/lint/testdata/lint-with-imports/zarf.yaml
@@ -1,0 +1,52 @@
+kind: ZarfPackageConfig
+metadata:
+  name: lint
+  description1: Testing bad yaml
+
+components:
+  - name: first-test-component
+    import:
+      not-path: packages/distros/k3s
+
+  - name: import-test
+    import:
+      path: linted-import
+
+  - name: full-repo
+    repos:
+      - https://github.com/zarf-dev/zarf-public-test.git
+      - https://dev.azure.com/defenseunicorns/zarf-public-test/_git/zarf-public-test@v0.0.1
+      - https://gitlab.com/gitlab-org/build/omnibus-mirror/pcre2/-/tree/vreverse?ref_type=heads
+    images:
+      - registry.com:9001/whatever/image:1.0.0
+      - busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79
+      - busybox:###ZARF_PKG_VAR_WHATEVER_IMAGE###
+      - busybox:###ZARF_PKG_TMPL_BUSYBOX_IMAGE###
+      - ubuntu:###ZARF_PKG_TMPL_UBUNTU_IMAGE###
+    files:
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.28.2+k3s1/k3s
+        shasum: 2f041d37a2c6d54d53e106e1c7713bc48f806f3919b0d9e092f5fcbdc55b41cf
+        target: src/
+      - source: file-without-shasum.txt
+        target: src/
+
+  - name: oci-games-url
+    import:
+      url: oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0
+      name: baseline
+
+  - name: oci-games-url
+    import:
+      path: linted-import
+
+  - name: import-bad-flavor
+    only:
+      flavor: bad-flavor
+    images:
+      - image-in-bad-flavor-component:unpinned
+
+  - name: import-good-flavor
+    only:
+      flavor: good-flavor
+    images:
+      - image-in-good-flavor-component:unpinned

--- a/src/pkg/lint/testdata/package-with-templates/zarf.yaml
+++ b/src/pkg/lint/testdata/package-with-templates/zarf.yaml
@@ -1,4 +1,5 @@
 kind: ZarfPackageConfig
+# Tests that the schema regex validation happen after templating
 metadata:
   name: "###ZARF_PKG_VAR_PACKAGE_NAME###"
 components:

--- a/src/test/testutil/schema.go
+++ b/src/test/testutil/schema.go
@@ -6,6 +6,8 @@ package testutil
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +29,13 @@ func (m *schemaFS) Open(_ string) (fs.File, error) {
 func LoadSchema(t *testing.T, path string) fs.ReadFileFS {
 	t.Helper()
 
-	b, err := os.ReadFile(path)
+	_, testFilePath, _, ok := runtime.Caller(1)
+	require.True(t, ok, "failed to determine the test file path")
+
+	// Resolve the schema file's absolute path
+	schemaPath := filepath.Join(filepath.Dir(testFilePath), path)
+
+	b, err := os.ReadFile(schemaPath)
 	require.NoError(t, err)
 	return &schemaFS{b: b}
 }


### PR DESCRIPTION
## Description

lint e2e test should be moved to a unit test for simplicity and to avoid checking output from the cli

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
