### PR TITLE
fix: remove empty directory in package tars

### DIFF
--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -201,7 +201,15 @@ func (p *PackageLayout) Archive(ctx context.Context, dirPath string, maxPackageS
 	}
 	message.Notef("Saving package to path %s", tarballPath)
 	logger.From(ctx).Info("writing package to disk", "path", tarballPath)
-	err = archiver.Archive([]string{p.dirPath + string(os.PathSeparator)}, tarballPath)
+	files, err := os.ReadDir(p.dirPath)
+	if err != nil {
+		return err
+	}
+	var filePaths []string
+	for _, file := range files {
+		filePaths = append(filePaths, filepath.Join(p.dirPath, file.Name()))
+	}
+	err = archiver.Archive(filePaths, tarballPath)
 	if err != nil {
 		return fmt.Errorf("unable to create package: %w", err)
 	}


### PR DESCRIPTION
## Description

Creating a zarf package currently results in an extra directory that looks like `zarf-<9-digit-number>`. This is because the temp directory where the package is built is getting added to the tar file. 

Relates to  #2218

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
