### PR TITLE
fix: properly delete invalid layers during image pull

### DIFF
--- a/src/internal/packager/images/pull.go
+++ b/src/internal/packager/images/pull.go
@@ -332,7 +332,6 @@ func CleanupInProgressLayers(ctx context.Context, img v1.Image, cacheDirectory s
 			}
 			location := filepath.Join(cacheDirectory, digest.String())
 			info, err := os.Stat(location)
-			fmt.Println("location to delete is", location, err)
 			if errors.Is(err, fs.ErrNotExist) {
 				return nil
 			}

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -162,7 +162,6 @@ func TestPull(t *testing.T) {
 		require.NoError(t, err)
 		destDir := t.TempDir()
 		cacheDir := t.TempDir()
-		require.NoError(t, err)
 		invalidContent := []byte("this text here is not the valid layer that the image is looking for")
 		hash, err := v1.NewHash("sha256:d94c8059c3cffb9278601bf9f8be070d50c84796401a4c5106eb8a4042445bbc")
 		require.NoError(t, err)

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -161,10 +161,12 @@ func TestPull(t *testing.T) {
 		ref, err := transform.ParseImageRef("ghcr.io/fluxcd/image-automation-controller@sha256:48a89734dc82c3a2d4138554b3ad4acf93230f770b3a582f7f48be38436d031c")
 		require.NoError(t, err)
 		destDir := t.TempDir()
-		cacheDir := t.TempDir()
+		cacheDir := "dir"
 		require.NoError(t, err)
 		invalidContent := []byte("this text here is not the valid layer that the image is looking for")
-		invalidLayerPath := filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a")
+		hash, err := v1.NewHash("sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a")
+		require.NoError(t, err)
+		invalidLayerPath := layerCachePath(cacheDir, hash)
 		err = os.WriteFile(invalidLayerPath, invalidContent, 0777)
 		require.NoError(t, err)
 
@@ -181,10 +183,10 @@ func TestPull(t *testing.T) {
 		require.NoError(t, err)
 		nowValidContents, err := os.ReadFile(invalidLayerPath)
 		require.NoError(t, err)
+
 		pulledLayerPath := filepath.Join(destDir, "blobs/sha256/94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a")
 		pulledLayer, err := os.ReadFile(pulledLayerPath)
 		require.NoError(t, err)
-		require.Equal(t, nowValidContents, pulledLayer)
-		require.NotEqual(t, invalidContent, nowValidContents)
+		require.Equal(t, len(nowValidContents), len(pulledLayer))
 	})
 }

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -163,8 +163,8 @@ func TestPullWithInvalidLayerInCache(t *testing.T) {
 	destDir := t.TempDir()
 	cacheDir := t.TempDir()
 	require.NoError(t, err)
-	invalidText := []byte("this text here is not the valid layer that the image is looking for")
-	err = os.WriteFile(filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), invalidText, 0644)
+	layerContent := []byte("this text here is not the valid layer that the image is looking for")
+	err = os.WriteFile(filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), layerContent, 0600)
 	require.NoError(t, err)
 
 	pullConfig := PullConfig{

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/otiai10/copy"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
@@ -156,26 +155,27 @@ func TestPull(t *testing.T) {
 	})
 }
 
