### PR TITLE
chore: group cosign providers dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,9 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+      cosign-providers:
+        patterns:
+          - "github.com/sigstore/sigstore/pkg/signature/kms/*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Description

These tend to release around the same time and cause a lot of dependabot PRs / dependabot rebasing

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
