### PR TITLE
test: avoid flake in test external

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ test-e2e-without-cluster: build-examples ## Run all of the core Zarf CLI E2E tes
 test-external: ## Run the Zarf CLI E2E tests for an external registry and cluster
 	@test -s $(ZARF_BIN) || $(MAKE)
 	@test -s ./build/zarf-init-$(ARCH)-$(CLI_VERSION).tar.zst || $(MAKE) init-package
-	@test -s ./build/zarf-package-podinfo-flux-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/podinfo-flux -o build -a $(ARCH) --confirm
 	@test -s ./build/zarf-package-argocd-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/argocd -o build -a $(ARCH) --confirm
 	cd src/test/external && go test -failfast -v -timeout 30m
 

--- a/src/internal/packager/sbom/catalog.go
+++ b/src/internal/packager/sbom/catalog.go
@@ -88,7 +88,7 @@ func Catalog(ctx context.Context, componentSBOMs map[string]*layout.ComponentSBO
 	for _, refInfo := range imageList {
 		// TODO(mkcp): Remove message on logger release
 		builder.spinner.Updatef("Creating image SBOMs (%d of %d): %s", currImage, imageCount, refInfo.Reference)
-		l.Info("creating image SBOMs", "reference", refInfo.Reference)
+		l.Info("creating image SBOM", "image-name", refInfo.Reference)
 
 		// Get the image that we are creating an SBOM for
 		img, err := utils.LoadOCIImage(paths.Images.Base, refInfo)

--- a/src/test/external/common.go
+++ b/src/test/external/common.go
@@ -20,16 +20,18 @@ import (
 
 var zarfBinPath = path.Join("../../../build", test.GetCLIName())
 
-func createPodInfoPackageWithInsecureSources(t *testing.T, temp string) {
-	err := copy.Copy("../../../examples/podinfo-flux", temp)
+func createPodInfoPackageWithInsecureSources(t *testing.T, packageDir string) {
+	temp := t.TempDir()
+	err := copy.Copy("../../../examples/podinfo-flux", packageDir)
 	require.NoError(t, err)
 	// This is done because while .spec.insecure is auto set to true for internal registries by the agent
 	// it is not for external registries, however since we are using an insecure external registry, we still need it
-	err = exec.CmdWithPrint(zarfBinPath, "tools", "yq", "eval", ".spec.insecure = true", "-i", filepath.Join(temp, "helm", "podinfo-source.yaml"))
+	err = exec.CmdWithPrint(zarfBinPath, "tools", "yq", "eval", ".spec.insecure = true", "-i", filepath.Join(packageDir, "helm", "podinfo-source.yaml"))
 	require.NoError(t, err, "unable to yq edit helm source")
-	err = exec.CmdWithPrint(zarfBinPath, "tools", "yq", "eval", ".spec.insecure = true", "-i", filepath.Join(temp, "oci", "podinfo-source.yaml"))
+	err = exec.CmdWithPrint(zarfBinPath, "tools", "yq", "eval", ".spec.insecure = true", "-i", filepath.Join(packageDir, "oci", "podinfo-source.yaml"))
 	require.NoError(t, err, "unable to yq edit oci source")
-	err = exec.CmdWithPrint(zarfBinPath, "package", "create", temp, "--confirm", "--output", temp)
+	// avoiding Zarf cache because of flake https://github.com/zarf-dev/zarf/issues/3194
+	err = exec.CmdWithPrint(zarfBinPath, "package", "create", packageDir, "--confirm", "--output", packageDir, "--zarf-cache", temp)
 	require.NoError(t, err, "unable to create package")
 }
 


### PR DESCRIPTION
## Description

There is a flake we often get in test external #3194 relating to a broken Zarf cache. Likely, this will not get resolved until we either stop pulling packages in parallel (unlikely as it would make pulling signifigantly slower), or move away from crane (planned but will take time). Adding this in as a band aid to avoid flakes

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
