### PR TITLE
chore(release): install cross before injector build

### DIFF
--- a/.github/workflows/build-rust-injector.yml
+++ b/.github/workflows/build-rust-injector.yml
@@ -24,6 +24,7 @@ jobs:
       - name: "Build Rust Binary for x86_64 and arm64"
         run: |
           cd src/injector
+          make install-cross
           make injector-linux
           cd target
           mkdir -p ../dist


### PR DESCRIPTION
## Description

We reworked the injector process to use cross, but didn't install cross before building 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
