### PR TITLE
refactor: Create structs for each tools command to better isolate commands - cont'd

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -145,6 +145,8 @@ func NewZarfCommand() *cobra.Command {
 	rootCmd.AddCommand(NewInternalCommand(rootCmd))
 	rootCmd.AddCommand(NewPackageCommand())
 
+	rootCmd.AddCommand(NewVersionCommand())
+
 	return rootCmd
 }
 

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -19,70 +19,81 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 )
 
-var outputFormat string
-
-var versionCmd = &cobra.Command{
-	Use:     "version",
-	Aliases: []string{"v"},
-	Short:   lang.CmdVersionShort,
-	Long:    lang.CmdVersionLong,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		if outputFormat == "" {
-			fmt.Println(config.CLIVersion)
-			return nil
-		}
-
-		output := make(map[string]interface{})
-		output["version"] = config.CLIVersion
-
-		buildInfo, ok := debug.ReadBuildInfo()
-		if !ok {
-			return errors.New("failed to get build info")
-		}
-		depMap := map[string]string{}
-		for _, dep := range buildInfo.Deps {
-			if dep.Replace != nil {
-				depMap[dep.Path] = fmt.Sprintf("%s -> %s %s", dep.Version, dep.Replace.Path, dep.Replace.Version)
-			} else {
-				depMap[dep.Path] = dep.Version
-			}
-		}
-		output["dependencies"] = depMap
-
-		buildMap := make(map[string]interface{})
-		buildMap["platform"] = runtime.GOOS + "/" + runtime.GOARCH
-		buildMap["goVersion"] = runtime.Version()
-		ver, err := semver.NewVersion(config.CLIVersion)
-		if err != nil && !errors.Is(err, semver.ErrInvalidSemVer) {
-			return fmt.Errorf("Could not parse CLI version %s: %w", config.CLIVersion, err)
-		}
-		if ver != nil {
-			buildMap["major"] = ver.Major()
-			buildMap["minor"] = ver.Minor()
-			buildMap["patch"] = ver.Patch()
-			buildMap["prerelease"] = ver.Prerelease()
-		}
-		output["build"] = buildMap
-
-		switch outputFormat {
-		case "yaml":
-			b, err := goyaml.Marshal(output)
-			if err != nil {
-				return fmt.Errorf("could not marshal yaml output: %w", err)
-			}
-			fmt.Println(string(b))
-		case "json":
-			b, err := json.Marshal(output)
-			if err != nil {
-				return fmt.Errorf("could not marshal json output: %w", err)
-			}
-			fmt.Println(string(b))
-		}
-		return nil
-	},
+// VersionOptions holds the command-line options for 'version' sub-command.
+type VersionOptions struct {
+	outputFormat string
 }
 
-func init() {
-	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json)")
-	rootCmd.AddCommand(versionCmd)
+// NewVersionCommand creates the `version` sub-command.
+func NewVersionCommand() *cobra.Command {
+	o := VersionOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   lang.CmdVersionShort,
+		Long:    lang.CmdVersionLong,
+		RunE:    o.Run,
+	}
+
+	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "", "Output format (yaml|json)")
+
+	return cmd
+}
+
+// Run performs the execution of 'version' sub-command.
+func (o *VersionOptions) Run(_ *cobra.Command, _ []string) error {
+	if o.outputFormat == "" {
+		fmt.Println(config.CLIVersion)
+		return nil
+	}
+
+	output := make(map[string]interface{})
+	output["version"] = config.CLIVersion
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return errors.New("failed to get build info")
+	}
+	depMap := map[string]string{}
+	for _, dep := range buildInfo.Deps {
+		if dep.Replace != nil {
+			depMap[dep.Path] = fmt.Sprintf("%s -> %s %s", dep.Version, dep.Replace.Path, dep.Replace.Version)
+		} else {
+			depMap[dep.Path] = dep.Version
+		}
+	}
+	output["dependencies"] = depMap
+
+	buildMap := make(map[string]interface{})
+	buildMap["platform"] = runtime.GOOS + "/" + runtime.GOARCH
+	buildMap["goVersion"] = runtime.Version()
+	ver, err := semver.NewVersion(config.CLIVersion)
+	if err != nil && !errors.Is(err, semver.ErrInvalidSemVer) {
+		return fmt.Errorf("Could not parse CLI version %s: %w", config.CLIVersion, err)
+	}
+	if ver != nil {
+		buildMap["major"] = ver.Major()
+		buildMap["minor"] = ver.Minor()
+		buildMap["patch"] = ver.Patch()
+		buildMap["prerelease"] = ver.Prerelease()
+	}
+	output["build"] = buildMap
+
+	switch o.outputFormat {
+	case "yaml":
+		b, err := goyaml.Marshal(output)
+		if err != nil {
+			return fmt.Errorf("could not marshal yaml output: %w", err)
+		}
+		fmt.Println(string(b))
+	case "json":
+		b, err := json.Marshal(output)
+		if err != nil {
+			return fmt.Errorf("could not marshal json output: %w", err)
+		}
+		fmt.Println(string(b))
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
Continuation of the effort to isolate commands. Followup to #3322 and #3340.

The remaining bit is the root command, `src/pkg/message/message.go` and `src/pkg/logger/logger.go`, which I'll need to tackle separately. Since I'm worried about potential impact it might have on all of zarf (the latter two), and on consumers of zarf (the root command). So I will want to coordinate the efforts. 

## Related Issue
Relates to #2773

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
