### PR TITLE
fix: include key in nightly e2e pull from ecr test

### DIFF
--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -49,8 +49,8 @@ jobs:
         if: always()
         uses: ./.github/actions/save-logs
 
-      - name: Send trigger to Slack on workflow failure
-        if: failure()
-        uses: ./.github/actions/slack
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Send trigger to Slack on workflow failure
+      #   if: failure()
+      #   uses: ./.github/actions/slack
+      #   with:
+      #     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-ecr.yml
+++ b/.github/workflows/nightly-ecr.yml
@@ -49,8 +49,8 @@ jobs:
         if: always()
         uses: ./.github/actions/save-logs
 
-      # - name: Send trigger to Slack on workflow failure
-      #   if: failure()
-      #   uses: ./.github/actions/slack
-      #   with:
-      #     slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Send trigger to Slack on workflow failure
+        if: failure()
+        uses: ./.github/actions/slack
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -31,9 +31,10 @@ $ zarf package pull oci://ghcr.io/defenseunicorns/packages/dos-games:1.0.0 -a sk
 ### Options
 
 ```
-  -h, --help                      help for pull
-  -o, --output-directory string   Specify the output directory for the pulled Zarf package
-      --shasum string             Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
+  -h, --help                        help for pull
+  -o, --output-directory string     Specify the output directory for the pulled Zarf package
+      --shasum string               Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
+      --skip-signature-validation   Skip validating the signature of the Zarf package
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -615,6 +615,7 @@ func NewPackagePullCommand(v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringVar(&pkgConfig.PkgOpts.Shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().StringVarP(&pkgConfig.PullOpts.OutputDirectory, "output-directory", "o", v.GetString(common.VPkgPullOutputDir), lang.CmdPackagePullFlagOutputDirectory)
+	cmd.Flags().BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 
 	return cmd
 }
@@ -629,7 +630,7 @@ func (o *PackagePullOptions) Run(cmd *cobra.Command, args []string) error {
 		}
 		outputDir = wd
 	}
-	err := packager2.Pull(cmd.Context(), args[0], outputDir, pkgConfig.PkgOpts.Shasum, filters.Empty(), pkgConfig.PkgOpts.PublicKeyPath)
+	err := packager2.Pull(cmd.Context(), args[0], outputDir, pkgConfig.PkgOpts.Shasum, filters.Empty(), pkgConfig.PkgOpts.PublicKeyPath, pkgConfig.PkgOpts.SkipSignatureValidation)
 	if err != nil {
 		return err
 	}

--- a/src/internal/packager2/pull_test.go
+++ b/src/internal/packager2/pull_test.go
@@ -39,7 +39,7 @@ func TestPull(t *testing.T) {
 
 	dir := t.TempDir()
 	shasum := "bef73d652f004d214d5cf9e00195293f7ae8390b8ff6ed45e39c2c9eb622b873"
-	err := Pull(ctx, srv.URL, dir, shasum, filters.Empty(), "")
+	err := Pull(ctx, srv.URL, dir, shasum, filters.Empty(), "", false)
 	require.NoError(t, err)
 
 	packageData, err := os.ReadFile(packagePath)

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -52,7 +52,10 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http")
 	suite.Error(err, stdOut, stdErr)
 
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", publicKeyFlag)
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", publicKeyFlag, "-o", outputPath)
+	suite.NoError(err, stdOut, stdErr)
+
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "--skip-signature-validation", "-o", outputPath)
 	suite.NoError(err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", simplePackageRef, "--plain-http")

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -63,16 +63,12 @@ func TestECRPublishing(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Validate that we can pull the package down from ECR
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL)
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL, keyFlag, fmt.Sprintf("-o=%s", tmpDir))
 	require.NoError(t, err, stdOut, stdErr)
-	defer e2e.CleanFiles(t, testPackageFileName)
 
-	// Ensure we get a warning when trying to inspect the package without providing the public key
-	// and the insecure flag
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
 
-	// Validate that we get no warnings when inspecting the package while providing the public key
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, keyFlag)
 	require.NoError(t, err, stdOut, stdErr)
 }

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -63,14 +63,15 @@ func TestECRPublishing(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	// Validate that we can pull the package down from ECR
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL, keyFlag, fmt.Sprintf("-o=%s", tmpDir))
+	pullTempDir := t.TempDir()
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL, keyFlag, fmt.Sprintf("-o=%s", pullTempDir))
 	require.NoError(t, err, stdOut, stdErr)
 
-	pulledPath := filepath.Join(tmpDir, testPackageFileName)
+	pulledPackagePath := filepath.Join(pullTempDir, testPackageFileName)
 
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPath, "--skip-signature-validation")
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPackagePath, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
 
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPath, keyFlag)
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPackagePath, keyFlag)
 	require.NoError(t, err, stdOut, stdErr)
 }

--- a/src/test/nightly/ecr_publish_test.go
+++ b/src/test/nightly/ecr_publish_test.go
@@ -66,9 +66,11 @@ func TestECRPublishing(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "pull", upstreamPackageURL, keyFlag, fmt.Sprintf("-o=%s", tmpDir))
 	require.NoError(t, err, stdOut, stdErr)
 
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, "--skip-signature-validation")
+	pulledPath := filepath.Join(tmpDir, testPackageFileName)
+
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPath, "--skip-signature-validation")
 	require.NoError(t, err, stdOut, stdErr)
 
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", testPackageFileName, keyFlag)
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", pulledPath, keyFlag)
 	require.NoError(t, err, stdOut, stdErr)
 }


### PR DESCRIPTION
## Description

During #3348 we added the requirement to use the `--key` flag for signed packages during `zarf package pull`. This broke a nightly test . Additionally, we did not add the `--skip-signature-validation` flag in #3348 which should have been added

Relates to #3346 

Manually run workflow showing it's fixed - https://github.com/zarf-dev/zarf/actions/runs/12416094320

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
