### PR TITLE
fix: print image list without package yaml when using `--image-list` flag with inspect

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -401,6 +401,7 @@ func (o *PackageInspectOptions) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
+		return nil
 	}
 
 	output, err := packager2.Inspect(ctx, inspectOpt)

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -373,6 +373,11 @@ func (o *PackageInspectOptions) PreRun(_ *cobra.Command, _ []string) {
 // Run performs the execution of 'package inspect' sub-command.
 func (o *PackageInspectOptions) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
+	if pkgConfig.InspectOpts.ListImages && (pkgConfig.InspectOpts.SBOMOutputDir != "" || pkgConfig.InspectOpts.ViewSBOM) {
+		return fmt.Errorf("cannot use --sbom or --sbom-out and --list-images at the same time")
+	}
+
 	// NOTE(mkcp): Gets user input with message
 	src, err := choosePackage(ctx, args)
 	if err != nil {

--- a/src/internal/packager2/inspect.go
+++ b/src/internal/packager2/inspect.go
@@ -54,19 +54,14 @@ func InspectList(ctx context.Context, opt ZarfInspectOptions) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	// Only list images if we have components
-	if len(pkg.Components) > 0 {
-		for _, component := range pkg.Components {
-			imageList = append(imageList, component.Images...)
-		}
-		if len(imageList) > 0 {
-			imageList = helpers.Unique(imageList)
-			return imageList, nil
-		}
-		return nil, fmt.Errorf("failed listing images: list of images found in components: %d", len(imageList))
+	for _, component := range pkg.Components {
+		imageList = append(imageList, component.Images...)
 	}
-
-	return imageList, err
+	if imageList == nil {
+		return nil, fmt.Errorf("failed listing images: 0 images found in package")
+	}
+	imageList = helpers.Unique(imageList)
+	return imageList, nil
 }
 
 func getPackageMetadata(ctx context.Context, opt ZarfInspectOptions) (v1alpha1.ZarfPackage, error) {


### PR DESCRIPTION
## Description

In #2990 we changed the `zarf package inspect --list-images` logic to print both the image list and the color printed yaml file. This reverts back to the old behavior of only printing the image list, which should make it easier for users to view / parse this list. 

## Related Issue

Fixes #3374 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
