### PR TITLE
refactor: Create structs for each tools command to better isolate commands - cont'd 

### DIFF
--- a/src/cmd/common/viper.go
+++ b/src/cmd/common/viper.go
@@ -116,13 +116,8 @@ var (
 	vConfigError error
 )
 
-// InitViper initializes the viper singleton for the CLI
-func InitViper() *viper.Viper {
-	// Already initialized by some other command
-	if v != nil {
-		return v
-	}
-
+// initializes the viper singleton for the CLI
+func initViper() *viper.Viper {
 	v = viper.New()
 
 	// Skip for vendor-only commands or the version command
@@ -159,6 +154,10 @@ func InitViper() *viper.Viper {
 
 // GetViper returns the viper singleton
 func GetViper() *viper.Viper {
+	if v == nil {
+		v = initViper()
+	}
+
 	return v
 }
 

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -45,7 +45,7 @@ func NewInitCommand() *cobra.Command {
 		RunE:    o.Run,
 	}
 
-	v := common.InitViper()
+	v := common.GetViper()
 
 	// Init package variable defaults that are non-zero values
 	// NOTE: these are not in common.setDefaults so that zarf tools update-creds does not erroneously update values back to the default

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -43,7 +43,7 @@ func NewPackageCommand() *cobra.Command {
 		Short:   lang.CmdPackageShort,
 	}
 
-	v := common.InitViper()
+	v := common.GetViper()
 
 	persistentFlags := cmd.PersistentFlags()
 	persistentFlags.IntVar(&config.CommonOptions.OCIConcurrency, "oci-concurrency", v.GetInt(common.VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -130,6 +130,13 @@ func NewZarfCommand() *cobra.Command {
 		Run:               run,
 	}
 
+	// Add the tools commands
+	// IMPORTANT: we need to make sure the tools command are added first
+	// to ensure the config defaulting doesn't kick in, and inject values
+	// into zart tools update-creds command
+	// see https://github.com/zarf-dev/zarf/pull/3340#discussion_r1889221826
+	rootCmd.AddCommand(tools.NewToolsCommand())
+
 	// TODO(soltysh): consider adding command groups
 	rootCmd.AddCommand(NewConnectCommand())
 	rootCmd.AddCommand(NewDestroyCommand())
@@ -170,9 +177,6 @@ func Execute(ctx context.Context) {
 }
 
 func init() {
-	// Add the tools commands
-	tools.Include(rootCmd)
-
 	// Skip for vendor-only commands
 	if common.CheckVendorOnlyFromArgs() {
 		return

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -178,7 +178,7 @@ func init() {
 		return
 	}
 
-	v := common.InitViper()
+	v := common.GetViper()
 
 	// Logs
 	rootCmd.PersistentFlags().StringVarP(&LogLevelCLI, "log-level", "l", v.GetString(common.VLogLevel), lang.RootCmdFlagLogLevel)

--- a/src/cmd/tools/archiver.go
+++ b/src/cmd/tools/archiver.go
@@ -19,80 +19,108 @@ import (
 // ldflags github.com/zarf-dev/zarf/src/cmd/tools.archiverVersion=x.x.x
 var archiverVersion string
 
-var archiverCmd = &cobra.Command{
-	Use:     "archiver",
-	Aliases: []string{"a"},
-	Short:   lang.CmdToolsArchiverShort,
-	Version: archiverVersion,
+// NewArchiverCommand creates the `tools archiver` sub-command and its nested children.
+func NewArchiverCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "archiver",
+		Aliases: []string{"a"},
+		Short:   lang.CmdToolsArchiverShort,
+		Version: archiverVersion,
+	}
+
+	cmd.AddCommand(NewArchiverCompressCommand())
+	cmd.AddCommand(NewArchiverDecompressCommand())
+	cmd.AddCommand(newVersionCmd("mholt/archiver", archiverVersion))
+
+	return cmd
 }
 
-var archiverCompressCmd = &cobra.Command{
-	Use:     "compress SOURCES ARCHIVE",
-	Aliases: []string{"c"},
-	Short:   lang.CmdToolsArchiverCompressShort,
-	Args:    cobra.MinimumNArgs(2),
-	RunE: func(_ *cobra.Command, args []string) error {
-		sourceFiles, destinationArchive := args[:len(args)-1], args[len(args)-1]
-		err := archiver.Archive(sourceFiles, destinationArchive)
-		if err != nil {
-			return fmt.Errorf("unable to perform compression: %w", err)
-		}
-		return err
-	},
+// ArchiverCompressOptions holds the command-line options for 'tools archiver compress' sub-command.
+type ArchiverCompressOptions struct{}
+
+// NewArchiverCompressCommand creates the `tools archiver compress` sub-command.
+func NewArchiverCompressCommand() *cobra.Command {
+	o := ArchiverCompressOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "compress SOURCES ARCHIVE",
+		Aliases: []string{"c"},
+		Short:   lang.CmdToolsArchiverCompressShort,
+		Args:    cobra.MinimumNArgs(2),
+		RunE:    o.Run,
+	}
+
+	return cmd
 }
 
-var unarchiveAll bool
+// Run performs the execution of 'tools archiver compress' sub-command.
+func (o *ArchiverCompressOptions) Run(_ *cobra.Command, args []string) error {
+	sourceFiles, destinationArchive := args[:len(args)-1], args[len(args)-1]
+	err := archiver.Archive(sourceFiles, destinationArchive)
+	if err != nil {
+		return fmt.Errorf("unable to perform compression: %w", err)
+	}
+	return err
+}
 
-var archiverDecompressCmd = &cobra.Command{
-	Use:     "decompress ARCHIVE DESTINATION",
-	Aliases: []string{"d"},
-	Short:   lang.CmdToolsArchiverDecompressShort,
-	Args:    cobra.ExactArgs(2),
-	RunE: func(_ *cobra.Command, args []string) error {
-		sourceArchive, destinationPath := args[0], args[1]
-		err := archiver.Unarchive(sourceArchive, destinationPath)
+// ArchiverDecompressOptions holds the command-line options for 'tools archiver decompress' sub-command.
+type ArchiverDecompressOptions struct {
+	unarchiveAll bool
+}
+
+// NewArchiverDecompressCommand creates the `tools archiver decompress` sub-command.
+func NewArchiverDecompressCommand() *cobra.Command {
+	o := ArchiverDecompressOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "decompress ARCHIVE DESTINATION",
+		Aliases: []string{"d"},
+		Short:   lang.CmdToolsArchiverDecompressShort,
+		Args:    cobra.ExactArgs(2),
+		RunE:    o.Run,
+	}
+
+	cmd.Flags().BoolVar(&o.unarchiveAll, "decompress-all", false, "Decompress all tarballs in the archive")
+	cmd.Flags().BoolVar(&o.unarchiveAll, "unarchive-all", false, "Unarchive all tarballs in the archive")
+	cmd.MarkFlagsMutuallyExclusive("decompress-all", "unarchive-all")
+	cmd.Flags().MarkHidden("decompress-all")
+
+	return cmd
+}
+
+// Run performs the execution of 'tools archiver decompress' sub-command.
+func (o *ArchiverDecompressOptions) Run(_ *cobra.Command, args []string) error {
+	sourceArchive, destinationPath := args[0], args[1]
+	err := archiver.Unarchive(sourceArchive, destinationPath)
+	if err != nil {
+		return fmt.Errorf("unable to perform decompression: %w", err)
+	}
+	if !o.unarchiveAll {
+		return nil
+	}
+	err = filepath.Walk(destinationPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("unable to perform decompression: %w", err)
+			return err
 		}
-		if !unarchiveAll {
-			return nil
-		}
-		err = filepath.Walk(destinationPath, func(path string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(path, ".tar") {
+			dst := filepath.Join(strings.TrimSuffix(path, ".tar"), "..")
+			// Unpack sboms.tar differently since it has a different folder structure than components
+			if info.Name() == layout.SBOMTar {
+				dst = strings.TrimSuffix(path, ".tar")
+			}
+			err := archiver.Unarchive(path, dst)
 			if err != nil {
-				return err
+				return fmt.Errorf(lang.ErrUnarchive, path, err.Error())
 			}
-			if strings.HasSuffix(path, ".tar") {
-				dst := filepath.Join(strings.TrimSuffix(path, ".tar"), "..")
-				// Unpack sboms.tar differently since it has a different folder structure than components
-				if info.Name() == layout.SBOMTar {
-					dst = strings.TrimSuffix(path, ".tar")
-				}
-				err := archiver.Unarchive(path, dst)
-				if err != nil {
-					return fmt.Errorf(lang.ErrUnarchive, path, err.Error())
-				}
-				err = os.Remove(path)
-				if err != nil {
-					return fmt.Errorf(lang.ErrRemoveFile, path, err.Error())
-				}
+			err = os.Remove(path)
+			if err != nil {
+				return fmt.Errorf(lang.ErrRemoveFile, path, err.Error())
 			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("unable to unarchive all nested tarballs: %w", err)
 		}
 		return nil
-	},
-}
-
-func init() {
-	toolsCmd.AddCommand(archiverCmd)
-
-	archiverCmd.AddCommand(archiverCompressCmd)
-	archiverCmd.AddCommand(archiverDecompressCmd)
-	archiverCmd.AddCommand(newVersionCmd("mholt/archiver", archiverVersion))
-	archiverDecompressCmd.Flags().BoolVar(&unarchiveAll, "decompress-all", false, "Decompress all tarballs in the archive")
-	archiverDecompressCmd.Flags().BoolVar(&unarchiveAll, "unarchive-all", false, "Unarchive all tarballs in the archive")
-	archiverDecompressCmd.MarkFlagsMutuallyExclusive("decompress-all", "unarchive-all")
-	archiverDecompressCmd.Flags().MarkHidden("decompress-all")
+	})
+	if err != nil {
+		return fmt.Errorf("unable to unarchive all nested tarballs: %w", err)
+	}
+	return nil
 }

--- a/src/cmd/tools/common.go
+++ b/src/cmd/tools/common.go
@@ -8,19 +8,36 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
+	"github.com/zarf-dev/zarf/src/cmd/common"
 	"github.com/zarf-dev/zarf/src/config/lang"
 )
 
-var toolsCmd = &cobra.Command{
-	Use:     "tools",
-	Aliases: []string{"t"},
-	Short:   lang.CmdToolsShort,
-}
+// NewToolsCommand creates the `tools` sub-command and its nested children.
+func NewToolsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "tools",
+		Aliases: []string{"t"},
+		Short:   lang.CmdToolsShort,
+	}
 
-// Include adds the tools command to the root command.
-func Include(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(toolsCmd)
+	v := common.GetViper()
+
+	cmd.AddCommand(NewArchiverCommand())
+	cmd.AddCommand(NewRegistryCommand())
+	cmd.AddCommand(NewHelmCommand())
+	cmd.AddCommand(NewK9sCommand())
+	cmd.AddCommand(NewKubectlCommand())
+	cmd.AddCommand(NewSbomCommand())
+	cmd.AddCommand(NewWaitForCommand())
+	cmd.AddCommand(NewYQCommand())
+	cmd.AddCommand(NewGetCredsCommand())
+	cmd.AddCommand(NewUpdateCredsCommand(v))
+	cmd.AddCommand(NewClearCacheCommand())
+	cmd.AddCommand(NewDownloadInitCommand())
+	cmd.AddCommand(NewGenPKICommand())
+	cmd.AddCommand(NewGenKeyCommand())
+
+	return cmd
 }
 
 // newVersionCmd is a generic version command for tools

--- a/src/cmd/tools/helm.go
+++ b/src/cmd/tools/helm.go
@@ -7,18 +7,19 @@ package tools
 import (
 	"os"
 
-	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
-
+	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/cmd/tools/helm"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 	"helm.sh/helm/v3/pkg/action"
 )
 
 // ldflags github.com/zarf-dev/zarf/src/cmd/tools.helmVersion=x.x.x
 var helmVersion string
 
-func init() {
+// NewHelmCommand creates the `tools helm` sub-command.
+func NewHelmCommand() *cobra.Command {
 	actionConfig := new(action.Configuration)
 
 	// Truncate Helm's arguments so that it thinks its all alone
@@ -27,14 +28,14 @@ func init() {
 		helmArgs = os.Args[3:]
 	}
 	// The inclusion of Helm in this manner should be changed once https://github.com/helm/helm/pull/12725 is merged
-	helmCmd, err := helm.NewRootCmd(actionConfig, os.Stdout, helmArgs)
+	cmd, err := helm.NewRootCmd(actionConfig, os.Stdout, helmArgs)
 	if err != nil {
 		message.Debug("Failed to initialize helm command", "error", err)
 		logger.Default().Debug("failed to initialize helm command", "error", err)
 	}
-	helmCmd.Short = lang.CmdToolsHelmShort
-	helmCmd.Long = lang.CmdToolsHelmLong
-	helmCmd.AddCommand(newVersionCmd("helm", helmVersion))
+	cmd.Short = lang.CmdToolsHelmShort
+	cmd.Long = lang.CmdToolsHelmLong
+	cmd.AddCommand(newVersionCmd("helm", helmVersion))
 
-	toolsCmd.AddCommand(helmCmd)
+	return cmd
 }

--- a/src/cmd/tools/k9s.go
+++ b/src/cmd/tools/k9s.go
@@ -18,8 +18,9 @@ import (
 //go:linkname k9sRootCmd github.com/derailed/k9s/cmd.rootCmd
 var k9sRootCmd *cobra.Command
 
-func init() {
-	k9sCmd := &cobra.Command{
+// NewK9sCommand creates the `tools k9s` sub-command.
+func NewK9sCommand() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:     "monitor",
 		Aliases: []string{"m", "k9s"},
 		Short:   lang.CmdToolsMonitorShort,
@@ -30,7 +31,7 @@ func init() {
 		},
 	}
 
-	k9sCmd.Flags().AddFlagSet(k9sRootCmd.Flags())
+	cmd.Flags().AddFlagSet(k9sRootCmd.Flags())
 
-	toolsCmd.AddCommand(k9sCmd)
+	return cmd
 }

--- a/src/cmd/tools/kubectl.go
+++ b/src/cmd/tools/kubectl.go
@@ -19,9 +19,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-func init() {
+// NewKubectlCommand creates the `tools kubectl` sub-command.
+func NewKubectlCommand() *cobra.Command {
 	// Kubectl stub command.
-	kubectlCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Short: lang.CmdToolsKubectlDocs,
 		Run:   func(_ *cobra.Command, _ []string) {},
 	}
@@ -29,17 +30,17 @@ func init() {
 	// Only load this command if it is being called directly.
 	if common.IsVendorCmd(os.Args, []string{"kubectl", "k"}) {
 		// Add the kubectl command to the tools command.
-		kubectlCmd = kubeCmd.NewDefaultKubectlCommand()
+		cmd = kubeCmd.NewDefaultKubectlCommand()
 
-		if err := kubeCLI.RunNoErrOutput(kubectlCmd); err != nil {
+		if err := kubeCLI.RunNoErrOutput(cmd); err != nil {
 			// @todo(jeff-mccoy) - Kubectl gets mad about being a subcommand.
 			message.Debug(err)
 			logger.Default().Debug(err.Error())
 		}
 	}
 
-	kubectlCmd.Use = "kubectl"
-	kubectlCmd.Aliases = []string{"k"}
+	cmd.Use = "kubectl"
+	cmd.Aliases = []string{"k"}
 
-	toolsCmd.AddCommand(kubectlCmd)
+	return cmd
 }

--- a/src/cmd/tools/syft.go
+++ b/src/cmd/tools/syft.go
@@ -7,25 +7,27 @@ package tools
 import (
 	"github.com/anchore/clio"
 	syftCLI "github.com/anchore/syft/cmd/syft/cli"
+	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/config/lang"
 )
 
 // ldflags github.com/zarf-dev/zarf/src/cmd/tools.syftVersion=x.x.x
 var syftVersion string
 
-func init() {
-	syftCmd := syftCLI.Command(clio.Identification{
+// NewSbomCommand creates the `tools sbom` sub-command.
+func NewSbomCommand() *cobra.Command {
+	cmd := syftCLI.Command(clio.Identification{
 		Name:    "syft",
 		Version: syftVersion,
 	})
-	syftCmd.Use = "sbom"
-	syftCmd.Short = lang.CmdToolsSbomShort
-	syftCmd.Aliases = []string{"s", "syft"}
-	syftCmd.Example = ""
+	cmd.Use = "sbom"
+	cmd.Short = lang.CmdToolsSbomShort
+	cmd.Aliases = []string{"s", "syft"}
+	cmd.Example = ""
 
-	for _, subCmd := range syftCmd.Commands() {
+	for _, subCmd := range cmd.Commands() {
 		subCmd.Example = ""
 	}
 
-	toolsCmd.AddCommand(syftCmd)
+	return cmd
 }

--- a/src/cmd/tools/wait.go
+++ b/src/cmd/tools/wait.go
@@ -17,50 +17,54 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-var (
+// WaitForOptions holds the command-line options for 'tools registry' sub-command.
+type WaitForOptions struct {
 	waitTimeout   string
 	waitNamespace string
-)
-
-var waitForCmd = &cobra.Command{
-	Use:     "wait-for { KIND | PROTOCOL } { NAME | SELECTOR | URI } { CONDITION | HTTP_CODE }",
-	Aliases: []string{"w", "wait"},
-	Short:   lang.CmdToolsWaitForShort,
-	Long:    lang.CmdToolsWaitForLong,
-	Example: lang.CmdToolsWaitForExample,
-	Args:    cobra.MinimumNArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		// Parse the timeout string
-		timeout, err := time.ParseDuration(waitTimeout)
-		if err != nil {
-			return fmt.Errorf("invalid timeout duration %s, use a valid duration string e.g. 1s, 2m, 3h: %w", waitTimeout, err)
-		}
-
-		kind := args[0]
-
-		// identifier is optional to allow for commands like `zarf tools wait-for storageclass` without specifying a name.
-		identifier := ""
-		if len(args) > 1 {
-			identifier = args[1]
-		}
-
-		// Condition is optional, default to "exists".
-		condition := ""
-		if len(args) > 2 {
-			condition = args[2]
-		}
-
-		// Execute the wait command.
-		if err := utils.ExecuteWait(waitTimeout, waitNamespace, condition, kind, identifier, timeout); err != nil {
-			return err
-		}
-		return err
-	},
 }
 
-func init() {
-	toolsCmd.AddCommand(waitForCmd)
-	waitForCmd.Flags().StringVar(&waitTimeout, "timeout", "5m", lang.CmdToolsWaitForFlagTimeout)
-	waitForCmd.Flags().StringVarP(&waitNamespace, "namespace", "n", "", lang.CmdToolsWaitForFlagNamespace)
-	waitForCmd.Flags().BoolVar(&message.NoProgress, "no-progress", false, lang.RootCmdFlagNoProgress)
+// NewWaitForCommand creates the `tools wait-for` sub-command.
+func NewWaitForCommand() *cobra.Command {
+	o := WaitForOptions{}
+	cmd := &cobra.Command{
+		Use:     "wait-for { KIND | PROTOCOL } { NAME | SELECTOR | URI } { CONDITION | HTTP_CODE }",
+		Aliases: []string{"w", "wait"},
+		Short:   lang.CmdToolsWaitForShort,
+		Long:    lang.CmdToolsWaitForLong,
+		Example: lang.CmdToolsWaitForExample,
+		Args:    cobra.MinimumNArgs(1),
+		RunE:    o.Run,
+	}
+
+	cmd.Flags().StringVar(&o.waitTimeout, "timeout", "5m", lang.CmdToolsWaitForFlagTimeout)
+	cmd.Flags().StringVarP(&o.waitNamespace, "namespace", "n", "", lang.CmdToolsWaitForFlagNamespace)
+	cmd.Flags().BoolVar(&message.NoProgress, "no-progress", false, lang.RootCmdFlagNoProgress)
+
+	return cmd
+}
+
+// Run performs the execution of 'tools wait-for' sub-command.
+func (o *WaitForOptions) Run(_ *cobra.Command, args []string) error {
+	// Parse the timeout string
+	timeout, err := time.ParseDuration(o.waitTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid timeout duration %s, use a valid duration string e.g. 1s, 2m, 3h: %w", o.waitTimeout, err)
+	}
+
+	kind := args[0]
+
+	// identifier is optional to allow for commands like `zarf tools wait-for storageclass` without specifying a name.
+	identifier := ""
+	if len(args) > 1 {
+		identifier = args[1]
+	}
+
+	// Condition is optional, default to "exists".
+	condition := ""
+	if len(args) > 2 {
+		condition = args[2]
+	}
+
+	// Execute the wait command.
+	return utils.ExecuteWait(o.waitTimeout, o.waitNamespace, condition, kind, identifier, timeout)
 }

--- a/src/cmd/tools/yq.go
+++ b/src/cmd/tools/yq.go
@@ -6,14 +6,16 @@ package tools
 
 import (
 	yq "github.com/mikefarah/yq/v4/cmd"
+	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/config/lang"
 )
 
-func init() {
-	yqCmd := yq.New()
-	yqCmd.Example = lang.CmdToolsYqExample
-	yqCmd.Use = "yq"
-	for _, subCmd := range yqCmd.Commands() {
+// NewYQCommand creates the `tools yq` sub-command and its nested children.
+func NewYQCommand() *cobra.Command {
+	cmd := yq.New()
+	cmd.Example = lang.CmdToolsYqExample
+	cmd.Use = "yq"
+	for _, subCmd := range cmd.Commands() {
 		if subCmd.Name() == "eval" {
 			subCmd.Example = lang.CmdToolsYqEvalExample
 		}
@@ -22,5 +24,5 @@ func init() {
 		}
 	}
 
-	toolsCmd.AddCommand(yqCmd)
+	return cmd
 }

--- a/src/cmd/tools/zarf.go
+++ b/src/cmd/tools/zarf.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/sigstore/cosign/v2/pkg/cosign"
-	"github.com/spf13/cobra"
-
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/zarf-dev/zarf/src/cmd/common"
 	"github.com/zarf-dev/zarf/src/config"
@@ -46,163 +46,55 @@ const (
 	agentKey        = "agent"
 )
 
-var getCredsCmd = &cobra.Command{
-	Use:     "get-creds",
-	Short:   lang.CmdToolsGetCredsShort,
-	Long:    lang.CmdToolsGetCredsLong,
-	Example: lang.CmdToolsGetCredsExample,
-	Aliases: []string{"gc"},
-	Args:    cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
+// GetCredsOptions holds the command-line options for 'tools get-creds' sub-command.
+type GetCredsOptions struct{}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
-		defer cancel()
-		c, err := cluster.NewClusterWithWait(timeoutCtx)
-		if err != nil {
-			return err
-		}
+// NewGetCredsCommand creates the `tools get-creds` sub-command.
+func NewGetCredsCommand() *cobra.Command {
+	o := GetCredsOptions{}
 
-		state, err := c.LoadZarfState(ctx)
-		if err != nil {
-			return err
-		}
-		// TODO: Determine if this is actually needed.
-		if state.Distro == "" {
-			return errors.New("zarf state secret did not load properly")
-		}
+	cmd := &cobra.Command{
+		Use:     "get-creds",
+		Short:   lang.CmdToolsGetCredsShort,
+		Long:    lang.CmdToolsGetCredsLong,
+		Example: lang.CmdToolsGetCredsExample,
+		Aliases: []string{"gc"},
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    o.Run,
+	}
 
-		if len(args) > 0 {
-			// If a component name is provided, only show that component's credentials
-			// Printing both the pterm output and slogger for now
-			printComponentCredential(ctx, state, args[0])
-			message.PrintComponentCredential(state, args[0])
-		} else {
-			message.PrintCredentialTable(state, nil)
-		}
-		return nil
-	},
+	return cmd
 }
 
-var updateCredsCmd = &cobra.Command{
-	Use:     "update-creds",
-	Short:   lang.CmdToolsUpdateCredsShort,
-	Long:    lang.CmdToolsUpdateCredsLong,
-	Example: lang.CmdToolsUpdateCredsExample,
-	Aliases: []string{"uc"},
-	Args:    cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		validKeys := []string{message.RegistryKey, message.GitKey, message.ArtifactKey, message.AgentKey}
-		if len(args) == 0 {
-			args = validKeys
-		} else {
-			if !slices.Contains(validKeys, args[0]) {
-				cmd.Help()
-				return fmt.Errorf("invalid service key specified, valid key choices are: %v", validKeys)
-			}
-		}
+// Run performs the execution of 'tools get-creds' sub-command.
+func (o *GetCredsOptions) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 
-		ctx := cmd.Context()
-		l := logger.From(ctx)
+	timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
+	defer cancel()
+	c, err := cluster.NewClusterWithWait(timeoutCtx)
+	if err != nil {
+		return err
+	}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
-		defer cancel()
-		c, err := cluster.NewClusterWithWait(timeoutCtx)
-		if err != nil {
-			return err
-		}
+	state, err := c.LoadZarfState(ctx)
+	if err != nil {
+		return err
+	}
+	// TODO: Determine if this is actually needed.
+	if state.Distro == "" {
+		return errors.New("zarf state secret did not load properly")
+	}
 
-		oldState, err := c.LoadZarfState(ctx)
-		if err != nil {
-			return err
-		}
-		// TODO: Determine if this is actually needed.
-		if oldState.Distro == "" {
-			return errors.New("zarf state secret did not load properly")
-		}
-		newState, err := cluster.MergeZarfState(oldState, updateCredsInitOpts, args)
-		if err != nil {
-			return fmt.Errorf("unable to update Zarf credentials: %w", err)
-		}
-
+	if len(args) > 0 {
+		// If a component name is provided, only show that component's credentials
 		// Printing both the pterm output and slogger for now
-		message.PrintCredentialUpdates(oldState, newState, args)
-		printCredentialUpdates(ctx, oldState, newState, args)
-
-		confirm := config.CommonOptions.Confirm
-
-		if !confirm {
-			prompt := &survey.Confirm{
-				Message: lang.CmdToolsUpdateCredsConfirmContinue,
-			}
-			if err := survey.AskOne(prompt, &confirm); err != nil {
-				return fmt.Errorf("confirm selection canceled: %w", err)
-			}
-		}
-
-		if confirm {
-			// Update registry and git pull secrets
-			if slices.Contains(args, message.RegistryKey) {
-				err := c.UpdateZarfManagedImageSecrets(ctx, newState)
-				if err != nil {
-					return err
-				}
-			}
-			if slices.Contains(args, message.GitKey) {
-				err := c.UpdateZarfManagedGitSecrets(ctx, newState)
-				if err != nil {
-					return err
-				}
-			}
-			// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
-			// and sufficient time has passed for users state to get updated we can remove this check
-			internalGitServerExists, err := c.InternalGitServerExists(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			// Update artifact token (if internal)
-			if slices.Contains(args, message.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
-				newState.ArtifactServer.PushToken, err = c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
-				if err != nil {
-					return fmt.Errorf("unable to create the new Gitea artifact token: %w", err)
-				}
-			}
-
-			// Save the final Zarf State
-			err = c.SaveZarfState(ctx, newState)
-			if err != nil {
-				return fmt.Errorf("failed to save the Zarf State to the cluster: %w", err)
-			}
-
-			// Update Zarf 'init' component Helm releases if present
-			h := helm.NewClusterOnly(&types.PackagerConfig{}, template.GetZarfVariableConfig(cmd.Context()), newState, c)
-
-			if slices.Contains(args, message.RegistryKey) && newState.RegistryInfo.IsInternal() {
-				err = h.UpdateZarfRegistryValues(ctx)
-				if err != nil {
-					// Warn if we couldn't actually update the registry (it might not be installed and we should try to continue)
-					message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateRegistry, err.Error())
-					l.Warn("unable to update Zarf Registry values", "error", err.Error())
-				}
-			}
-			if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
-				err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
-				if err != nil {
-					return fmt.Errorf("unable to update Zarf Git Server values: %w", err)
-				}
-			}
-			if slices.Contains(args, message.AgentKey) {
-				err = h.UpdateZarfAgentValues(ctx)
-				if err != nil {
-					// Warn if we couldn't actually update the agent (it might not be installed and we should try to continue)
-					message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateAgent, err.Error())
-					l.Warn("unable to update Zarf Agent TLS secrets", "error", err.Error())
-				}
-			}
-		}
-		return nil
-	},
+		printComponentCredential(ctx, state, args[0])
+		message.PrintComponentCredential(state, args[0])
+	} else {
+		message.PrintCredentialTable(state, nil)
+	}
+	return nil
 }
 
 func printComponentCredential(ctx context.Context, state *types.ZarfState, componentName string) {
@@ -223,6 +115,167 @@ func printComponentCredential(ctx context.Context, state *types.ZarfState, compo
 	default:
 		l.Warn("unknown component", "component", componentName)
 	}
+}
+
+// UpdateCredsOptions holds the command-line options for 'tools update-creds' sub-command.
+type UpdateCredsOptions struct{}
+
+// NewUpdateCredsCommand creates the `tools update-creds` sub-command.
+func NewUpdateCredsCommand(v *viper.Viper) *cobra.Command {
+	o := UpdateCredsOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "update-creds",
+		Short:   lang.CmdToolsUpdateCredsShort,
+		Long:    lang.CmdToolsUpdateCredsLong,
+		Example: lang.CmdToolsUpdateCredsExample,
+		Aliases: []string{"uc"},
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    o.Run,
+	}
+
+	// Always require confirm flag (no viper)
+	cmd.Flags().BoolVar(&config.CommonOptions.Confirm, "confirm", false, lang.CmdToolsUpdateCredsConfirmFlag)
+
+	// Flags for using an external Git server
+	cmd.Flags().StringVar(&updateCredsInitOpts.GitServer.Address, "git-url", v.GetString(common.VInitGitURL), lang.CmdInitFlagGitURL)
+	cmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PushUsername, "git-push-username", v.GetString(common.VInitGitPushUser), lang.CmdInitFlagGitPushUser)
+	cmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PushPassword, "git-push-password", v.GetString(common.VInitGitPushPass), lang.CmdInitFlagGitPushPass)
+	cmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PullUsername, "git-pull-username", v.GetString(common.VInitGitPullUser), lang.CmdInitFlagGitPullUser)
+	cmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PullPassword, "git-pull-password", v.GetString(common.VInitGitPullPass), lang.CmdInitFlagGitPullPass)
+
+	// Flags for using an external registry
+	cmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.Address, "registry-url", v.GetString(common.VInitRegistryURL), lang.CmdInitFlagRegURL)
+	cmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PushUsername, "registry-push-username", v.GetString(common.VInitRegistryPushUser), lang.CmdInitFlagRegPushUser)
+	cmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PushPassword, "registry-push-password", v.GetString(common.VInitRegistryPushPass), lang.CmdInitFlagRegPushPass)
+	cmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PullUsername, "registry-pull-username", v.GetString(common.VInitRegistryPullUser), lang.CmdInitFlagRegPullUser)
+	cmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PullPassword, "registry-pull-password", v.GetString(common.VInitRegistryPullPass), lang.CmdInitFlagRegPullPass)
+
+	// Flags for using an external artifact server
+	cmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.Address, "artifact-url", v.GetString(common.VInitArtifactURL), lang.CmdInitFlagArtifactURL)
+	cmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.PushUsername, "artifact-push-username", v.GetString(common.VInitArtifactPushUser), lang.CmdInitFlagArtifactPushUser)
+	cmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.PushToken, "artifact-push-token", v.GetString(common.VInitArtifactPushToken), lang.CmdInitFlagArtifactPushToken)
+
+	cmd.Flags().SortFlags = true
+
+	return cmd
+}
+
+// Run performs the execution of 'tools update-creds' sub-command.
+func (o *UpdateCredsOptions) Run(cmd *cobra.Command, args []string) error {
+	validKeys := []string{message.RegistryKey, message.GitKey, message.ArtifactKey, message.AgentKey}
+	if len(args) == 0 {
+		args = validKeys
+	} else {
+		if !slices.Contains(validKeys, args[0]) {
+			cmd.Help()
+			return fmt.Errorf("invalid service key specified, valid key choices are: %v", validKeys)
+		}
+	}
+
+	ctx := cmd.Context()
+	l := logger.From(ctx)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
+	defer cancel()
+	c, err := cluster.NewClusterWithWait(timeoutCtx)
+	if err != nil {
+		return err
+	}
+
+	oldState, err := c.LoadZarfState(ctx)
+	if err != nil {
+		return err
+	}
+	// TODO: Determine if this is actually needed.
+	if oldState.Distro == "" {
+		return errors.New("zarf state secret did not load properly")
+	}
+	newState, err := cluster.MergeZarfState(oldState, updateCredsInitOpts, args)
+	if err != nil {
+		return fmt.Errorf("unable to update Zarf credentials: %w", err)
+	}
+
+	// Printing both the pterm output and slogger for now
+	message.PrintCredentialUpdates(oldState, newState, args)
+	printCredentialUpdates(ctx, oldState, newState, args)
+
+	confirm := config.CommonOptions.Confirm
+
+	if !confirm {
+		prompt := &survey.Confirm{
+			Message: lang.CmdToolsUpdateCredsConfirmContinue,
+		}
+		if err := survey.AskOne(prompt, &confirm); err != nil {
+			return fmt.Errorf("confirm selection canceled: %w", err)
+		}
+	}
+
+	if !confirm {
+		return nil
+	}
+
+	// Update registry and git pull secrets
+	if slices.Contains(args, message.RegistryKey) {
+		err := c.UpdateZarfManagedImageSecrets(ctx, newState)
+		if err != nil {
+			return err
+		}
+	}
+	if slices.Contains(args, message.GitKey) {
+		err := c.UpdateZarfManagedGitSecrets(ctx, newState)
+		if err != nil {
+			return err
+		}
+	}
+	// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
+	// and sufficient time has passed for users state to get updated we can remove this check
+	internalGitServerExists, err := c.InternalGitServerExists(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	// Update artifact token (if internal)
+	if slices.Contains(args, message.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
+		newState.ArtifactServer.PushToken, err = c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
+		if err != nil {
+			return fmt.Errorf("unable to create the new Gitea artifact token: %w", err)
+		}
+	}
+
+	// Save the final Zarf State
+	err = c.SaveZarfState(ctx, newState)
+	if err != nil {
+		return fmt.Errorf("failed to save the Zarf State to the cluster: %w", err)
+	}
+
+	// Update Zarf 'init' component Helm releases if present
+	h := helm.NewClusterOnly(&types.PackagerConfig{}, template.GetZarfVariableConfig(cmd.Context()), newState, c)
+
+	if slices.Contains(args, message.RegistryKey) && newState.RegistryInfo.IsInternal() {
+		err = h.UpdateZarfRegistryValues(ctx)
+		if err != nil {
+			// Warn if we couldn't actually update the registry (it might not be installed and we should try to continue)
+			message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateRegistry, err.Error())
+			l.Warn("unable to update Zarf Registry values", "error", err.Error())
+		}
+	}
+	if slices.Contains(args, message.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
+		err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
+		if err != nil {
+			return fmt.Errorf("unable to update Zarf Git Server values: %w", err)
+		}
+	}
+	if slices.Contains(args, message.AgentKey) {
+		err = h.UpdateZarfAgentValues(ctx)
+		if err != nil {
+			// Warn if we couldn't actually update the agent (it might not be installed and we should try to continue)
+			message.Warnf(lang.CmdToolsUpdateCredsUnableUpdateAgent, err.Error())
+			l.Warn("unable to update Zarf Agent TLS secrets", "error", err.Error())
+		}
+	}
+
+	return nil
 }
 
 func printCredentialUpdates(ctx context.Context, oldState *types.ZarfState, newState *types.ZarfState, services []string) {
@@ -263,184 +316,202 @@ func printCredentialUpdates(ctx context.Context, oldState *types.ZarfState, newS
 	}
 }
 
-var clearCacheCmd = &cobra.Command{
-	Use:     "clear-cache",
-	Aliases: []string{"c"},
-	Short:   lang.CmdToolsClearCacheShort,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		l := logger.From(cmd.Context())
-		cachePath, err := config.GetAbsCachePath()
-		if err != nil {
-			return err
-		}
-		message.Notef(lang.CmdToolsClearCacheDir, cachePath)
-		l.Info("clearing cache", "path", cachePath)
-		if err := os.RemoveAll(cachePath); err != nil {
-			return fmt.Errorf("unable to clear the cache directory %s: %w", cachePath, err)
-		}
-		message.Successf(lang.CmdToolsClearCacheSuccess, cachePath)
-		return nil
-	},
+// ClearCacheOptions holds the command-line options for 'tools clear-cache' sub-command.
+type ClearCacheOptions struct{}
+
+// NewClearCacheCommand creates the `tools clear-cache` sub-command.
+func NewClearCacheCommand() *cobra.Command {
+	o := &ClearCacheOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "clear-cache",
+		Aliases: []string{"c"},
+		Short:   lang.CmdToolsClearCacheShort,
+		RunE:    o.Run,
+	}
+
+	cmd.Flags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", config.ZarfDefaultCachePath, lang.CmdToolsClearCacheFlagCachePath)
+
+	return cmd
 }
 
-var downloadInitCmd = &cobra.Command{
-	Use:   "download-init",
-	Short: lang.CmdToolsDownloadInitShort,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		ctx := cmd.Context()
-		url := zoci.GetInitPackageURL(config.CLIVersion)
-		remote, err := zoci.NewRemote(ctx, url, oci.PlatformForArch(config.GetArch()))
-		if err != nil {
-			return fmt.Errorf("unable to download the init package: %w", err)
-		}
-		source := &sources.OCISource{Remote: remote}
-		_, err = source.Collect(ctx, outputDirectory)
-		if err != nil {
-			return fmt.Errorf("unable to download the init package: %w", err)
-		}
-		return nil
-	},
+// Run performs the execution of 'tools clear-cache' sub-command.
+func (o *ClearCacheOptions) Run(cmd *cobra.Command, _ []string) error {
+	l := logger.From(cmd.Context())
+	cachePath, err := config.GetAbsCachePath()
+	if err != nil {
+		return err
+	}
+	message.Notef(lang.CmdToolsClearCacheDir, cachePath)
+	l.Info("clearing cache", "path", cachePath)
+	if err := os.RemoveAll(cachePath); err != nil {
+		return fmt.Errorf("unable to clear the cache directory %s: %w", cachePath, err)
+	}
+	message.Successf(lang.CmdToolsClearCacheSuccess, cachePath)
+
+	return nil
 }
 
-var generatePKICmd = &cobra.Command{
-	Use:     "gen-pki HOST",
-	Aliases: []string{"pki"},
-	Short:   lang.CmdToolsGenPkiShort,
-	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pki, err := pki.GeneratePKI(args[0], subAltNames...)
+// DownloadInitOptions holds the command-line options for 'tools download-init' sub-command.
+type DownloadInitOptions struct{}
+
+// NewDownloadInitCommand creates the `tools download-init` sub-command.
+func NewDownloadInitCommand() *cobra.Command {
+	o := &DownloadInitOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "download-init",
+		Short: lang.CmdToolsDownloadInitShort,
+		RunE:  o.Run,
+	}
+
+	cmd.Flags().StringVarP(&outputDirectory, "output-directory", "o", "", lang.CmdToolsDownloadInitFlagOutputDirectory)
+
+	return cmd
+}
+
+// Run performs the execution of 'tools download-init' sub-command.
+func (o *DownloadInitOptions) Run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	url := zoci.GetInitPackageURL(config.CLIVersion)
+	remote, err := zoci.NewRemote(ctx, url, oci.PlatformForArch(config.GetArch()))
+	if err != nil {
+		return fmt.Errorf("unable to download the init package: %w", err)
+	}
+	source := &sources.OCISource{Remote: remote}
+	_, err = source.Collect(ctx, outputDirectory)
+	if err != nil {
+		return fmt.Errorf("unable to download the init package: %w", err)
+	}
+	return nil
+}
+
+// GenPKIOptions holds the command-line options for 'tools gen-pki' sub-command.
+type GenPKIOptions struct{}
+
+// NewGenPKICommand creates the `tools gen-pki` sub-command.
+func NewGenPKICommand() *cobra.Command {
+	o := &GenPKIOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "gen-pki HOST",
+		Aliases: []string{"pki"},
+		Short:   lang.CmdToolsGenPkiShort,
+		Args:    cobra.ExactArgs(1),
+		RunE:    o.Run,
+	}
+
+	cmd.Flags().StringArrayVar(&subAltNames, "sub-alt-name", []string{}, lang.CmdToolsGenPkiFlagAltName)
+
+	return cmd
+}
+
+// Run performs the execution of 'tools gen-pki' sub-command.
+func (o *GenPKIOptions) Run(cmd *cobra.Command, args []string) error {
+	pki, err := pki.GeneratePKI(args[0], subAltNames...)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile("tls.ca", pki.CA, helpers.ReadAllWriteUser); err != nil {
+		return err
+	}
+	if err := os.WriteFile("tls.crt", pki.Cert, helpers.ReadAllWriteUser); err != nil {
+		return err
+	}
+	if err := os.WriteFile("tls.key", pki.Key, helpers.ReadWriteUser); err != nil {
+		return err
+	}
+	message.Successf(lang.CmdToolsGenPkiSuccess, args[0])
+	logger.From(cmd.Context()).Info("successfully created a chain of trust", "host", args[0])
+
+	return nil
+}
+
+// GenKeyOptions holds the command-line options for 'tools gen-key' sub-command.
+type GenKeyOptions struct{}
+
+// NewGenKeyCommand creates the `tools gen-key` sub-command.
+func NewGenKeyCommand() *cobra.Command {
+	o := &GenKeyOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "gen-key",
+		Aliases: []string{"key"},
+		Short:   lang.CmdToolsGenKeyShort,
+		RunE:    o.Run,
+	}
+
+	return cmd
+}
+
+// Run performs the execution of 'tools gen-key' sub-command.
+func (o *GenKeyOptions) Run(cmd *cobra.Command, _ []string) error {
+	// Utility function to prompt the user for the password to the private key
+	passwordFunc := func(bool) ([]byte, error) {
+		// perform the first prompt
+		var password string
+		prompt := &survey.Password{
+			Message: lang.CmdToolsGenKeyPrompt,
+		}
+		if err := survey.AskOne(prompt, &password); err != nil {
+			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
+		}
+
+		// perform the second prompt
+		var doubleCheck string
+		rePrompt := &survey.Password{
+			Message: lang.CmdToolsGenKeyPromptAgain,
+		}
+		if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
+			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
+		}
+
+		// check if the passwords match
+		if password != doubleCheck {
+			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
+		}
+
+		return []byte(password), nil
+	}
+
+	// Use cosign to generate the keypair
+	keyBytes, err := cosign.GenerateKeyPair(passwordFunc)
+	if err != nil {
+		return fmt.Errorf("unable to generate key pair: %w", err)
+	}
+
+	prvKeyFileName := "cosign.key"
+	pubKeyFileName := "cosign.pub"
+
+	// Check if we are about to overwrite existing key files
+	_, prvKeyExistsErr := os.Stat(prvKeyFileName)
+	_, pubKeyExistsErr := os.Stat(pubKeyFileName)
+	if prvKeyExistsErr == nil || pubKeyExistsErr == nil {
+		var confirm bool
+		confirmOverwritePrompt := &survey.Confirm{
+			Message: fmt.Sprintf(lang.CmdToolsGenKeyPromptExists, prvKeyFileName),
+		}
+		err := survey.AskOne(confirmOverwritePrompt, &confirm)
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile("tls.ca", pki.CA, helpers.ReadAllWriteUser); err != nil {
-			return err
+		if !confirm {
+			return errors.New("did not receive confirmation for overwriting key file(s)")
 		}
-		if err := os.WriteFile("tls.crt", pki.Cert, helpers.ReadAllWriteUser); err != nil {
-			return err
-		}
-		if err := os.WriteFile("tls.key", pki.Key, helpers.ReadWriteUser); err != nil {
-			return err
-		}
-		message.Successf(lang.CmdToolsGenPkiSuccess, args[0])
-		logger.From(cmd.Context()).Info("successfully created a chain of trust", "host", args[0])
-		return nil
-	},
-}
+	}
 
