### PR TITLE
chore(deps): group golang dependencies in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,9 @@ updates:
       cosign-providers:
         patterns:
           - "github.com/sigstore/sigstore/pkg/signature/kms/*"
+      golang:
+        patterns:
+          - "golang.org/x/*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Description

Golang often releases their changes together. Generally they work with one another and often update the same dependencies so this avoids the double review and merge conflict errors

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
