### PR TITLE
fix: pass insecure flag option to FindChartInAuthAndTLSRepoURL

### DIFF
--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -221,7 +221,18 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 			}
 		}
 
-		chartURL, err = repo.FindChartInAuthRepoURL(h.chart.URL, username, password, chartName, h.chart.Version, pull.CertFile, pull.KeyFile, pull.CaFile, getter.All(pull.Settings))
+		chartURL, err = repo.FindChartInAuthAndTLSRepoURL(
+			h.chart.URL,
+			username,
+			password,
+			chartName,
+			h.chart.Version,
+			pull.CertFile,
+			pull.KeyFile,
+			pull.CaFile,
+			config.CommonOptions.InsecureSkipTLSVerify,
+			getter.All(pull.Settings),
+		)
 		if err != nil {
 			return fmt.Errorf("unable to pull the helm chart: %w", err)
 		}


### PR DESCRIPTION
## Description

Rather than use [`FindChartInAuthRepoURL`](https://github.com/helm/helm/blob/301108edc7ac2a8ba79e4ebf5701b0b6ce6a31e4/pkg/repo/chartrepo.go#L208), we can instead use [`FindChartInAuthAndTLSRepoURL`](https://github.com/helm/helm/blob/301108edc7ac2a8ba79e4ebf5701b0b6ce6a31e4/pkg/repo/chartrepo.go#L216) and pass  the Zarf CLI `--insecure-skip-tls-verify` boolean flag down directly via `config.CommonOptions.InsecureSkipTLSVerify`.

## Related Issue

Fixes #3476

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
