### PR TITLE
Allow resource to be mutated without adding crc32 checksum

### DIFF
--- a/src/internal/agent/hooks/common.go
+++ b/src/internal/agent/hooks/common.go
@@ -6,10 +6,19 @@ package hooks
 
 import "github.com/zarf-dev/zarf/src/internal/agent/operations"
 
+const annotationDisableCRC32 = "zarf.dev/remove-checksum"
+
 func getLabelPatch(currLabels map[string]string) operations.PatchOperation {
 	if currLabels == nil {
 		currLabels = make(map[string]string)
 	}
 	currLabels["zarf-agent"] = "patched"
 	return operations.ReplacePatchOperation("/metadata/labels", currLabels)
+}
+
+func hasRemoveChecksumAnnotation(annotations map[string]string) bool {
+	if val, ok := annotations[annotationDisableCRC32]; ok {
+		return val == "enable"
+	}
+	return false
 }

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -97,7 +97,17 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 			patchedURL = fmt.Sprintf("%s:%s", patchedURL, src.Spec.Reference.Tag)
 		}
 
-		patchedSrc, err := transform.ImageTransformHost(registryAddress, patchedURL)
+		var (
+			patchedSrc string
+			err        error
+		)
+
+		if hasRemoveChecksumAnnotation(src.Annotations) {
+			patchedSrc, err = transform.ImageTransformHostWithoutChecksum(registryAddress, patchedURL)
+		} else {
+			patchedSrc, err = transform.ImageTransformHost(registryAddress, patchedURL)
+		}
+
 		if err != nil {
 			return nil, fmt.Errorf("unable to transform the OCIRepo URL: %w", err)
 		}

--- a/src/internal/agent/hooks/flux-ocirepo_test.go
+++ b/src/internal/agent/hooks/flux-ocirepo_test.go
@@ -254,6 +254,82 @@ func TestFluxOCIMutationWebhook(t *testing.T) {
 			},
 			code: http.StatusOK,
 		},
+		{
+			name: "url should not include crc32 checksum",
+			admissionReq: createFluxOCIRepoAdmissionRequest(t, v1.Update, &flux.OCIRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mutate-this",
+					Annotations: map[string]string{
+						"zarf.dev/remove-checksum": "enable",
+					},
+				},
+				Spec: flux.OCIRepositorySpec{
+					URL: "oci://ghcr.io/stefanprodan/manifests/podinfo",
+					Reference: &flux.OCIRepositoryRef{
+						Tag: "6.4.0",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/url",
+					"oci://127.0.0.1:31999/stefanprodan/manifests/podinfo",
+				),
+				operations.AddPatchOperation(
+					"/spec/secretRef",
+					fluxmeta.LocalObjectReference{Name: config.ZarfImagePullSecretName},
+				),
+				operations.ReplacePatchOperation(
+					"/spec/ref/tag",
+					"6.4.0",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "url should include crc32 checksum when annotation is not 'enable'",
+			admissionReq: createFluxOCIRepoAdmissionRequest(t, v1.Update, &flux.OCIRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mutate-this",
+					Annotations: map[string]string{
+						"zarf.dev/remove-checksum": "test",
+					},
+				},
+				Spec: flux.OCIRepositorySpec{
+					URL: "oci://ghcr.io/stefanprodan/manifests/podinfo",
+					Reference: &flux.OCIRepositoryRef{
+						Tag: "6.4.0",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/url",
+					"oci://127.0.0.1:31999/stefanprodan/manifests/podinfo",
+				),
+				operations.AddPatchOperation(
+					"/spec/secretRef",
+					fluxmeta.LocalObjectReference{Name: config.ZarfImagePullSecretName},
+				),
+				operations.ReplacePatchOperation(
+					"/spec/ref/tag",
+					"6.4.0-zarf-2823281104",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Description
Draft for adding annotations to prevent adding crc32 checksum from being added to mutated resources

## Related Issue

Relates to #3435

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
