### PR TITLE
chore: separate code changes from dependency updates in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: 🚀 Updates
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 📦 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
## Description

The current release notes are hard to read because so much of it is dependabot updates. By separating it out, it will be easier to parse. Tried it out to make sure it works as I expected - https://github.com/AustinAbro321/goreleaser-test/releases

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