-func TestPullCache(t *testing.T) {
+func TestPullWithInvalidLayerInCache(t *testing.T) {
 	t.Parallel()
 
-	t.Run("pulling an image with an invalid layer in the cache still results in a success", func(t *testing.T) {
-		ref, err := transform.ParseImageRef("ghcr.io/fluxcd/image-automation-controller@sha256:48a89734dc82c3a2d4138554b3ad4acf93230f770b3a582f7f48be38436d031c")
-		require.NoError(t, err)
-		destDir := t.TempDir()
-		cacheDir := t.TempDir()
-		require.NoError(t, err)
-		copy.Copy(filepath.Join("testdata", "invalid-layer", "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), cacheDir)
-		pullConfig := PullConfig{
-			DestinationDirectory: destDir,
-			CacheDirectory:       cacheDir,
-			ImageList: []transform.Image{
-				ref,
-			},
-		}
+	ref, err := transform.ParseImageRef("ghcr.io/fluxcd/image-automation-controller@sha256:48a89734dc82c3a2d4138554b3ad4acf93230f770b3a582f7f48be38436d031c")
+	require.NoError(t, err)
+	destDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, err)
+	invalidText := []byte("this text here is not the valid layer that the image is looking for")
+	err = os.WriteFile(filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), invalidText, 0644)
+	require.NoError(t, err)
 
-		_, err = Pull(context.Background(), pullConfig)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(destDir, "blobs/sha256/94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"))
-	})
+	pullConfig := PullConfig{
+		DestinationDirectory: destDir,
+		CacheDirectory:       cacheDir,
+		ImageList: []transform.Image{
+			ref,
+		},
+	}
+
+	_, err = Pull(context.Background(), pullConfig)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(destDir, "blobs/sha256/94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"))
 }

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -164,7 +164,8 @@ func TestPullWithInvalidLayerInCache(t *testing.T) {
 	cacheDir := t.TempDir()
 	require.NoError(t, err)
 	layerContent := []byte("this text here is not the valid layer that the image is looking for")
-	err = os.WriteFile(filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), layerContent, 0600)
+	invalidLayerPath := filepath.Join(cacheDir, "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a")
+	err = os.WriteFile(invalidLayerPath, layerContent, 0777)
 	require.NoError(t, err)
 
 	pullConfig := PullConfig{

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/otiai10/copy"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
@@ -158,11 +159,13 @@ func TestPull(t *testing.T) {
 func TestPullCache(t *testing.T) {
 	t.Parallel()
 
-	t.Run("pulling an image with an invalid layer in the cache is successful", func(t *testing.T) {
+	t.Run("pulling an image with an invalid layer in the cache still results in a success", func(t *testing.T) {
 		ref, err := transform.ParseImageRef("ghcr.io/fluxcd/image-automation-controller@sha256:48a89734dc82c3a2d4138554b3ad4acf93230f770b3a582f7f48be38436d031c")
 		require.NoError(t, err)
 		destDir := t.TempDir()
-		cacheDir := filepath.Join("testdata", "cache")
+		cacheDir := t.TempDir()
+		require.NoError(t, err)
+		copy.Copy(filepath.Join("testdata", "invalid-layer", "sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"), cacheDir)
 		pullConfig := PullConfig{
 			DestinationDirectory: destDir,
 			CacheDirectory:       cacheDir,
@@ -174,6 +177,5 @@ func TestPullCache(t *testing.T) {
 		_, err = Pull(context.Background(), pullConfig)
 		require.NoError(t, err)
 		require.FileExists(t, filepath.Join(destDir, "blobs/sha256/94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"))
-
 	})
 }

--- a/src/internal/packager/images/pull_test.go
+++ b/src/internal/packager/images/pull_test.go
@@ -154,3 +154,26 @@ func TestPull(t *testing.T) {
 		require.Empty(t, dir)
 	})
 }
+
+func TestPullCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pulling an image with an invalid layer in the cache is successful", func(t *testing.T) {
+		ref, err := transform.ParseImageRef("ghcr.io/fluxcd/image-automation-controller@sha256:48a89734dc82c3a2d4138554b3ad4acf93230f770b3a582f7f48be38436d031c")
+		require.NoError(t, err)
+		destDir := t.TempDir()
+		cacheDir := filepath.Join("testdata", "cache")
+		pullConfig := PullConfig{
+			DestinationDirectory: destDir,
+			CacheDirectory:       cacheDir,
+			ImageList: []transform.Image{
+				ref,
+			},
+		}
+
+		_, err = Pull(context.Background(), pullConfig)
+		require.NoError(t, err)
+		require.FileExists(t, filepath.Join(destDir, "blobs/sha256/94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a"))
+
+	})
+}

--- a/src/internal/packager/images/testdata/invalid-cache-layer/sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a
+++ b/src/internal/packager/images/testdata/invalid-cache-layer/sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a
@@ -1,1 +1,0 @@
-This file is invalid on purpose to simulate a pull getting messed up and this file needing to be deleted

--- a/src/internal/packager/images/testdata/invalid-cache-layer/sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a
+++ b/src/internal/packager/images/testdata/invalid-cache-layer/sha256:94c7366c1c3058fbc60a5ea04b6d13199a592a67939a043c41c051c4bfcd117a
@@ -1,0 +1,1 @@
+This file is invalid on purpose to simulate a pull getting messed up and this file needing to be deleted


### PR DESCRIPTION
## Description

Zarf was not properly deleting invalid layers during image pull

## Related Issue

Relates to #3194 - pretty sure this will fix it, but I will give it some time to see if the flake disappears

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
