### PR TITLE
chore: add stalebot

### DIFF
--- a/.github/actions/stale/actions.yml
+++ b/.github/actions/stale/actions.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
+          exempt-all-milestones: true 
+          days-before-stale: 60
+          days-before-close: 10
+          days-before-pr-close: -1

--- a/.github/actions/stale/actions.yml
+++ b/.github/actions/stale/actions.yml
@@ -13,6 +13,7 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
           exempt-all-milestones: true 
-          days-before-stale: 60
+          days-before-issue-stale: 60
+          days-before-pr-stale: 45
           days-before-close: 10
           days-before-pr-close: -1


### PR DESCRIPTION
Reason:
As a smaller open source team it can be difficult without set triage people to manage the inbound requests. To keep ontop of the amount of requests I propose we start to mark issues stale after 60 days. After 70 days of no activity the issue will be closed.

Pull requests will never be closed, but marked stale after 45 days.

If an issue or PR is assigned to a milestone it will exempt from this. 