### PR TITLE
Increase DefaultTimeout for cluster connections from 30s to 60s

### DIFF
--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DefaultTimeout is the default time to wait for a cluster to be ready.
-	DefaultTimeout = 30 * time.Second
+	DefaultTimeout = 60 * time.Second
 	// AgentLabel is used to give instructions to the Zarf agent
 	AgentLabel = "zarf.dev/agent"
 	// FieldManagerName is the field manager used during server side apply


### PR DESCRIPTION
## Description

Increases timeout for cluster connections from 30s to 60s. 30s isn't long enough if someone's internet connection is slow.

More of a bandaid fix. The best thing to do would be to make the timeout configurable.
...

## Related Issue

Relates to https://github.com/defenseunicorns/uds-k3d/issues/137

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
