### PR TITLE
feat: improve skeleton package messaging

### DIFF
--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -117,3 +117,5 @@ Typically you should not deploy a Zarf package in YOLO mode if the cluster has a
 A `skeleton` package is a bare-bones Zarf package definition alongside its associated local files and manifests that has been published to an OCI registry. These packages are intended for use with [component composability](/ref/components) to provide versioned imports for components that you wish to mix and match or modify with merge-overrides across multiple separate packages.
 
 Skeleton packages have not been run through the `zarf package create` process yet, and thus do not have any remote resources included (no images, repos, or remote manifests and files) thereby retaining any [create-time package configuration templates](/ref/values) as they were defined in the original `zarf.yaml` (i.e. untemplated).
+
+Skeleton packages are published by pointing the publish command to a directory rather than a tarball, e.g. `zarf package publish my-package/`

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -113,6 +113,7 @@ func (p *Packager) Publish(ctx context.Context) (err error) {
 		return err
 	}
 	if p.cfg.CreateOpts.IsSkeleton {
+		l.Info("skeleton packages contain metadata and local resources to allow for remote component imports")
 		message.Title("How to import components from this skeleton:", "")
 		ex := []v1alpha1.ZarfComponent{}
 		for _, c := range p.cfg.Pkg.Components {
@@ -128,6 +129,7 @@ func (p *Packager) Publish(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+		l.Info("find more info on skeleton packages at https://docs.zarf.dev/faq/#what-is-a-skeleton-zarf-package")
 	}
 	l.Info("packaged successfully published",
 		"name", p.cfg.Pkg.Metadata.Name,


### PR DESCRIPTION
## Description

We've heard complaints about skeleton packages being confusing, I expect them to be deprecated and their use case along custom init packages to be replaced some day, but for now I wanted to make it more clear to users that they are publishing a skeleton package and what that means. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