-var generateKeyCmd = &cobra.Command{
-	Use:     "gen-key",
-	Aliases: []string{"key"},
-	Short:   lang.CmdToolsGenKeyShort,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Utility function to prompt the user for the password to the private key
-		passwordFunc := func(bool) ([]byte, error) {
-			// perform the first prompt
-			var password string
-			prompt := &survey.Password{
-				Message: lang.CmdToolsGenKeyPrompt,
-			}
-			if err := survey.AskOne(prompt, &password); err != nil {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
-			}
+	// Write the key file contents to disk
+	if err := os.WriteFile(prvKeyFileName, keyBytes.PrivateBytes, helpers.ReadWriteUser); err != nil {
+		return err
+	}
+	if err := os.WriteFile(pubKeyFileName, keyBytes.PublicBytes, helpers.ReadAllWriteUser); err != nil {
+		return err
+	}
 
-			// perform the second prompt
-			var doubleCheck string
-			rePrompt := &survey.Password{
-				Message: lang.CmdToolsGenKeyPromptAgain,
-			}
-			if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
-			}
+	message.Successf(lang.CmdToolsGenKeySuccess, prvKeyFileName, pubKeyFileName)
+	logger.From(cmd.Context()).Info("Successfully generated key pair",
+		"private-key-path", prvKeyExistsErr,
+		"public-key-path", pubKeyFileName)
 
-			// check if the passwords match
-			if password != doubleCheck {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
-			}
-
-			return []byte(password), nil
-		}
-
-		// Use cosign to generate the keypair
-		keyBytes, err := cosign.GenerateKeyPair(passwordFunc)
-		if err != nil {
-			return fmt.Errorf("unable to generate key pair: %w", err)
-		}
-
-		prvKeyFileName := "cosign.key"
-		pubKeyFileName := "cosign.pub"
-
-		// Check if we are about to overwrite existing key files
-		_, prvKeyExistsErr := os.Stat(prvKeyFileName)
-		_, pubKeyExistsErr := os.Stat(pubKeyFileName)
-		if prvKeyExistsErr == nil || pubKeyExistsErr == nil {
-			var confirm bool
-			confirmOverwritePrompt := &survey.Confirm{
-				Message: fmt.Sprintf(lang.CmdToolsGenKeyPromptExists, prvKeyFileName),
-			}
-			err := survey.AskOne(confirmOverwritePrompt, &confirm)
-			if err != nil {
-				return err
-			}
-			if !confirm {
-				return errors.New("did not receive confirmation for overwriting key file(s)")
-			}
-		}
-
-		// Write the key file contents to disk
-		if err := os.WriteFile(prvKeyFileName, keyBytes.PrivateBytes, helpers.ReadWriteUser); err != nil {
-			return err
-		}
-		if err := os.WriteFile(pubKeyFileName, keyBytes.PublicBytes, helpers.ReadAllWriteUser); err != nil {
-			return err
-		}
-
-		message.Successf(lang.CmdToolsGenKeySuccess, prvKeyFileName, pubKeyFileName)
-		logger.From(cmd.Context()).Info("Successfully generated key pair",
-			"private-key-path", prvKeyExistsErr,
-			"public-key-path", pubKeyFileName)
-		return nil
-	},
-}
-
-func init() {
-	v := common.InitViper()
-
-	toolsCmd.AddCommand(getCredsCmd)
-
-	toolsCmd.AddCommand(updateCredsCmd)
-
-	// Always require confirm flag (no viper)
-	updateCredsCmd.Flags().BoolVar(&config.CommonOptions.Confirm, "confirm", false, lang.CmdToolsUpdateCredsConfirmFlag)
-
-	// Flags for using an external Git server
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.GitServer.Address, "git-url", v.GetString(common.VInitGitURL), lang.CmdInitFlagGitURL)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PushUsername, "git-push-username", v.GetString(common.VInitGitPushUser), lang.CmdInitFlagGitPushUser)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PushPassword, "git-push-password", v.GetString(common.VInitGitPushPass), lang.CmdInitFlagGitPushPass)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PullUsername, "git-pull-username", v.GetString(common.VInitGitPullUser), lang.CmdInitFlagGitPullUser)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.GitServer.PullPassword, "git-pull-password", v.GetString(common.VInitGitPullPass), lang.CmdInitFlagGitPullPass)
-
-	// Flags for using an external registry
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.Address, "registry-url", v.GetString(common.VInitRegistryURL), lang.CmdInitFlagRegURL)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PushUsername, "registry-push-username", v.GetString(common.VInitRegistryPushUser), lang.CmdInitFlagRegPushUser)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PushPassword, "registry-push-password", v.GetString(common.VInitRegistryPushPass), lang.CmdInitFlagRegPushPass)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PullUsername, "registry-pull-username", v.GetString(common.VInitRegistryPullUser), lang.CmdInitFlagRegPullUser)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.RegistryInfo.PullPassword, "registry-pull-password", v.GetString(common.VInitRegistryPullPass), lang.CmdInitFlagRegPullPass)
-
-	// Flags for using an external artifact server
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.Address, "artifact-url", v.GetString(common.VInitArtifactURL), lang.CmdInitFlagArtifactURL)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.PushUsername, "artifact-push-username", v.GetString(common.VInitArtifactPushUser), lang.CmdInitFlagArtifactPushUser)
-	updateCredsCmd.Flags().StringVar(&updateCredsInitOpts.ArtifactServer.PushToken, "artifact-push-token", v.GetString(common.VInitArtifactPushToken), lang.CmdInitFlagArtifactPushToken)
-
-	updateCredsCmd.Flags().SortFlags = true
-
-	toolsCmd.AddCommand(clearCacheCmd)
-	clearCacheCmd.Flags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", config.ZarfDefaultCachePath, lang.CmdToolsClearCacheFlagCachePath)
-
-	toolsCmd.AddCommand(downloadInitCmd)
-	downloadInitCmd.Flags().StringVarP(&outputDirectory, "output-directory", "o", "", lang.CmdToolsDownloadInitFlagOutputDirectory)
-
-	toolsCmd.AddCommand(generatePKICmd)
-	generatePKICmd.Flags().StringArrayVar(&subAltNames, "sub-alt-name", []string{}, lang.CmdToolsGenPkiFlagAltName)
-
-	toolsCmd.AddCommand(generateKeyCmd)
+	return nil
 }


### PR DESCRIPTION
## Description
Continuation of the effort to isolate commands. Followup to #3322.

This PR additionally changes how viper is initiated, see the first commit for that specifically. 

## Related Issue
Relates to #2773

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
