### PR TITLE
fix: transform set variables to uppercase in dev inspect definition

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -89,6 +89,7 @@ func newDevInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 
 func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	o.setVariables = helpers.TransformMapKeys(o.setVariables, strings.ToUpper)
 	pkg, err := layout2.LoadPackage(ctx, setBaseDirectory(args), o.flavor, o.setVariables)
 	if err != nil {
 		return err

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -91,7 +91,7 @@ func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) err
 	ctx := cmd.Context()
 	v := getViper()
 	o.setVariables = helpers.TransformAndMergeMap(
-		v.GetStringMapString(VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
+		v.GetStringMapString(VPkgCreateSet), o.setVariables, strings.ToUpper)
 	pkg, err := layout2.LoadPackage(ctx, setBaseDirectory(args), o.flavor, o.setVariables)
 	if err != nil {
 		return err

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -89,7 +89,9 @@ func newDevInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 
 func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	o.setVariables = helpers.TransformMapKeys(o.setVariables, strings.ToUpper)
+	v := getViper()
+	o.setVariables = helpers.TransformAndMergeMap(
+		v.GetStringMapString(VPkgCreateSet), pkgConfig.CreateOpts.SetVariables, strings.ToUpper)
 	pkg, err := layout2.LoadPackage(ctx, setBaseDirectory(args), o.flavor, o.setVariables)
 	if err != nil {
 		return err

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -25,7 +25,7 @@ func TestUseCLI(t *testing.T) {
 		t.Parallel()
 		pathToPackage := filepath.Join("src", "test", "packages", "00-dev-inspect-definition")
 
-		stdOut, _, err := e2e.Zarf(t, "dev", "inspect", "definition", pathToPackage, "--flavor=ice-cream", "--set=MY_VAR=worked-as-expected", "--architecture=amd64")
+		stdOut, _, err := e2e.Zarf(t, "dev", "inspect", "definition", pathToPackage, "--flavor=ice-cream", "--set=my_var=worked-as-expected", "--architecture=amd64")
 		require.NoError(t, err)
 		b, err := os.ReadFile(filepath.Join(pathToPackage, "expected-zarf.yaml"))
 		require.NoError(t, err)


### PR DESCRIPTION
## Description
Fixes a bug where user variables were not getting transformed to uppercase. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
