### PR TITLE
test: delete e2e test for examples/package-flavors

### DIFF
--- a/src/test/e2e/10_component_flavor_test.go
+++ b/src/test/e2e/10_component_flavor_test.go
@@ -15,25 +15,6 @@ import (
 	layout2 "github.com/zarf-dev/zarf/src/internal/packager2/layout"
 )
 
-func TestFlavorExample(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	flavorExample := filepath.Join("examples", "package-flavors")
-	_, _, err := e2e.Zarf(t, "package", "create", flavorExample, "-o", tmpDir, "--flavor", "oracle-cookie-crunch", "--no-color", "--confirm")
-	require.NoError(t, err)
-
-	tarPath := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-package-flavors-%s-1.0.0.tar.zst", e2e.Arch))
-	pkgLayout, err := layout2.LoadFromTar(context.Background(), tarPath, layout2.PackageLayoutOptions{})
-	require.NoError(t, err)
-	pkgLayout.Pkg.Metadata.Description = "The pod that runs the specified flavor of Enterprise Linux"
-	imgs := []string{}
-	for _, comp := range pkgLayout.Pkg.Components {
-		imgs = append(imgs, comp.Images...)
-	}
-	require.ElementsMatch(t, imgs, []string{"oraclelinux:9-slim"})
-}
-
 func TestFlavorArchFiltering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

This deletes the e2e test for package flavors. The other test in [10_component_flavor_test.go](https://github.com/zarf-dev/zarf/blob/33d8a2a2dc84b89913cc74d45157a04f6230c5ec/src/test/e2e/10_component_flavor_test.go#L37) already covers flavors and `layout2.LoadFromTar` more in depth. We have unit tests for verifying package builds with flavors as well. 

I think the package-flavors example does a good job of showing off the `--flavor` feature, but doesn't make for a good e2e test. Especially since it pulls images from dockerhub which can lead to flakes on TOOMANYREQUESTS. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
