### PR TITLE
Add support for import chains in packager2

### DIFF
--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -62,7 +62,7 @@ func CreateSkeleton(ctx context.Context, packagePath string, opt CreateOptions) 
 
 	pkg.Metadata.Architecture = config.GetArch()
 
-	pkg, err = resolveImports(ctx, pkg, packagePath, pkg.Metadata.Architecture, opt.Flavor)
+	pkg, err = resolveImports(ctx, pkg, packagePath, pkg.Metadata.Architecture, opt.Flavor, map[string]interface{}{})
 	if err != nil {
 		return "", err
 	}

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -4,13 +4,33 @@
 package layout
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/lint"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 )
+
+func TestResolveImportsCircular(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
+
+	b, err := os.ReadFile(filepath.Join("./testdata/import/first", ZarfYAML))
+	require.NoError(t, err)
+	pkg, err := ParseZarfPackage(b)
+	require.NoError(t, err)
+
+	_, err = resolveImports(ctx, pkg, "./testdata/import/first", "", "", map[string]interface{}{})
+	require.EqualError(t, err, "package testdata/import/second imported in cycle by testdata/import/third")
+}
 
 func TestValidateComponentCompose(t *testing.T) {
 	t.Parallel()

--- a/src/internal/packager2/layout/testdata/import/first/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/first/zarf.yaml
@@ -1,0 +1,8 @@
+kind: ZarfPackageConfig
+metadata:
+  name: first
+components:
+  - name: component
+    required: true
+    import:
+      path: ../second

--- a/src/internal/packager2/layout/testdata/import/second/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/second/zarf.yaml
@@ -1,0 +1,8 @@
+kind: ZarfPackageConfig
+metadata:
+  name: second
+components:
+  - name: component
+    required: true
+    import:
+      path: ../third

--- a/src/internal/packager2/layout/testdata/import/third/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/third/zarf.yaml
@@ -1,0 +1,8 @@
+kind: ZarfPackageConfig
+metadata:
+  name: third
+components:
+  - name: component
+    required: true
+    import:
+      path: ../second


### PR DESCRIPTION
## Description

This change adds import chains to the packager2 which were never implemented during the refactor.

## Related Issue

Relates to #3180

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
