### PR TITLE
Remove support for legacy logging

### DIFF
--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -66,22 +66,22 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./zarf internal update-gitea-pvc --no-progress
+          - cmd: ./zarf internal update-gitea-pvc
             setVariables:
               - name: GIT_SERVER_CREATE_PVC
             mute: true
         after:
-          - cmd: ./zarf internal create-read-only-gitea-user --no-progress
+          - cmd: ./zarf internal create-read-only-gitea-user
             maxRetries: 3
             maxTotalSeconds: 60
             description: Create the read-only Gitea user
-          - cmd: ./zarf internal create-artifact-registry-token --no-progress
+          - cmd: ./zarf internal create-artifact-registry-token
             maxRetries: 3
             maxTotalSeconds: 60
             description: Create an artifact registry token
 
         onFailure:
-          - cmd: ./zarf internal update-gitea-pvc --rollback --no-progress
+          - cmd: ./zarf internal update-gitea-pvc --rollback
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI
 x-mdx: |

--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -27,6 +27,7 @@ zarf COMMAND [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -25,11 +25,8 @@ zarf COMMAND [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
   -h, --help                       help for zarf
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -29,6 +29,7 @@ See each sub-command's help for details on how to use the generated script.
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -27,11 +27,8 @@ See each sub-command's help for details on how to use the generated script.
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -50,11 +50,8 @@ zarf completion bash
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -52,6 +52,7 @@ zarf completion bash
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -43,6 +43,7 @@ zarf completion fish [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -41,11 +41,8 @@ zarf completion fish [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -40,6 +40,7 @@ zarf completion powershell [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -38,11 +38,8 @@ zarf completion powershell [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -52,11 +52,8 @@ zarf completion zsh [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -54,6 +54,7 @@ zarf completion zsh [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -41,11 +41,8 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -43,6 +43,7 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -25,11 +25,8 @@ zarf connect list [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -27,6 +27,7 @@ zarf connect list [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -39,6 +39,7 @@ zarf destroy --confirm [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -37,11 +37,8 @@ zarf destroy --confirm [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -23,6 +23,7 @@ Commands useful for developing packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -21,11 +21,8 @@ Commands useful for developing packages
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -40,6 +40,7 @@ zarf dev deploy [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -38,11 +38,8 @@ zarf dev deploy [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -39,11 +39,8 @@ zarf dev find-images [ DIRECTORY ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -41,6 +41,7 @@ zarf dev find-images [ DIRECTORY ] [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -34,11 +34,8 @@ zarf dev generate-config [ FILENAME ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -36,6 +36,7 @@ zarf dev generate-config [ FILENAME ] [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -38,6 +38,7 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -36,11 +36,8 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_inspect.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect.md
@@ -23,6 +23,7 @@ Commands to get information about a Zarf package using a `zarf.yaml`
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_inspect.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect.md
@@ -21,11 +21,8 @@ Commands to get information about a Zarf package using a `zarf.yaml`
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_definition.md
@@ -31,11 +31,8 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_definition.md
@@ -33,6 +33,7 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -31,11 +31,8 @@ zarf dev lint [ DIRECTORY ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -33,6 +33,7 @@ zarf dev lint [ DIRECTORY ] [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -29,6 +29,7 @@ zarf dev patch-git HOST FILE [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -27,11 +27,8 @@ zarf dev patch-git HOST FILE [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -28,6 +28,7 @@ zarf dev sha256sum { FILE | URL } [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -26,11 +26,8 @@ zarf dev sha256sum { FILE | URL } [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -86,11 +86,8 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -88,6 +88,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -23,11 +23,8 @@ Zarf package commands for creating, deploying, and inspecting packages
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -25,6 +25,7 @@ Zarf package commands for creating, deploying, and inspecting packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -44,11 +44,8 @@ zarf package create [ DIRECTORY ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -46,6 +46,7 @@ zarf package create [ DIRECTORY ] [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -41,6 +41,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -39,11 +39,8 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -33,11 +33,8 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -35,6 +35,7 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -29,6 +29,7 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -27,11 +27,8 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -29,6 +29,7 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -27,11 +27,8 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -28,11 +28,8 @@ zarf package inspect sbom [ PACKAGE ] [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -30,6 +30,7 @@ zarf package inspect sbom [ PACKAGE ] [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -29,6 +29,7 @@ zarf package list [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -27,11 +27,8 @@ zarf package list [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -67,11 +67,8 @@ $ zarf package mirror-resources <your-package.tar.zst> \
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -69,6 +69,7 @@ $ zarf package mirror-resources <your-package.tar.zst> \
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -42,11 +42,8 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -44,6 +44,7 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -45,6 +45,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -43,11 +43,8 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -35,6 +35,7 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -33,11 +33,8 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --oci-concurrency int        Number of concurrent layer operations to perform when interacting with a remote package. (default 6)
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -29,11 +29,8 @@ zarf say [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -31,6 +31,7 @@ zarf say [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -23,6 +23,7 @@ Collection of additional tools to make airgap easier
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -21,11 +21,8 @@ Collection of additional tools to make airgap easier
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -21,11 +21,8 @@ Compresses/Decompresses generic archives, including Zarf packages
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -23,6 +23,7 @@ Compresses/Decompresses generic archives, including Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -27,6 +27,7 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -25,11 +25,8 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -26,11 +26,8 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -28,6 +28,7 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -27,6 +27,7 @@ zarf tools archiver version [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -25,11 +25,8 @@ zarf tools archiver version [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -28,6 +28,7 @@ zarf tools clear-cache [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
 ```

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -26,11 +26,8 @@ zarf tools clear-cache [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
 ```

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -29,6 +29,7 @@ zarf tools download-init [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -27,11 +27,8 @@ zarf tools download-init [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -25,11 +25,8 @@ zarf tools gen-key [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -27,6 +27,7 @@ zarf tools gen-key [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -28,6 +28,7 @@ zarf tools gen-pki HOST [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -26,11 +26,8 @@ zarf tools gen-pki HOST [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -46,11 +46,8 @@ $ zarf tools get-creds artifact
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -48,6 +48,7 @@ $ zarf tools get-creds artifact
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -74,11 +74,8 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -76,6 +76,7 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -50,7 +50,6 @@ $ zarf tools wait-for http google.com success                           #  wait 
 ```
   -h, --help               help for wait-for
   -n, --namespace string   Specify the namespace of the resources to wait for.
-      --no-progress        Disable fancy UI progress bars, spinners, logos, etc
       --timeout string     Specify the timeout duration for the wait command. (default "5m")
 ```
 

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -30,11 +30,8 @@ zarf version [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
-      --log-format string          [beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release (default "console")
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
-      --no-color                   Disable colors in output
-      --no-log-file                Disable log file creation
-      --no-progress                Disable fancy UI progress bars, spinners, logos, etc
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -32,6 +32,7 @@ zarf version [flags]
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
       --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")

--- a/src/cmd/connect.go
+++ b/src/cmd/connect.go
@@ -54,9 +54,6 @@ func (o *connectOptions) run(cmd *cobra.Command, args []string) error {
 		target = args[0]
 	}
 
-	spinner := message.NewProgressSpinner(lang.CmdConnectPreparingTunnel, target)
-	defer spinner.Stop()
-
 	c, err := cluster.NewCluster()
 	if err != nil {
 		return err
@@ -84,20 +81,17 @@ func (o *connectOptions) run(cmd *cobra.Command, args []string) error {
 	defer tunnel.Close()
 
 	if o.open {
-		spinner.Updatef(lang.CmdConnectEstablishedWeb, tunnel.FullURL())
 		l.Info("Tunnel established, opening your default web browser (ctrl-c to end)", "url", tunnel.FullURL())
 		if err := exec.LaunchURL(tunnel.FullURL()); err != nil {
 			return err
 		}
 	} else {
-		spinner.Updatef(lang.CmdConnectEstablishedCLI, tunnel.FullURL())
 		l.Info("Tunnel established, waiting for user to interrupt (ctrl-c to end)", "url", tunnel.FullURL())
 	}
 
 	// Wait for the interrupt signal or an error.
 	select {
 	case <-ctx.Done():
-		spinner.Successf(lang.CmdConnectTunnelClosed, tunnel.FullURL())
 		return nil
 	case err = <-tunnel.ErrChan():
 		return fmt.Errorf("lost connection to the service: %w", err)

--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 
 	"github.com/spf13/cobra"
@@ -62,7 +61,6 @@ func (o *destroyOptions) run(cmd *cobra.Command, _ []string) error {
 	//       the scripts to remove k3s, we will still try to remove a locally installed k3s cluster
 	state, err := c.LoadZarfState(ctx)
 	if err != nil {
-		message.WarnErr(err, err.Error())
 		l.Warn(err.Error())
 	}
 
@@ -85,7 +83,6 @@ func (o *destroyOptions) run(cmd *cobra.Command, _ []string) error {
 			// Run the matched script
 			err := exec.CmdWithPrint(script)
 			if errors.Is(err, os.ErrPermission) {
-				message.Warnf(lang.CmdDestroyErrScriptPermissionDenied, script)
 				l.Warn("received 'permission denied' when trying to execute script. Please double-check you have the correct kube-context.", "script", script)
 
 				// Don't remove scripts we can't execute so the user can try to manually run
@@ -97,7 +94,6 @@ func (o *destroyOptions) run(cmd *cobra.Command, _ []string) error {
 			// Try to remove the script, but ignore any errors and debug log them
 			err = os.Remove(script)
 			if err != nil {
-				message.WarnErr(err, fmt.Sprintf("Unable to remove script. script=%s", script))
 				l.Warn("unable to remove script", "script", script, "error", err.Error())
 			}
 		}

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -234,7 +234,8 @@ func newDevPatchGitCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *devPatchGitOptions) run(_ *cobra.Command, args []string) error {
+func (o *devPatchGitOptions) run(cmd *cobra.Command, args []string) error {
+	l := logger.From(cmd.Context())
 	host, fileName := args[0], args[1]
 
 	// Read the contents of the given file
@@ -249,7 +250,6 @@ func (o *devPatchGitOptions) run(_ *cobra.Command, args []string) error {
 	// Perform git url transformation via regex
 	text := string(content)
 
-	l := logger.Default()
 	processedText := transform.MutateGitURLsInText(l.Warn, gitServer.Address, text, gitServer.PushUsername)
 
 	// Print the differences

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -25,7 +25,6 @@ import (
 	layout2 "github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -250,8 +249,9 @@ func (o *devPatchGitOptions) run(_ *cobra.Command, args []string) error {
 	// Perform git url transformation via regex
 	text := string(content)
 
-	// TODO(mkcp): Currently uses message for its log fn. Migrate to ctx and slog
-	processedText := transform.MutateGitURLsInText(message.Warnf, gitServer.Address, text, gitServer.PushUsername)
+	// FIXME(mkcp): Currently uses message for its log fn. Migrate to ctx and slog
+	l := logger.Default()
+	processedText := transform.MutateGitURLsInText(l.Warn, gitServer.Address, text, gitServer.PushUsername)
 
 	// Print the differences
 	// TODO(mkcp): Uses pterm to print text diffs. Decouple from pterm after we release logger.
@@ -309,7 +309,6 @@ func (o *devSha256SumOptions) run(cmd *cobra.Command, args []string) (err error)
 	var data io.ReadCloser
 
 	if helpers.IsURL(fileName) {
-		message.Warn(lang.CmdDevSha256sumRemoteWarning)
 		logger.From(cmd.Context()).Warn("this is a remote source. If a published checksum is available you should use that rather than calculating it directly from the remote link")
 
 		fileBase, err := helpers.ExtractBasePathFromURL(fileName)

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -249,12 +249,10 @@ func (o *devPatchGitOptions) run(_ *cobra.Command, args []string) error {
 	// Perform git url transformation via regex
 	text := string(content)
 
-	// FIXME(mkcp): Currently uses message for its log fn. Migrate to ctx and slog
 	l := logger.Default()
 	processedText := transform.MutateGitURLsInText(l.Warn, gitServer.Address, text, gitServer.PushUsername)
 
 	// Print the differences
-	// TODO(mkcp): Uses pterm to print text diffs. Decouple from pterm after we release logger.
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(text, processedText, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)

--- a/src/cmd/helm.go
+++ b/src/cmd/helm.go
@@ -11,7 +11,6 @@ import (
 	"github.com/zarf-dev/zarf/src/cmd/helm"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"helm.sh/helm/v3/pkg/action"
 )
 
@@ -29,7 +28,6 @@ func newHelmCommand() *cobra.Command {
 	// The inclusion of Helm in this manner should be changed once https://github.com/helm/helm/pull/13617 is merged
 	cmd, err := helm.NewRootCmd(actionConfig, os.Stdout, helmArgs)
 	if err != nil {
-		message.Debug("Failed to initialize helm command", "error", err)
 		logger.Default().Debug("failed to initialize helm command", "error", err)
 	}
 	cmd.Short = lang.CmdToolsHelmShort

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -186,8 +185,6 @@ func downloadInitPackage(ctx context.Context, cacheDirectory string) (string, er
 	url := zoci.GetInitPackageURL(config.CLIVersion)
 
 	// Give the user the choice to download the init-package and note that this does require an internet connection
-	message.Question(fmt.Sprintf(lang.CmdInitPullAsk, url))
-	message.Note(lang.CmdInitPullNote)
 	l.Info("the init package was not found locally, but can be pulled in connected environments", "url", fmt.Sprintf("oci://%s", url))
 
 	var confirmDownload bool

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -20,7 +20,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/gitea"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 func newInternalCommand(rootCmd *cobra.Command) *cobra.Command {
@@ -358,7 +357,6 @@ func (o *internalUpdateGiteaPVCOptions) run(cmd *cobra.Command, _ []string) erro
 	// There is a possibility that the pvc does not yet exist and Gitea helm chart should create it
 	helmShouldCreate, err := c.UpdateGiteaPVC(ctx, pvcName, o.rollback)
 	if err != nil {
-		message.WarnErr(err, lang.CmdInternalUpdateGiteaPVCErr)
 		logger.From(ctx).Warn("Unable to update the existing Gitea persistent volume claim", "error", err.Error())
 	}
 	fmt.Print(helmShouldCreate)

--- a/src/cmd/kubectl.go
+++ b/src/cmd/kubectl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	kubeCLI "k8s.io/component-base/cli"
 	kubeCmd "k8s.io/kubectl/pkg/cmd"
 
@@ -32,7 +31,6 @@ func newKubectlCommand() *cobra.Command {
 
 		if err := kubeCLI.RunNoErrOutput(cmd); err != nil {
 			// @todo(jeff-mccoy) - Kubectl gets mad about being a subcommand.
-			message.Debug(err)
 			logger.Default().Debug(err.Error())
 		}
 	}

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -16,8 +16,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/zarf-dev/zarf/src/pkg/message"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	goyaml "github.com/goccy/go-yaml"
@@ -32,6 +30,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -564,7 +563,6 @@ func newPackageListOptions() *packageListOptions {
 	return &packageListOptions{
 		outputFormat: outputTable,
 		// TODO accept output writer as a parameter to the root Zarf command and pass it through here
-		// FIXME(mkcp): fully remove message in zarf critical path
 		outputWriter: message.OutputWriter,
 	}
 }

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -9,13 +9,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/zarf-dev/zarf/src/pkg/message"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/pkg/helpers/v2"

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 	"io"
 	"os"
 	"path/filepath"
@@ -30,7 +31,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -900,7 +900,6 @@ func getPackageCompletionArgs(cmd *cobra.Command, _ []string, _ string) ([]strin
 
 	deployedZarfPackages, err := c.GetDeployedZarfPackages(ctx)
 	if err != nil {
-		message.Debug("Unable to get deployed zarf packages for package completion args", "error", err)
 		logger.From(cmd.Context()).Debug("unable to get deployed zarf packages for package completion args", "error", err)
 	}
 	// Populate list of package names

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -127,8 +127,6 @@ func (o *packageCreateOptions) run(cmd *cobra.Command, args []string) error {
 
 	var isCleanPathRegex = regexp.MustCompile(`^[a-zA-Z0-9\_\-\/\.\~\\:]+$`)
 	if !isCleanPathRegex.MatchString(config.CommonOptions.CachePath) {
-		// TODO(mkcp): Remove message on logger release
-		message.Warnf(lang.CmdPackageCreateCleanPathErr, config.ZarfDefaultCachePath)
 		l.Warn("invalid characters in Zarf cache path, using default", "cfg", config.ZarfDefaultCachePath, "default", config.ZarfDefaultCachePath)
 		config.CommonOptions.CachePath = config.ZarfDefaultCachePath
 	}
@@ -565,6 +563,7 @@ func newPackageListOptions() *packageListOptions {
 	return &packageListOptions{
 		outputFormat: outputTable,
 		// TODO accept output writer as a parameter to the root Zarf command and pass it through here
+		// FIXME(mkcp): fully remove message in zarf critical path
 		outputWriter: message.OutputWriter,
 	}
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -164,6 +164,7 @@ func Execute(ctx context.Context) {
 }
 
 func init() {
+	var showNoProgressDeprecation bool
 	// Skip for vendor-only commands
 	if checkVendorOnlyFromArgs() {
 		return
@@ -175,6 +176,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&LogLevelCLI, "log-level", "l", vpr.GetString(VLogLevel), lang.RootCmdFlagLogLevel)
 	rootCmd.PersistentFlags().StringVar(&LogFormat, "log-format", vpr.GetString(VLogFormat), "Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'.")
 	rootCmd.PersistentFlags().BoolVar(&IsColorDisabled, "no-color", vpr.GetBool(VNoColor), "Disable terminal color codes in logging and stdout prints.")
+	rootCmd.PersistentFlags().BoolVar(&showNoProgressDeprecation, "no-progress", v.GetBool("no_progress"), "Disable fancy UI progress bars, spinners, logos, etc")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("no-progress", "Progress bars and spinners were removed with --log-format=legacy, this flag will be removed in a future version of Zarf.")
 
 	// Core functionality
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", vpr.GetString(VArchitecture), lang.RootCmdFlagArch)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -158,12 +157,8 @@ func Execute(ctx context.Context) {
 		os.Exit(1)
 	}
 
-	// TODO(mkcp): Remove message on logger release
-	errParagraph := message.Paragraph(err.Error())
-	pterm.Error.Println(errParagraph)
-
-	// NOTE(mkcp): The default logger is set with user flags downstream in rootCmd's preRun func, so we don't have
-	// access to it on Execute's ctx.
+	// NOTE(mkcp): This line must be run with the unconfigured default logger because user flags are set downstream
+	// in rootCmd's preRun func.
 	logger.Default().Error(err.Error())
 	os.Exit(1)
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -6,14 +6,11 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 
@@ -85,23 +82,6 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Setup message
-	skipLogFile := SkipLogFile
-
-	// Don't write tool commands to file.
-	comps := strings.Split(cmd.CommandPath(), " ")
-	if len(comps) > 1 && comps[1] == "tools" {
-		skipLogFile = true
-	}
-	if len(comps) > 1 && comps[1] == "version" {
-		skipLogFile = true
-	}
-
-	// Dont write help command to file.
-	if cmd.Parent() == nil {
-		skipLogFile = true
-	}
-
 	// Configure logger and add it to cmd context.
 	l, err := setupLogger(LogLevelCLI, LogFormat, !NoColor)
 	if err != nil {
@@ -109,24 +89,6 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	}
 	ctx := logger.WithContext(cmd.Context(), l)
 	cmd.SetContext(ctx)
-
-	// Configure the global message instance.
-	var disableMessage bool
-	if LogFormat != string(logger.FormatLegacy) {
-		disableMessage = true
-		skipLogFile = true
-		ctx := logger.WithLoggingEnabled(ctx, true)
-		cmd.SetContext(ctx)
-	}
-	err = SetupMessage(MessageCfg{
-		Level:           LogLevelCLI,
-		SkipLogFile:     skipLogFile,
-		NoColor:         NoColor,
-		FeatureDisabled: disableMessage,
-	})
-	if err != nil {
-		return err
-	}
 
 	// Print out config location
 	err = PrintViperConfigUsed(cmd.Context())
@@ -213,10 +175,7 @@ func init() {
 
 	// Logs
 	rootCmd.PersistentFlags().StringVarP(&LogLevelCLI, "log-level", "l", v.GetString(VLogLevel), lang.RootCmdFlagLogLevel)
-	rootCmd.PersistentFlags().StringVar(&LogFormat, "log-format", v.GetString(VLogFormat), "[beta] Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev', 'legacy'. The legacy option will be removed in a coming release")
-	rootCmd.PersistentFlags().BoolVar(&SkipLogFile, "no-log-file", v.GetBool(VNoLogFile), lang.RootCmdFlagSkipLogFile)
-	rootCmd.PersistentFlags().BoolVar(&message.NoProgress, "no-progress", v.GetBool(VNoProgress), lang.RootCmdFlagNoProgress)
-	rootCmd.PersistentFlags().BoolVar(&NoColor, "no-color", v.GetBool(VNoColor), lang.RootCmdFlagNoColor)
+	rootCmd.PersistentFlags().StringVar(&LogFormat, "log-format", v.GetString(VLogFormat), "Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'.")
 
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", v.GetString(VArchitecture), lang.RootCmdFlagArch)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", v.GetString(VZarfCache), lang.RootCmdFlagCachePath)
@@ -255,69 +214,4 @@ func setupLogger(level, format string, color bool) (*slog.Logger, error) {
 	logger.SetDefault(l)
 	l.Debug("logger successfully initialized", "cfg", cfg)
 	return l, nil
-}
-
-// MessageCfg is used to configure the Message package output options.
-type MessageCfg struct {
-	Level       string
-	SkipLogFile bool
-	NoColor     bool
-	// FeatureDisabled is a feature flag that disables it
-	FeatureDisabled bool
-}
-
-// SetupMessage configures message while we migrate over to logger.
-func SetupMessage(cfg MessageCfg) error {
-	// HACK(mkcp): Discard message logs if feature is disabled. message calls InitializePTerm once in its init() fn so
-	//             this ends up being a messy solution.
-	if cfg.FeatureDisabled {
-		// Discard all* PTerm messages. *see below
-		message.InitializePTerm(io.Discard)
-		// Disable all progress bars and spinners
-		message.NoProgress = true
-		return nil
-	}
-
-	if cfg.NoColor {
-		message.DisableColor()
-	}
-
-	level := cfg.Level
-	if cfg.Level != "" {
-		match := map[string]message.LogLevel{
-			// NOTE(mkcp): Add error for forwards compatibility with logger
-			"error": message.WarnLevel,
-			"warn":  message.WarnLevel,
-			"info":  message.InfoLevel,
-			"debug": message.DebugLevel,
-			"trace": message.TraceLevel,
-		}
-		lvl, ok := match[level]
-		if !ok {
-			return errors.New("invalid log level, valid options are warn, info, debug, error, and trace")
-		}
-		message.SetLogLevel(lvl)
-		message.Debug("Log level set to " + level)
-	}
-
-	// Disable progress bars for CI envs
-	if os.Getenv("CI") == "true" {
-		message.Debug("CI environment detected, disabling progress bars")
-		message.NoProgress = true
-	}
-
-	if !cfg.SkipLogFile {
-		ts := time.Now().Format("2006-01-02-15-04-05")
-		f, err := os.CreateTemp("", fmt.Sprintf("zarf-%s-*.log", ts))
-		if err != nil {
-			return fmt.Errorf("could not create a log file in a the temporary directory: %w", err)
-		}
-		logFile, err := message.UseLogFile(f)
-		if err != nil {
-			return fmt.Errorf("could not save a log file to the temporary directory: %w", err)
-		}
-		pterm.SetDefaultOutput(io.MultiWriter(os.Stderr, logFile))
-		message.Notef("Saving log file to %s", f.Name())
-	}
-	return nil
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -31,7 +31,7 @@ var (
 	LogLevelCLI string
 	// LogFormat holds the log format as input from a command
 	LogFormat string
-	// NoColor is a flag to disable colors in output
+	// IsColorDisabled corresponds to the --no-color flag. It disables color codes in terminal output
 	IsColorDisabled bool
 	// OutputWriter provides a default writer to Stdout for user-facing command output
 	OutputWriter = os.Stdout

--- a/src/cmd/table.go
+++ b/src/cmd/table.go
@@ -44,7 +44,6 @@ func PrintFindings(ctx context.Context, lintErr *lint.LintError) {
 		}
 
 		// Print table to our OutputWriter
-		message.Notef("Linting package %q at %s", findings[0].PackageNameOverride, packagePathFromUser)
 		logger.From(ctx).Info("linting package", "name", findings[0].PackageNameOverride, "path", packagePathFromUser)
 		message.TableWithWriter(OutputWriter, []string{"Type", "Path", "Message"}, lintData)
 	}

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 type versionOptions struct {
@@ -26,16 +25,26 @@ type versionOptions struct {
 	outputWriter io.Writer
 }
 
-func newVersionOptions() *versionOptions {
+func newVersionOptions(writer ...io.Writer) (*versionOptions, error) {
+	if len(writer) > 1 {
+		return nil, fmt.Errorf("received more than one writer. writer=%+v", writer)
+	}
+	w := io.Writer(OutputWriter)
+	if len(writer) == 1 {
+		w = writer[0]
+	}
 	return &versionOptions{
 		outputFormat: "",
-		// TODO accept output writer as a parameter to the root Zarf command and pass it through here
-		outputWriter: message.OutputWriter,
-	}
+		outputWriter: w,
+	}, nil
 }
 
 func newVersionCommand() *cobra.Command {
-	o := newVersionOptions()
+	// TODO accept output writer as a parameter to the root Zarf command and pass it through here
+	o, err := newVersionOptions()
+	if err != nil {
+		panic(err)
+	}
 
 	cmd := &cobra.Command{
 		Use:     "version",

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -25,26 +25,22 @@ type versionOptions struct {
 	outputWriter io.Writer
 }
 
-func newVersionOptions(writer ...io.Writer) (*versionOptions, error) {
-	if len(writer) > 1 {
-		return nil, fmt.Errorf("received more than one writer. writer=%+v", writer)
-	}
+// newVersionOptions provides a default versionOptions with an overridable outputWriter. An empty writer defaults
+// to OutputWriter.
+func newVersionOptions(writer io.Writer) *versionOptions {
 	w := io.Writer(OutputWriter)
-	if len(writer) == 1 {
-		w = writer[0]
+	if writer != nil {
+		w = writer
 	}
 	return &versionOptions{
 		outputFormat: "",
 		outputWriter: w,
-	}, nil
+	}
 }
 
 func newVersionCommand() *cobra.Command {
 	// TODO accept output writer as a parameter to the root Zarf command and pass it through here
-	o, err := newVersionOptions()
-	if err != nil {
-		panic(err)
-	}
+	o := newVersionOptions(nil)
 
 	cmd := &cobra.Command{
 		Use:     "version",

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -34,6 +34,7 @@ const (
 
 	VLogLevel  = "log_level"
 	VLogFormat = "log_format"
+	VNoColor   = "no_color"
 
 	// Init config keys
 

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -32,11 +32,8 @@ const (
 
 	// Root config, Logging
 
-	VLogLevel   = "log_level"
-	VLogFormat  = "log_format"
-	VNoLogFile  = "no_log_file"
-	VNoProgress = "no_progress"
-	VNoColor    = "no_color"
+	VLogLevel  = "log_level"
+	VLogFormat = "log_format"
 
 	// Init config keys
 

--- a/src/cmd/wait.go
+++ b/src/cmd/wait.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/config/lang"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 
 	// Import to initialize client auth plugins.
@@ -36,13 +35,11 @@ func newWaitForCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&o.waitTimeout, "timeout", "5m", lang.CmdToolsWaitForFlagTimeout)
 	cmd.Flags().StringVarP(&o.waitNamespace, "namespace", "n", "", lang.CmdToolsWaitForFlagNamespace)
-	// FIXME(mkcp): Progress bars should be removed from message logging.
-	cmd.Flags().BoolVar(&message.NoProgress, "no-progress", false, lang.RootCmdFlagNoProgress)
 
 	return cmd
 }
 
-func (o *waitForOptions) run(_ *cobra.Command, args []string) error {
+func (o *waitForOptions) run(cmd *cobra.Command, args []string) error {
 	// Parse the timeout string
 	timeout, err := time.ParseDuration(o.waitTimeout)
 	if err != nil {
@@ -64,5 +61,5 @@ func (o *waitForOptions) run(_ *cobra.Command, args []string) error {
 	}
 
 	// Execute the wait command.
-	return utils.ExecuteWait(o.waitTimeout, o.waitNamespace, condition, kind, identifier, timeout)
+	return utils.ExecuteWait(cmd.Context(), o.waitTimeout, o.waitNamespace, condition, kind, identifier, timeout)
 }

--- a/src/cmd/wait.go
+++ b/src/cmd/wait.go
@@ -36,6 +36,7 @@ func newWaitForCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&o.waitTimeout, "timeout", "5m", lang.CmdToolsWaitForFlagTimeout)
 	cmd.Flags().StringVarP(&o.waitNamespace, "namespace", "n", "", lang.CmdToolsWaitForFlagNamespace)
+	// FIXME(mkcp): Progress bars should be removed from message logging.
 	cmd.Flags().BoolVar(&message.NoProgress, "no-progress", false, lang.RootCmdFlagNoProgress)
 
 	return cmd

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -45,7 +45,6 @@ const (
 	RootCmdFlagArch                  = "Architecture for OCI images and Zarf packages"
 	RootCmdFlagSkipLogFile           = "Disable log file creation"
 	RootCmdFlagNoProgress            = "Disable fancy UI progress bars, spinners, logos, etc"
-	RootCmdFlagNoColor               = "Disable colors in output"
 	RootCmdFlagCachePath             = "Specify the location of the Zarf cache directory"
 	RootCmdFlagTempDir               = "Specify the temporary directory to use for intermediate files"
 	RootCmdFlagInsecure              = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -614,8 +614,3 @@ var (
 	ErrUnableToCheckArch   = errors.New("unable to get the configured cluster's architecture")
 	ErrUnableToGetPackages = errors.New("unable to load the Zarf Package data from the cluster")
 )
-
-// Collection of reusable warn messages.
-var (
-	WarnSGetDeprecation = "Using sget to download resources is being deprecated and will removed in the v1.0.0 release of Zarf. Please publish the packages as OCI artifacts instead."
-)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -43,8 +43,6 @@ const (
 
 	RootCmdFlagLogLevel              = "Log level when running Zarf. Valid options are: warn, info, debug, trace"
 	RootCmdFlagArch                  = "Architecture for OCI images and Zarf packages"
-	RootCmdFlagSkipLogFile           = "Disable log file creation"
-	RootCmdFlagNoProgress            = "Disable fancy UI progress bars, spinners, logos, etc"
 	RootCmdFlagCachePath             = "Specify the location of the Zarf cache directory"
 	RootCmdFlagTempDir               = "Specify the temporary directory to use for intermediate files"
 	RootCmdFlagInsecure              = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."

--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -97,7 +96,6 @@ func Clone(ctx context.Context, rootPath, address string, shallow bool) (*Reposi
 	}
 	repo, err := git.PlainCloneContext(ctx, r.path, false, cloneOpts)
 	if err != nil {
-		message.Notef("Falling back to host 'git', failed to clone the repo %q with Zarf: %s", gitURLNoRef, err.Error())
 		l.Info("falling back to host 'git', failed to clone the repo with Zarf", "url", gitURLNoRef, "error", err)
 		err := r.gitCloneFallback(ctx, gitURLNoRef, ref, shallow)
 		if err != nil {
@@ -198,13 +196,10 @@ func (r *Repository) Push(ctx context.Context, address, username, password strin
 	}
 	err = repo.FetchContext(ctx, fetchOptions)
 	if errors.Is(err, transport.ErrRepositoryNotFound) {
-		message.Debugf("Repo not yet available offline, skipping fetch...")
 		l.Debug("repo not yet available offline, skipping fetch")
 	} else if errors.Is(err, git.ErrForceNeeded) {
-		message.Debugf("Repo fetch requires force, skipping fetch...")
 		l.Debug("repo fetch requires force, skipping fetch")
 	} else if errors.Is(err, git.NoErrAlreadyUpToDate) {
-		message.Debugf("Repo already up-to-date, skipping fetch...")
 		l.Debug("repo already up-to-date, skipping fetch")
 	} else if err != nil {
 		return fmt.Errorf("unable to fetch the git repo prior to push: %w", err)
@@ -223,7 +218,6 @@ func (r *Repository) Push(ctx context.Context, address, username, password strin
 		},
 	})
 	if errors.Is(err, git.NoErrAlreadyUpToDate) {
-		message.Debug("Repo already up-to-date")
 		l.Debug("repo already up-to-date")
 	} else if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return fmt.Errorf("unable to push repo due to likely shallow clone: %s", err.Error())

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/healthchecks"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -218,7 +217,6 @@ func (h *Helm) RemoveChart(ctx context.Context, namespace string, name string) e
 	_ = h.createActionConfig(ctx, namespace)
 	// Perform the uninstall.
 	response, err := h.uninstallChart(name)
-	message.Debug(response)
 	logger.From(ctx).Debug("chart uninstalled", "response", response)
 	return err
 }
@@ -439,7 +437,6 @@ func (h *Helm) migrateDeprecatedAPIs(ctx context.Context, latestRelease *release
 
 	// If the release was modified in the above loop, save it back to the cluster
 	if modified {
-		message.Warnf("Zarf detected deprecated APIs for the '%s' helm release.  Attempting automatic upgrade.", latestRelease.Name)
 		logger.From(ctx).Warn("detected deprecated APIs for the helm release", "name", latestRelease.Name)
 
 		// Update current release version to be superseded (same as the helm mapkubeapis plugin)

--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -96,7 +96,6 @@ func NewFromZarfManifest(manifest v1alpha1.ZarfManifest, manifestPath, packageNa
 
 	// Add the manifest files so helm does its thing.
 	for _, file := range manifest.Files {
-		spinner.Updatef("Processing %s", file)
 		manifest := path.Join(manifestPath, file)
 		data, err := os.ReadFile(manifest)
 		if err != nil {
@@ -127,8 +126,6 @@ func NewFromZarfManifest(manifest v1alpha1.ZarfManifest, manifestPath, packageNa
 	for _, mod := range mods {
 		mod(h)
 	}
-
-	spinner.Success()
 
 	return h, nil
 }

--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -17,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
 	"github.com/zarf-dev/zarf/src/types"
 	"helm.sh/helm/v3/pkg/action"
@@ -80,9 +79,6 @@ func NewClusterOnly(cfg *types.PackagerConfig, variableConfig *variables.Variabl
 
 // NewFromZarfManifest generates a helm chart and config from a given Zarf manifest.
 func NewFromZarfManifest(manifest v1alpha1.ZarfManifest, manifestPath, packageName, componentName string, mods ...Modifier) (h *Helm, err error) {
-	spinner := message.NewProgressSpinner("Starting helm chart generation %s", manifest.Name)
-	defer spinner.Stop()
-
 	// Generate a new chart.
 	tmpChart := new(chart.Chart)
 	tmpChart.Metadata = new(chart.Metadata)

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"os"
 	"path/filepath"
 	"slices"
@@ -221,7 +220,6 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 			}
 			if key, keyExists := labels[cluster.ZarfConnectLabelName]; keyExists {
 				// If there is a zarf-connect label
-				message.Debugf("Match helm service %s for zarf connection %s", rawData.GetName(), key)
 				l.Debug("match helm service for zarf connection", "service", rawData.GetName(), "connection-key", key)
 
 				// Add the connectString for processing later in the deployment

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/types"
 	"helm.sh/helm/v3/pkg/releaseutil"
@@ -142,7 +142,6 @@ func (r *renderer) adoptAndUpdateNamespaces(ctx context.Context) error {
 			// Refuse to adopt namespace if it is one of four initial Kubernetes namespaces.
 			// https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#initial-namespaces
 			if slices.Contains([]string{"default", "kube-node-lease", "kube-public", "kube-system"}, name) {
-				message.Warnf("Refusing to adopt the initial namespace: %s", name)
 				l.Warn("refusing to adopt initial namespace", "name", name)
 			} else {
 				// This is an existing namespace to adopt
@@ -200,10 +199,8 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 			namespace := &corev1.Namespace{}
 			// parse the namespace resource so it can be applied out-of-band by zarf instead of helm to avoid helm ns shenanigans
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawData.UnstructuredContent(), namespace); err != nil {
-				message.WarnErrf(err, "could not parse namespace %s", rawData.GetName())
 				l.Warn("failed to parse namespace", "name", rawData.GetName(), "error", err)
 			} else {
-				message.Debugf("Matched helm namespace %s for zarf annotation", namespace.Name)
 				l.Debug("matched helm namespace for zarf annotation", "name", namespace.Name)
 				namespace.Labels = cluster.AdoptZarfManagedLabels(namespace.Labels)
 				// Add it to the stack

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -222,7 +222,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 
 	// Set up the chart chartDownloader
 	chartDownloader := downloader.ChartDownloader{
-		// FIXME(mkcp): Should we be using OutputWriter here?
+		// TODO(mkcp): Shouldn't rely on a global mutable var. Pass in a writer here somehow, or at least make atomic?
 		Out:            message.OutputWriter,
 		RegistryClient: regClient,
 		// TODO: Further research this with regular/OCI charts
@@ -330,6 +330,7 @@ func (h *Helm) buildChartDependencies(ctx context.Context) error {
 	h.settings = cli.New()
 
 	man := &downloader.Manager{
+		// TODO(mkcp): Shouldn't rely on a global mutable var. Pass in a writer here somehow, or at least make atomic?
 		Out:            &message.DebugWriter{},
 		ChartPath:      h.chart.LocalPath,
 		Getters:        getter.All(h.settings),

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/message"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -29,7 +31,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/git"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -222,8 +223,7 @@ func (h *Helm) DownloadPublishedChart(ctx context.Context, cosignKeyPath string)
 
 	// Set up the chart chartDownloader
 	chartDownloader := downloader.ChartDownloader{
-		// TODO(mkcp): Shouldn't rely on a global mutable var. Pass in a writer here somehow, or at least make atomic?
-		Out:            message.OutputWriter,
+		Out:            io.Discard,
 		RegistryClient: regClient,
 		// TODO: Further research this with regular/OCI charts
 		Verify:  downloader.VerifyNever,

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -346,21 +346,16 @@ func (h *Helm) buildChartDependencies(ctx context.Context) error {
 	var notFoundErr *downloader.ErrRepoNotFound
 	if errors.As(err, &notFoundErr) {
 		// If we encounter a repo not found error point the user to `zarf tools helm repo add`
-		// TODO(mkcp): Remove message on logger release
-		message.Warnf("%s. Please add the missing repo(s) via the following:", notFoundErr.Error())
 		l.Warn("Error occurred", "error", notFoundErr.Error())
 		l.Warn("Please add the missing repo(s) via the following:")
 		for _, repository := range notFoundErr.Repos {
-			l.Warn("$zarf tools helm repo add <your-repo-name> %s")
-			// TODO(mkcp): Remove message on logger release
-			message.ZarfCommand(fmt.Sprintf("tools helm repo add <your-repo-name> %s", repository))
+			l.Warn("$zarf tools helm repo add <your-repo-name>", "repository", repository)
 		}
 		return err
 	}
 	if err != nil {
-		// TODO(mkcp): Remove message on logger release
-		message.ZarfCommand("tools helm dependency build --verify")
-		message.Warnf("Unable to perform a rebuild of Helm dependencies: %s", err.Error())
+		l.Info("$zarf tools helm dependency build --verify")
+		l.Warn("unable to perform a rebuild of Helm dependencies", "error", err.Error())
 		return err
 	}
 	return nil

--- a/src/internal/packager/helm/utils.go
+++ b/src/internal/packager/helm/utils.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -63,7 +62,7 @@ func (h *Helm) parseChartValues() (chartutil.Values, error) {
 	return helpers.MergeMapRecursive(chartValues, h.valuesOverrides), nil
 }
 
-func (h *Helm) createActionConfig(ctx context.Context, namespace string, spinner *message.Spinner) error {
+func (h *Helm) createActionConfig(ctx context.Context, namespace string) error {
 	// Initialize helm SDK
 	actionConfig := new(action.Configuration)
 	// Set the settings for the helm SDK
@@ -73,11 +72,8 @@ func (h *Helm) createActionConfig(ctx context.Context, namespace string, spinner
 	h.settings.SetNamespace(namespace)
 
 	// Setup K8s connection
-	helmLogger := spinner.Updatef
-	if logger.Enabled(ctx) {
-		l := logger.From(ctx)
-		helmLogger = slog.NewLogLogger(l.Handler(), slog.LevelDebug).Printf
-	}
+	l := logger.From(ctx)
+	helmLogger := slog.NewLogLogger(l.Handler(), slog.LevelDebug).Printf
 	err := actionConfig.Init(h.settings.RESTClientGetter(), namespace, "", helmLogger)
 
 	// Set the actionConfig is the received Helm pointer

--- a/src/internal/packager/sbom/tools.go
+++ b/src/internal/packager/sbom/tools.go
@@ -6,13 +6,11 @@ package sbom
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 )
 
@@ -25,14 +23,11 @@ func ViewSBOMFiles(ctx context.Context, directory string) error {
 	}
 
 	if len(sbomViewFiles) == 0 {
-		message.Note("There were no images with software bill-of-materials (SBOM) included.")
 		l.Info("there were no images with software bill-of-materials (SBOM) included.")
 		return nil
 	}
 
 	link := sbomViewFiles[0]
-	msg := fmt.Sprintf("This package has %d images with software bill-of-materials (SBOM) included. If your browser did not open automatically you can copy and paste this file location into your browser address bar to view them: %s\n\n", len(sbomViewFiles), link)
-	message.Note(msg)
 	l.Info("this package has images with software bill-of-materials (SBOM) included. If your browser did not open automatically you can copy and paste this file location into your browser address bar to view them", "SBOMCount", len(sbomViewFiles), "link", link)
 	if err := exec.LaunchURL(link); err != nil {
 		return err

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -7,7 +7,6 @@ package template
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
 )
@@ -129,13 +127,6 @@ func generateHtpasswd(regInfo *types.RegistryInfo) (string, error) {
 
 func debugPrintTemplateMap(ctx context.Context, templateMap map[string]*variables.TextTemplate) error {
 	sanitizedMap := getSanitizedTemplateMap(templateMap)
-
-	b, err := json.MarshalIndent(sanitizedMap, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	message.Debug(fmt.Sprintf("templateMap = %s", string(b)))
 	logger.From(ctx).Debug("cluster.debugPrintTemplateMap", "templateMap", sanitizedMap)
 	return nil
 }

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -37,10 +36,7 @@ func GetZarfVariableConfig(ctx context.Context) *variables.VariableConfig {
 		return interactive.PromptVariable(ctx, variable)
 	}
 
-	if logger.Enabled(ctx) {
-		return variables.New("zarf", prompt, logger.From(ctx))
-	}
-	return variables.New("zarf", prompt, slog.New(message.ZarfHandler{}))
+	return variables.New("zarf", prompt, logger.From(ctx))
 }
 
 // GetZarfTemplates returns the template keys and values to be used for templating.

--- a/src/internal/packager2/layout/oci.go
+++ b/src/internal/packager2/layout/oci.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"maps"
 	"strings"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 const (
@@ -38,10 +36,7 @@ type Remote struct {
 
 // NewRemote returns an oras remote repository client and context for the given url with zarf opination embedded.
 func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
-	l := slog.New(message.ZarfHandler{})
-	if logger.Enabled(ctx) {
-		l = logger.From(ctx)
-	}
+	l := logger.From(ctx)
 	modifiers := append([]oci.Modifier{
 		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
 		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),

--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -22,7 +22,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -188,7 +187,6 @@ func (p *PackageLayout) Archive(ctx context.Context, dirPath string, maxPackageS
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	message.Notef("Saving package to path %s", tarballPath)
 	logger.From(ctx).Info("writing package to disk", "path", tarballPath)
 	files, err := os.ReadDir(p.dirPath)
 	if err != nil {

--- a/src/internal/packager2/remove.go
+++ b/src/internal/packager2/remove.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/types"
@@ -111,7 +110,6 @@ func Remove(ctx context.Context, opt RemoveOptions) error {
 						return fmt.Errorf("unable to uninstall the helm chart %s in the namespace %s: %w", chart.ChartName, chart.Namespace, err)
 					}
 					if errors.Is(err, driver.ErrReleaseNotFound) {
-						message.Warnf("Helm release for helm chart '%s' in the namespace '%s' was not found.  Was it already removed?", chart.ChartName, chart.Namespace)
 						l.Warn("helm release was not found. was it already removed?", "name", chart.ChartName, "namespace", chart.Namespace)
 					}
 
@@ -122,7 +120,6 @@ func Remove(ctx context.Context, opt RemoveOptions) error {
 					err = opt.Cluster.UpdateDeployedPackage(ctx, *depPkg)
 					if err != nil {
 						// We warn and ignore errors because we may have removed the cluster that this package was inside of
-						message.Warnf("Unable to update the secret for package %s, this may be normal if the cluster was removed: %s", depPkg.Name, err.Error())
 						l.Warn("unable to update secret for package, this may be normal if the cluster was removed", "pkgName", depPkg.Name, "error", err.Error())
 					}
 				}
@@ -143,7 +140,6 @@ func Remove(ctx context.Context, opt RemoveOptions) error {
 				err = opt.Cluster.UpdateDeployedPackage(ctx, *depPkg)
 				if err != nil {
 					// We warn and ignore errors because we may have removed the cluster that this package was inside of
-					message.Warnf("Unable to update the secret for package %s, this may be normal if the cluster was removed: %s", depPkg.Name, err.Error())
 					l.Warn("unable to update secret package, this may be normal if the cluster was removed", "pkgName", depPkg.Name, "error", err.Error())
 				}
 			}
@@ -162,7 +158,6 @@ func Remove(ctx context.Context, opt RemoveOptions) error {
 	if opt.Cluster != nil && len(depPkg.DeployedComponents) == 0 {
 		err := opt.Cluster.DeleteDeployedPackage(ctx, depPkg.Name)
 		if err != nil {
-			message.Warnf("Unable to delete the secret for package %s, this may be normal if the cluster was removed: %s", depPkg.Name, err.Error())
 			l.Warn("unable to delete secret for package, this may be normal if the cluster was removed", "pkgName", depPkg.Name, "error", err.Error())
 		}
 	}

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -19,7 +19,6 @@ import (
 	"github.com/avast/retry-go/v4"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -45,8 +44,6 @@ type Cluster struct {
 func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
 	start := time.Now()
 	l := logger.From(ctx)
-	spinner := message.NewProgressSpinner("Waiting for cluster connection")
-	defer spinner.Stop()
 	l.Info("waiting for cluster connection")
 
 	c, err := NewCluster()
@@ -76,7 +73,6 @@ func NewClusterWithWait(ctx context.Context) (*Cluster, error) {
 		return nil, err
 	}
 
-	spinner.Success()
 	l.Debug("done waiting for cluster, connected", "duration", time.Since(start))
 
 	return c, nil

--- a/src/pkg/cluster/data.go
+++ b/src/pkg/cluster/data.go
@@ -26,7 +26,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 )
@@ -62,7 +61,6 @@ func (c *Cluster) HandleDataInjection(ctx context.Context, data v1alpha1.ZarfDat
 		return fmt.Errorf("unable to execute tar, ensure it is installed in the $PATH: %w", err)
 	}
 
-	message.Debugf("Attempting to inject data into %s", data.Target)
 	l.Debug("performing data injection", "target", data.Target)
 
 	source := filepath.Join(componentPath.DataInjections, filepath.Base(data.Target.Path))
@@ -93,7 +91,6 @@ func (c *Cluster) HandleDataInjection(ctx context.Context, data v1alpha1.ZarfDat
 		zarfCommand, err := utils.GetFinalExecutableCommand()
 		kubectlBinPath := "kubectl"
 		if err != nil {
-			message.Warnf("Unable to get the zarf executable path, falling back to host kubectl: %s", err)
 			l.Warn("unable to get the zarf executable path, falling back to host kubectl", "error", err)
 		} else {
 			kubectlBinPath = fmt.Sprintf("%s tools kubectl", zarfCommand)
@@ -184,7 +181,6 @@ func waitForPodsAndContainers(ctx context.Context, clientset kubernetes.Interfac
 		if err != nil {
 			return nil, err
 		}
-		message.Debugf("Found %d pods for target %#v", len(podList.Items), target)
 		l.Debug("found pods matching the target", "count", len(podList.Items), "target", target)
 		// Sort the pods from newest to oldest
 		sort.Slice(podList.Items, func(i, j int) bool {
@@ -193,7 +189,6 @@ func waitForPodsAndContainers(ctx context.Context, clientset kubernetes.Interfac
 
 		readyPods := []corev1.Pod{}
 		for _, pod := range podList.Items {
-			message.Debugf("Testing pod %q", pod.Name)
 			l.Debug("testing pod", "name", pod.Name)
 
 			// If an include function is provided, only keep pods that return true
@@ -203,7 +198,6 @@ func waitForPodsAndContainers(ctx context.Context, clientset kubernetes.Interfac
 
 			// Handle container targeting
 			if target.Container != "" {
-				message.Debugf("Testing pod %q for container %q", pod.Name, target.Container)
 				l.Debug("testing container", "name", target.Container, "source-pod", pod.Name)
 
 				// Check the status of initContainers for a running match
@@ -226,7 +220,6 @@ func waitForPodsAndContainers(ctx context.Context, clientset kubernetes.Interfac
 				}
 			} else {
 				status := pod.Status.Phase
-				message.Debugf("Testing pod %q phase, want (%q) got (%q)", pod.Name, corev1.PodRunning, status)
 				l.Debug(fmt.Sprintf("checking pod for %s status", corev1.PodRunning), "pod", pod.Name, "status", status)
 				// Regular status checking without a container
 				if status == corev1.PodRunning {

--- a/src/pkg/cluster/namespace.go
+++ b/src/pkg/cluster/namespace.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	corev1 "k8s.io/api/core/v1"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
 )
@@ -23,8 +22,6 @@ import (
 func (c *Cluster) DeleteZarfNamespace(ctx context.Context) error {
 	start := time.Now()
 	l := logger.From(ctx)
-	spinner := message.NewProgressSpinner("Deleting the zarf namespace from this cluster")
-	defer spinner.Stop()
 	l.Info("deleting the zarf namespace from this cluster")
 
 	err := c.Clientset.CoreV1().Namespaces().Delete(ctx, ZarfNamespaceName, metav1.DeleteOptions{})

--- a/src/pkg/cluster/state.go
+++ b/src/pkg/cluster/state.go
@@ -9,11 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
@@ -23,6 +23,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/types"
 )

--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -25,7 +25,6 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/internal/dns"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -231,7 +230,6 @@ func (c *Cluster) checkForZarfConnectLabel(ctx context.Context, name string) (Tu
 		// Add the url suffix too.
 		zt.urlSuffix = svc.Annotations[ZarfConnectAnnotationURL]
 
-		message.Debugf("tunnel connection match: %s/%s on port %d", svc.Namespace, svc.Name, zt.RemotePort)
 		logger.From(ctx).Debug("tunnel connection match",
 			"namespace", svc.Namespace,
 			"name", svc.Name,
@@ -420,26 +418,16 @@ func (tunnel *Tunnel) establish(ctx context.Context) (string, error) {
 	// since there is a brief moment between `GetAvailablePort` and `forwarder.ForwardPorts` where the selected port
 	// is available for selection again.
 	if localPort == 0 {
-		message.Debugf("Requested local port is 0. Selecting an open port on host system")
 		l.Debug("requested local port is 0. Selecting an open port on host system")
 		localPort, err = helpers.GetAvailablePort()
 		if err != nil {
 			return "", fmt.Errorf("unable to find an available port: %w", err)
 		}
-		message.Debugf("Selected port %d", localPort)
 		l.Debug("selected port", "port", localPort)
 		globalMutex.Lock()
 		defer globalMutex.Unlock()
 	}
 
-	msg := fmt.Sprintf("Opening tunnel %d -> %d for %s/%s in namespace %s",
-		localPort,
-		tunnel.remotePort,
-		tunnel.resourceType,
-		tunnel.resourceName,
-		tunnel.namespace,
-	)
-	message.Debugf(msg)
 	l.Debug("opening tunnel",
 		"localPort", localPort,
 		"remotePort", tunnel.remotePort,
@@ -453,7 +441,6 @@ func (tunnel *Tunnel) establish(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to find pod attached to given resource: %w", err)
 	}
-	message.Debugf("Selected pod %s to open port forward to", podName)
 	l.Debug("selected pod to open port forward to", "name", podName)
 
 	// Build url to the port forward endpoint.
@@ -467,7 +454,6 @@ func (tunnel *Tunnel) establish(ctx context.Context) (string, error) {
 		SubResource("portforward").
 		URL()
 
-	message.Debugf("Using URL %s to create portforward", portForwardCreateURL)
 	l.Debug("using URL to create portforward", "url", portForwardCreateURL)
 
 	// Construct the spdy client required by the client-go portforward library.
@@ -503,7 +489,6 @@ func (tunnel *Tunnel) establish(ctx context.Context) (string, error) {
 		// Store the error channel to listen for errors
 		tunnel.errChan = errChan
 
-		message.Debugf("Creating port forwarding tunnel at %s", url)
 		l.Debug("creating port forwarding tunnel", "url", url)
 		return url, nil
 	}

--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -22,7 +22,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/gitea"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -110,8 +109,6 @@ func (c *Cluster) DeleteDeployedPackage(ctx context.Context, packageName string)
 func (c *Cluster) StripZarfLabelsAndSecretsFromNamespaces(ctx context.Context) {
 	start := time.Now()
 	l := logger.From(ctx)
-	spinner := message.NewProgressSpinner("Removing zarf metadata & secrets from existing namespaces not managed by Zarf")
-	defer spinner.Stop()
 	l.Info("removing zarf metadata & secrets from existing namespaces not managed by Zarf")
 
 	deleteOptions := metav1.DeleteOptions{}
@@ -122,36 +119,30 @@ func (c *Cluster) StripZarfLabelsAndSecretsFromNamespaces(ctx context.Context) {
 	// TODO(mkcp): Remove unnecessary nesting w/ else
 	namespaceList, err := c.Clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		spinner.Errorf(err, "Unable to get k8s namespaces")
 		l.Error("unable to get k8s namespaces", "error", err)
 	} else {
 		for _, namespace := range namespaceList.Items {
 			if _, ok := namespace.Labels[AgentLabel]; ok {
-				spinner.Updatef("Removing Zarf Agent label for namespace %s", namespace.Name)
 				l.Info("removing Zarf Agent label", "namespace", namespace.Name)
 				delete(namespace.Labels, AgentLabel)
 				namespaceCopy := namespace
 				_, err := c.Clientset.CoreV1().Namespaces().Update(ctx, &namespaceCopy, metav1.UpdateOptions{})
 				if err != nil {
 					// This is not a hard failure, but we should log it
-					spinner.Errorf(err, "Unable to update the namespace labels for %s", namespace.Name)
 					l.Warn("unable to update the namespace labels", "namespace", namespace.Name, "error", err)
 				}
 			}
 
-			spinner.Updatef("Removing Zarf secrets for namespace %s", namespace.Name)
 			l.Info("removing Zarf secrets", "namespace", namespace.Name)
 			err := c.Clientset.CoreV1().
 				Secrets(namespace.Name).
 				DeleteCollection(ctx, deleteOptions, listOptions)
 			if err != nil {
-				spinner.Errorf(err, "Unable to delete secrets from namespace %s", namespace.Name)
 				l.Error("unable to delete secrets", "namespace", namespace.Name, "error", err)
 			}
 		}
 	}
 
-	spinner.Success()
 	l.Debug("done stripping zarf labels and secrets from namespaces", "duration", time.Since(start))
 }
 

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mholt/archiver/v3"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // ComponentPaths contains paths for a component.
@@ -133,15 +132,12 @@ func (c *Components) Unarchive(ctx context.Context, component v1alpha1.ZarfCompo
 
 	// if the component is already unarchived, skip
 	if !helpers.InvalidPath(cs.Base) {
-		// TODO(mkcp): Bring in context and port to logger
 		l.Debug("component already unarchived", "component", name)
-		message.Debugf("Component %q already unarchived", name)
 		return nil
 	}
 
 	// TODO(mkcp): Bring in context and port to logger
-	l.Debug("unarchiving %q", filepath.Base(tb))
-	message.Debugf("Unarchiving %q", filepath.Base(tb))
+	l.Debug("unarchiving", "component", filepath.Base(tb))
 	if err := archiver.Unarchive(tb, c.Base); err != nil {
 		return err
 	}

--- a/src/pkg/layout/component.go
+++ b/src/pkg/layout/component.go
@@ -64,8 +64,6 @@ func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfCompone
 	}
 	if size > 0 {
 		tb := fmt.Sprintf("%s.tar", base)
-		// TODO(mkcp): Remove message on logger release
-		message.Debugf("Archiving %q", name)
 		l.Debug("archiving component", "name", name)
 		if err := helpers.CreateReproducibleTarballFromDir(base, name, tb); err != nil {
 			return err
@@ -75,8 +73,6 @@ func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfCompone
 		}
 		c.Tarballs[name] = tb
 	} else {
-		// TODO(mkcp): Remove message on logger release
-		message.Debugf("Component %q is empty, skipping archiving", name)
 		l.Debug("component is empty, skipping archiving", "name", name)
 	}
 
@@ -85,7 +81,8 @@ func (c *Components) Archive(ctx context.Context, component v1alpha1.ZarfCompone
 }
 
 // Unarchive unarchives a component.
-func (c *Components) Unarchive(component v1alpha1.ZarfComponent) error {
+func (c *Components) Unarchive(ctx context.Context, component v1alpha1.ZarfComponent) error {
+	l := logger.From(ctx)
 	name := component.Name
 	tb, ok := c.Tarballs[name]
 	if !ok {
@@ -136,10 +133,14 @@ func (c *Components) Unarchive(component v1alpha1.ZarfComponent) error {
 
 	// if the component is already unarchived, skip
 	if !helpers.InvalidPath(cs.Base) {
+		// TODO(mkcp): Bring in context and port to logger
+		l.Debug("component already unarchived", "component", name)
 		message.Debugf("Component %q already unarchived", name)
 		return nil
 	}
 
+	// TODO(mkcp): Bring in context and port to logger
+	l.Debug("unarchiving %q", filepath.Base(tb))
 	message.Debugf("Unarchiving %q", filepath.Base(tb))
 	if err := archiver.Unarchive(tb, c.Base); err != nil {
 		return err

--- a/src/pkg/layout/package.go
+++ b/src/pkg/layout/package.go
@@ -21,7 +21,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/deprecated"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
@@ -230,9 +229,6 @@ func (pp *PackagePaths) GenerateChecksums() (string, error) {
 // ArchivePackage creates an archive for a Zarf package.
 func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball string, maxPackageSizeMB int) error {
 	l := logger.From(ctx)
-	// TODO(mkcp): Remove message on logger release
-	spinner := message.NewProgressSpinner("Writing %s to %s", pp.Base, destinationTarball)
-	defer spinner.Stop()
 	l.Info("archiving zarf package", "base", pp.Base, "destination", destinationTarball)
 
 	// Make the archive
@@ -240,16 +236,12 @@ func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball s
 	if err := archiver.Archive(archiveSrc, destinationTarball); err != nil {
 		return fmt.Errorf("unable to create package: %w", err)
 	}
-	// TODO(mkcp): Remove message on logger release
-	spinner.Updatef("Wrote %s to %s", pp.Base, destinationTarball)
 	l.Debug("ArchivePackage wrote", "base", pp.Base, "destination", destinationTarball)
 
 	fi, err := os.Stat(destinationTarball)
 	if err != nil {
 		return fmt.Errorf("unable to read the package archive: %w", err)
 	}
-	// TODO(mkcp): Remove message on logger release
-	spinner.Successf("Package saved to %q", destinationTarball)
 	l.Debug("package saved", "destination", destinationTarball)
 
 	// Convert Megabytes to bytes.
@@ -260,7 +252,6 @@ func (pp *PackagePaths) ArchivePackage(ctx context.Context, destinationTarball s
 		if fi.Size()/int64(chunkSize) > 999 {
 			return fmt.Errorf("unable to split the package archive into multiple files: must be less than 1,000 files")
 		}
-		message.Notef("Package is larger than %dMB, splitting into multiple files", maxPackageSizeMB)
 		l.Info("package is larger than max, splitting into multiple files", "maxPackageSize", maxPackageSizeMB)
 		err := splitFile(ctx, destinationTarball, chunkSize)
 		if err != nil {
@@ -342,7 +333,8 @@ func (pp *PackagePaths) Files() map[string]string {
 	stripBase := func(path string) string {
 		rel, err := filepath.Rel(pp.Base, path)
 		if err != nil {
-			message.Debug("unable to strip base from path", "error", err)
+			// HACK(mkcp): Source this logger from ctx chain instead or this logging behavior gets weird in testing.
+			logger.Default().Debug("unable to strip base from path", "error", err)
 		}
 		// Convert from the OS path separator to the standard '/' for Windows support
 		return filepath.ToSlash(rel)

--- a/src/pkg/layout/package_test.go
+++ b/src/pkg/layout/package_test.go
@@ -5,6 +5,7 @@
 package layout
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -102,7 +103,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with paths mapped to package paths", func(t *testing.T) {
 		t.Parallel()
-		ctx := t.Context()
+		ctx := context.Background()
 
 		pp := New("test")
 
@@ -134,7 +135,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with image layers mapped to package paths", func(t *testing.T) {
 		t.Parallel()
-		ctx := t.Context()
+		ctx := context.Background()
 
 		pp := New("test")
 

--- a/src/pkg/layout/package_test.go
+++ b/src/pkg/layout/package_test.go
@@ -5,7 +5,6 @@
 package layout
 
 import (
-	"context"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -36,7 +35,6 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files()", func(t *testing.T) {
 		t.Parallel()
-
 		pp := New("test")
 
 		files := pp.Files()
@@ -104,7 +102,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with paths mapped to package paths", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 
 		pp := New("test")
 
@@ -136,7 +134,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with image layers mapped to package paths", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 
 		pp := New("test")
 

--- a/src/pkg/layout/package_test.go
+++ b/src/pkg/layout/package_test.go
@@ -5,6 +5,7 @@
 package layout
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -103,6 +104,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with paths mapped to package paths", func(t *testing.T) {
 		t.Parallel()
+		ctx := context.Background()
 
 		pp := New("test")
 
@@ -115,7 +117,7 @@ func TestPackageFiles(t *testing.T) {
 			normalizePath("images/oci-layout"),
 			normalizePath("images/blobs/sha256/" + strings.Repeat("1", 64)),
 		}
-		pp.SetFromPaths(paths)
+		pp.SetFromPaths(ctx, paths)
 
 		files := pp.Files()
 		expected := map[string]string{
@@ -134,6 +136,7 @@ func TestPackageFiles(t *testing.T) {
 
 	t.Run("Verify Files() with image layers mapped to package paths", func(t *testing.T) {
 		t.Parallel()
+		ctx := context.Background()
 
 		pp := New("test")
 
@@ -150,7 +153,7 @@ func TestPackageFiles(t *testing.T) {
 			},
 		}
 		pp.AddImages()
-		pp.SetFromLayers(descs)
+		pp.SetFromLayers(ctx, descs)
 
 		files := pp.Files()
 		expected := map[string]string{

--- a/src/pkg/logger/logger_test.go
+++ b/src/pkg/logger/logger_test.go
@@ -224,8 +224,4 @@ func TestContext(t *testing.T) {
 		res := From(ctx)
 		require.NotNil(t, res)
 	})
-	t.Run("can add a flag to the context to determine if enabled", func(t *testing.T) {
-		ctx := WithLoggingEnabled(context.Background(), true)
-		require.True(t, Enabled(ctx))
-	})
 }

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -12,12 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/zarf-dev/zarf/src/pkg/logger"
-
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
@@ -80,16 +78,11 @@ func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefau
 		cmdEscaped = helpers.Truncate(cmd, 60, false)
 	}
 
-	// TODO(mkcp): Remove message on logger release
-	spinner := message.NewProgressSpinner("Running \"%s\"", cmdEscaped)
-	// Persist the spinner output so it doesn't get overwritten by the command output.
-	spinner.EnablePreserveWrites()
 	l.Info("running command", "cmd", cmdEscaped)
 
 	actionDefaults := actionGetCfg(ctx, defaultCfg, action, variableConfig.GetAllTemplates())
 
 	if cmd, err = actionCmdMutation(ctx, cmd, actionDefaults.Shell); err != nil {
-		spinner.Errorf(err, "Error mutating command: %s", cmdEscaped)
 		l.Error("error mutating command", "cmd", cmdEscaped, "err", err.Error())
 	}
 
@@ -103,7 +96,7 @@ retryCmd:
 		// Perform the action run.
 		tryCmd := func(ctx context.Context) error {
 			// Try running the command and continue the retry loop if it fails.
-			stdout, stderr, err := actionRun(ctx, actionDefaults, cmd, spinner)
+			stdout, stderr, err := actionRun(ctx, actionDefaults, cmd)
 			if err != nil {
 				if !actionDefaults.Mute {
 					l.Warn("action failed", "cmd", cmdEscaped, "stdout", stdout, "stderr", stderr)
@@ -126,12 +119,10 @@ retryCmd:
 
 			// If the action has a wait, change the spinner message to reflect that on success.
 			if action.Wait != nil {
-				spinner.Successf("Wait for \"%s\" succeeded", cmdEscaped)
 				l.Debug("wait for action succeeded", "cmd", cmdEscaped, "duration", time.Since(start))
 				return nil
 			}
 
-			spinner.Successf("Completed \"%s\"", cmdEscaped)
 			l.Debug("completed action", "cmd", cmdEscaped, "duration", time.Since(start))
 
 			// If the command ran successfully, continue to the next action.
@@ -140,7 +131,6 @@ retryCmd:
 
 		// If no timeout is set, run the command and return or continue retrying.
 		if actionDefaults.MaxTotalSeconds < 1 {
-			spinner.Updatef("Waiting for \"%s\" (no timeout)", cmdEscaped)
 			l.Info("waiting for action (no timeout)", "cmd", cmdEscaped)
 			if err := tryCmd(ctx); err != nil {
 				continue retryCmd
@@ -150,7 +140,6 @@ retryCmd:
 		}
 
 		// Run the command on repeat until success or timeout.
-		spinner.Updatef("Waiting for \"%s\" (timeout: %ds)", cmdEscaped, actionDefaults.MaxTotalSeconds)
 		l.Info("waiting for action", "cmd", cmdEscaped, "timeout", actionDefaults.MaxTotalSeconds)
 		select {
 		// On timeout break the loop to abort.
@@ -242,8 +231,6 @@ func actionCmdMutation(ctx context.Context, cmd string, shellPref v1alpha1.Shell
 		get, err := helpers.MatchRegex(envVarRegex, cmd)
 		if err == nil {
 			newCmd := strings.ReplaceAll(cmd, get("envIndicator"), fmt.Sprintf("$Env:%s", get("varName")))
-			// TODO(mkcp): Remove message on logger release
-			message.Debugf("Converted command \"%s\" to \"%s\" t", cmd, newCmd)
 			logger.From(ctx).Debug("converted command", "cmd", cmd, "newCmd", newCmd)
 			cmd = newCmd
 		}
@@ -292,12 +279,10 @@ func actionGetCfg(_ context.Context, cfg v1alpha1.ZarfComponentActionDefaults, a
 	return cfg
 }
 
-func actionRun(ctx context.Context, cfg v1alpha1.ZarfComponentActionDefaults, cmd string, spinner *message.Spinner) (string, string, error) {
+func actionRun(ctx context.Context, cfg v1alpha1.ZarfComponentActionDefaults, cmd string) (string, string, error) {
 	l := logger.From(ctx)
 	shell, shellArgs := exec.GetOSShell(cfg.Shell)
 
-	// TODO(mkcp): Remove message on logger release
-	message.Debugf("Running command in %s: %s", shell, cmd)
 	l.Debug("running command", "shell", shell, "cmd", cmd)
 
 	execCfg := exec.Config{
@@ -305,16 +290,10 @@ func actionRun(ctx context.Context, cfg v1alpha1.ZarfComponentActionDefaults, cm
 		Dir: cfg.Dir,
 	}
 
-	if !cfg.Mute {
-		execCfg.Stdout = spinner
-		execCfg.Stderr = spinner
-	}
-
 	stdout, stderr, err := exec.CmdWithContext(ctx, execCfg, shell, append(shellArgs, cmd)...)
 	// Dump final complete output (respect mute to prevent sensitive values from hitting the logs).
 	if !cfg.Mute {
-		// TODO(mkcp): Remove message on logger release
-		message.Debug(cmd, stdout, stderr)
+		l.Debug("action complete", "cmd", cmd, "stdout", stdout, "stderr", stderr)
 	}
 	return stdout, stderr, err
 }

--- a/src/pkg/packager/common.go
+++ b/src/pkg/packager/common.go
@@ -22,7 +22,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/deprecated"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -100,8 +99,6 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 	if config.CommonOptions.TempDirectory != "" {
 		// If the cache directory is within the temp directory, warn the user
 		if strings.HasPrefix(cacheDir, tmpDir) {
-			// TODO(mkcp): Remove message on logger release
-			message.Warnf("The cache directory (%q) is within the temp directory (%q) and will be removed when the temp directory is cleaned up", config.CommonOptions.CachePath, config.CommonOptions.TempDirectory)
 			l.Warn("the cache directory is within the temp directory and will be removed when the temp directory is cleaned up", "cacheDir", cacheDir, "tmpDir", tmpDir)
 		}
 	}
@@ -120,8 +117,6 @@ func New(cfg *types.PackagerConfig, mods ...Modifier) (*Packager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create package temp paths: %w", err)
 		}
-		// TODO(mkcp): Remove message on logger release
-		message.Debug("Using temporary directory:", dir)
 		l.Debug("using temporary directory", "tmpDir", dir)
 		pkgr.layout = layout.New(dir)
 	}
@@ -175,13 +170,9 @@ func (p *Packager) isConnectedToCluster() bool {
 // attemptClusterChecks attempts to connect to the cluster and check for useful metadata and config mismatches.
 // NOTE: attemptClusterChecks should only return an error if there is a problem significant enough to halt a deployment, otherwise it should return nil and print a warning message.
 func (p *Packager) attemptClusterChecks(ctx context.Context) error {
-	spinner := message.NewProgressSpinner("Gathering additional cluster information (if available)")
-	defer spinner.Stop()
-
 	// Check the clusters architecture matches the package spec
 	if err := p.validatePackageArchitecture(ctx); err != nil {
 		if errors.Is(err, lang.ErrUnableToCheckArch) {
-			message.Warnf("Unable to validate package architecture: %s", err.Error())
 			logger.From(ctx).Warn("unable to validate package architecture", "error", err)
 		} else {
 			return err
@@ -196,8 +187,6 @@ func (p *Packager) attemptClusterChecks(ctx context.Context) error {
 			return err
 		}
 	}
-
-	spinner.Success()
 
 	return nil
 }

--- a/src/pkg/packager/composer/oci.go
+++ b/src/pkg/packager/composer/oci.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	ocistore "oras.land/oras-go/v2/content/oci"
 )
@@ -100,12 +99,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 		if err != nil {
 			return err
 		} else if !exists {
-			doneSaving := make(chan error)
-			successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+remote.Repo().Reference.String())
-			go utils.RenderProgressBarForLocalDirWrite(cache, componentDesc.Size, doneSaving, "Pulling", successText)
 			err = remote.CopyToTarget(ctx, []ocispec.Descriptor{componentDesc}, store, remote.GetDefaultCopyOpts())
-			doneSaving <- err
-			<-doneSaving
 			if err != nil {
 				return err
 			}

--- a/src/pkg/packager/composer/oci.go
+++ b/src/pkg/packager/composer/oci.go
@@ -17,7 +17,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	ocistore "oras.land/oras-go/v2/content/oci"
@@ -46,6 +46,7 @@ func (ic *ImportChain) ContainsOCIImport() bool {
 }
 
 func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
+	l := logger.From(ctx)
 	if !ic.ContainsOCIImport() {
 		return nil
 	}
@@ -84,7 +85,7 @@ func (ic *ImportChain) fetchOCISkeleton(ctx context.Context) error {
 
 		dir = filepath.Join(cache, "dirs", id)
 
-		message.Debug("creating empty directory for remote component:", filepath.Join("<zarf-cache>", "oci", "dirs", id))
+		l.Debug("creating empty directory for remote component", "component", filepath.Join("<zarf-cache>", "oci", "dirs", id))
 	} else {
 		tb = filepath.Join(cache, "blobs", "sha256", componentDesc.Digest.Encoded())
 		dir = filepath.Join(cache, "dirs", componentDesc.Digest.Encoded())

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -38,8 +37,6 @@ func (p *Packager) Create(ctx context.Context) error {
 	if err := os.Chdir(baseDir); err != nil {
 		return fmt.Errorf("unable to access directory %q: %w", baseDir, err)
 	}
-	// TODO(mkcp): Remove message on logger release
-	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
 	l.Info("using build directory", "baseDir", baseDir)
 
 	// Setup package creator
@@ -62,7 +59,6 @@ func (p *Packager) Create(ctx context.Context) error {
 		"description", pkg.Metadata.Description,
 	)
 
-	// TODO(mkcp): Remove interactive on logger release
 	if !p.confirmAction(ctx, config.ZarfCreateStage, warnings, nil) {
 		return fmt.Errorf("package creation canceled")
 	}

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -29,7 +28,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/sbom"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -312,10 +310,6 @@ func (pc *PackageCreator) Output(ctx context.Context, dst *layout.PackagePaths, 
 		if config.CommonOptions.InsecureSkipTLSVerify {
 			flags = append(flags, "--insecure-skip-tls-verify")
 		}
-		message.Title("To inspect/deploy/pull:", "")
-		message.ZarfCommand("package inspect %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
-		message.ZarfCommand("package deploy %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
-		message.ZarfCommand("package pull %s %s", helpers.OCIURLPrefix+remote.Repo().Reference.String(), strings.Join(flags, " "))
 	} else {
 		// Use the output path if the user specified it.
 		packageName := fmt.Sprintf("%s%s", sources.NameFromMetadata(pkg, pc.createOpts.IsSkeleton), sources.PkgSuffix(pkg.Metadata.Uncompressed))
@@ -490,7 +484,6 @@ func (pc *PackageCreator) addComponent(ctx context.Context, component v1alpha1.Z
 			manifestCount += len(manifest.Kustomizations)
 		}
 
-		// TODO(mkcp): Remove message on logger release
 		l.Info("processing k8s manifests", "component", component.Name, "manifests", manifestCount)
 
 		// Iterate over all manifests.

--- a/src/pkg/packager/creator/skeleton.go
+++ b/src/pkg/packager/creator/skeleton.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/mholt/archiver/v3"
@@ -21,7 +20,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/types"
@@ -45,6 +43,7 @@ func NewSkeletonCreator(createOpts types.ZarfCreateOptions, publishOpts types.Za
 
 // LoadPackageDefinition loads and configure a zarf.yaml file when creating and publishing a skeleton package.
 func (sc *SkeletonCreator) LoadPackageDefinition(ctx context.Context, src *layout.PackagePaths) (pkg v1alpha1.ZarfPackage, warnings []string, err error) {
+	l := logger.From(ctx)
 	pkg, warnings, err = src.ReadZarfYAML()
 	if err != nil {
 		return v1alpha1.ZarfPackage{}, nil, err
@@ -63,7 +62,7 @@ func (sc *SkeletonCreator) LoadPackageDefinition(ctx context.Context, src *layou
 	warnings = append(warnings, composeWarnings...)
 
 	for _, warning := range warnings {
-		message.Warn(warning)
+		l.Warn(warning)
 	}
 
 	if err := Validate(pkg, sc.createOpts.BaseDir, sc.createOpts.SetVariables); err != nil {
@@ -123,7 +122,6 @@ func (sc *SkeletonCreator) Output(ctx context.Context, dst *layout.PackagePaths,
 
 func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.ZarfComponent, dst *layout.PackagePaths) (updatedComponent *v1alpha1.ZarfComponent, err error) {
 	l := logger.From(ctx)
-	message.HeaderInfof("📦 %s COMPONENT", strings.ToUpper(component.Name))
 	logger.From(ctx).Info("processing component", "name", component.Name)
 
 	updatedComponent = &component
@@ -233,11 +231,7 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 	}
 
 	if len(component.DataInjections) > 0 {
-		spinner := message.NewProgressSpinner("Loading data injections")
-		defer spinner.Stop()
-
 		for dataIdx, data := range component.DataInjections {
-			spinner.Updatef("Copying data injection %s for %s", data.Target.Path, data.Target.Selector)
 			l.Debug("copying data injection", "source", data.Source, "target", data.Target.Path)
 
 			rel := filepath.Join(layout.DataInjectionsDir, strconv.Itoa(dataIdx), filepath.Base(data.Target.Path))
@@ -250,7 +244,6 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 			updatedComponent.DataInjections[dataIdx].Source = rel
 		}
 
-		spinner.Success()
 	}
 
 	if len(component.Manifests) > 0 {
@@ -262,9 +255,6 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 			manifestCount += len(manifest.Kustomizations)
 		}
 
-		spinner := message.NewProgressSpinner("Loading %d K8s manifests", manifestCount)
-		defer spinner.Stop()
-
 		// Iterate over all manifests.
 		for manifestIdx, manifest := range component.Manifests {
 			for fileIdx, path := range manifest.Files {
@@ -272,7 +262,6 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 				dst := filepath.Join(componentPaths.Base, rel)
 
 				// Copy manifests without any processing.
-				spinner.Updatef("Copying manifest %s", path)
 				l.Debug("copying manifest", "path", path)
 
 				if err := helpers.CreatePathAndCopy(path, dst); err != nil {
@@ -284,7 +273,6 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 
 			for kustomizeIdx, path := range manifest.Kustomizations {
 				// Generate manifests from kustomizations and place in the package.
-				spinner.Updatef("Building kustomization for %s", path)
 				l.Debug("building kustomization", "path", path)
 
 				kname := fmt.Sprintf("kustomization-%s-%d.yaml", manifest.Name, kustomizeIdx)
@@ -299,8 +287,6 @@ func (sc *SkeletonCreator) addComponent(ctx context.Context, component v1alpha1.
 			// remove kustomizations
 			updatedComponent.Manifests[manifestIdx].Kustomizations = nil
 		}
-
-		spinner.Success()
 	}
 
 	return updatedComponent, nil

--- a/src/pkg/packager/deprecated/common_test.go
+++ b/src/pkg/packager/deprecated/common_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 func TestPrintBreakingChanges(t *testing.T) {
@@ -47,7 +46,6 @@ func TestPrintBreakingChanges(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var output bytes.Buffer
-			message.InitializePTerm(&output)
 			err := PrintBreakingChanges(&output, tt.deployedVersion, tt.cliVersion)
 			require.NoError(t, err)
 			for _, bc := range tt.breakingChanges {

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -15,7 +15,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/types"
@@ -77,7 +76,6 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 		return err
 	}
 
-	message.HeaderInfof("📦 PACKAGE DEPLOY %s", p.cfg.Pkg.Metadata.Name)
 	l.Info("starting package deploy", "name", p.cfg.Pkg.Metadata.Name)
 
 	if !p.cfg.CreateOpts.NoYOLO {
@@ -112,18 +110,12 @@ func (p *Packager) DevDeploy(ctx context.Context) error {
 		return err
 	}
 	if len(deployedComponents) == 0 {
-		message.Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
 		l.Warn("No components were selected for deployment.  Inspect the package to view the available components and select components interactively or by name with \"--components\"")
 	}
 
 	// Notify all the things about the successful deployment
-	message.Successf("Zarf dev deployment complete")
 	l.Debug("dev deployment complete", "package", p.cfg.Pkg.Metadata.Name, "duration", time.Since(start))
-
-	message.HorizontalRule()
-	message.Title("Next steps:", "")
-
-	message.ZarfCommand("package inspect %s", p.cfg.Pkg.Metadata.Name)
+	l.Info("consider `zarf package inspect PACKAGE`", "package", p.cfg.Pkg.Metadata.Name)
 
 	// cd back
 	return os.Chdir(cwd)

--- a/src/pkg/packager/generate.go
+++ b/src/pkg/packager/generate.go
@@ -19,7 +19,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // Generate generates a Zarf package definition.
@@ -27,12 +26,10 @@ func (p *Packager) Generate(ctx context.Context) error {
 	l := logger.From(ctx)
 	start := time.Now()
 	generatedZarfYAMLPath := filepath.Join(p.cfg.GenerateOpts.Output, layout.ZarfYAML)
-	spinner := message.NewProgressSpinner("Generating package for %q at %s", p.cfg.GenerateOpts.Name, generatedZarfYAMLPath)
 
 	if !helpers.InvalidPath(generatedZarfYAMLPath) {
 		prefixed := filepath.Join(p.cfg.GenerateOpts.Output, fmt.Sprintf("%s-%s", p.cfg.GenerateOpts.Name, layout.ZarfYAML))
 
-		message.Warnf("%s already exists, writing to %s", generatedZarfYAMLPath, prefixed)
 		l.Warn("using a prefixed name since zarf.yaml already exists in the output directory",
 			"output-directory", p.cfg.GenerateOpts.Output,
 			"name", prefixed)
@@ -74,7 +71,6 @@ func (p *Packager) Generate(ctx context.Context) error {
 	images, err := p.findImages(ctx)
 	if err != nil {
 		// purposefully not returning error here, as we can still generate the package without images
-		message.Warnf("Unable to find images: %s", err.Error())
 		l.Error("failed to find images", "error", err.Error())
 	}
 
@@ -104,7 +100,6 @@ func (p *Packager) Generate(ctx context.Context) error {
 	content = strings.Replace(content, "metadata:\n", "\nmetadata:\n", 1)
 	content = strings.Replace(content, "components:\n", "\ncomponents:\n", 1)
 
-	spinner.Successf("Generated package for %q at %s", p.cfg.GenerateOpts.Name, generatedZarfYAMLPath)
 	l.Debug("generated package", "name", p.cfg.GenerateOpts.Name, "path", generatedZarfYAMLPath, "duration", time.Since(start))
 
 	return os.WriteFile(generatedZarfYAMLPath, []byte(content), helpers.ReadAllWriteUser)

--- a/src/pkg/packager/interactive.go
+++ b/src/pkg/packager/interactive.go
@@ -12,80 +12,47 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/defenseunicorns/pkg/helpers/v2"
-	"github.com/pterm/pterm"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
-// TODO(mkcp): Implementation is heavily dependent on Message
 func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []string, sbomViewFiles []string) bool {
-	pterm.Println()
-	message.HeaderInfof("📦 PACKAGE DEFINITION")
 	l := logger.From(ctx)
 	err := utils.ColorPrintYAML(p.cfg.Pkg, p.getPackageYAMLHints(stage), true)
 	if err != nil {
-		message.WarnErr(err, "unable to print yaml")
+		l.Error("unable to print yaml", "stage", stage, "error", err)
 	}
 
 	// Print any potential breaking changes (if this is a Deploy confirm) between this CLI version and the deployed init package
 	if stage == config.ZarfDeployStage {
 		if p.cfg.Pkg.IsSBOMAble() {
 			// Print the location that the user can view the package SBOMs from
-			message.HorizontalRule()
-			message.Title("Software Bill of Materials", "an inventory of all software contained in this package")
-
 			if len(sbomViewFiles) > 0 {
 				cwd, _ := os.Getwd()
-				link := pterm.FgLightCyan.Sprint(pterm.Bold.Sprint(filepath.Join(cwd, layout.SBOMDir, filepath.Base(sbomViewFiles[0]))))
-				inspect := pterm.BgBlack.Sprint(pterm.FgWhite.Sprint(pterm.Bold.Sprintf("$ zarf package inspect %s", p.cfg.PkgOpts.PackageSource)))
-
-				artifactMsg := pterm.Bold.Sprintf("%d artifacts", len(sbomViewFiles)) + " to be reviewed. These are"
-				if len(sbomViewFiles) == 1 {
-					artifactMsg = pterm.Bold.Sprintf("%d artifact", len(sbomViewFiles)) + " to be reviewed. This is"
-				}
-
-				msg := fmt.Sprintf("This package has %s available in a temporary '%s' folder in this directory and will be removed upon deployment.\n", artifactMsg, pterm.Bold.Sprint("zarf-sbom"))
-				viewNow := fmt.Sprintf("\n- View SBOMs %s by navigating to the '%s' folder or copying this link into a browser:\n%s", pterm.Bold.Sprint("now"), pterm.Bold.Sprint("zarf-sbom"), link)
-				viewLater := fmt.Sprintf("\n- View SBOMs %s deployment with this command:\n%s", pterm.Bold.Sprint("after"), inspect)
-
-				message.Note(msg)
-				pterm.Println(viewNow)
-				pterm.Println(viewLater)
 				l.Info("this package has SBOMs available for review in a temporary directory", "directory", filepath.Join(cwd, layout.SBOMDir))
 			} else {
-				message.Warn("This package does NOT contain an SBOM.  If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.")
+				l.Warn("this package does NOT contain an SBOM.  If you require an SBOM, please contact the creator of this package to request a version that includes an SBOM.",
+					"name", p.cfg.Pkg.Metadata.Name)
 			}
 		}
 	}
 
 	if len(warnings) > 0 {
-		message.HorizontalRule()
-		message.Title("Package Warnings", "the following warnings were flagged while reading the package")
 		for _, warning := range warnings {
-			message.Warn(warning)
 			l.Warn(warning)
 		}
 	}
-
-	message.HorizontalRule()
-
 	// Display prompt if not auto-confirmed
 	if config.CommonOptions.Confirm {
-		pterm.Println()
-		message.Successf("%s Zarf package confirmed", stage)
 		return config.CommonOptions.Confirm
 	}
 
+	// Prompt the user for confirmation, on abort return false
 	prompt := &survey.Confirm{
 		Message: stage + " this Zarf package?",
 	}
-
-	pterm.Println()
-
-	// Prompt the user for confirmation, on abort return false
 	var confirm bool
 	if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
 		// User aborted or declined, cancel the action

--- a/src/pkg/packager/interactive.go
+++ b/src/pkg/packager/interactive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
+// TODO(mkcp): Implementation is heavily dependent on Message
 func (p *Packager) confirmAction(ctx context.Context, stage string, warnings []string, sbomViewFiles []string) bool {
 	pterm.Println()
 	message.HeaderInfof("📦 PACKAGE DEFINITION")

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -7,14 +7,12 @@ package packager
 import (
 	"context"
 	"fmt"
-	"runtime"
-	"strings"
-
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/types"
+	"runtime"
 )
 
 // Mirror pulls resources from a package (images, git repositories, etc) and pushes them to remotes in the air gap without deploying them
@@ -58,8 +56,7 @@ func (p *Packager) Mirror(ctx context.Context) error {
 func (p *Packager) mirrorComponent(ctx context.Context, component v1alpha1.ZarfComponent) error {
 	componentPaths := p.layout.Components.Dirs[component.Name]
 
-	// All components now require a name
-	message.HeaderInfof("📦 %s COMPONENT", strings.ToUpper(component.Name))
+	logger.From(ctx).Info("mirroring component", "component", component.Name)
 
 	hasImages := len(component.Images) > 0
 	hasRepos := len(component.Repos) > 0

--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -32,7 +32,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager/images"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/types"
@@ -51,14 +50,12 @@ func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) 
 	defer func() {
 		// Return to the original working directory
 		if err := os.Chdir(cwd); err != nil {
-			message.Warnf("Unable to return to the original working directory: %s", err.Error())
 			l.Warn("unable to return to the original working directory", "error", err)
 		}
 	}()
 	if err := os.Chdir(p.cfg.CreateOpts.BaseDir); err != nil {
 		return nil, fmt.Errorf("unable to access directory %q: %w", p.cfg.CreateOpts.BaseDir, err)
 	}
-	message.Note(fmt.Sprintf("Using build directory %s", p.cfg.CreateOpts.BaseDir))
 	l.Info("using build directory", "path", p.cfg.CreateOpts.BaseDir)
 
 	c := creator.NewPackageCreator(p.cfg.CreateOpts, cwd)
@@ -72,7 +69,6 @@ func (p *Packager) FindImages(ctx context.Context) (map[string][]string, error) 
 		return nil, err
 	}
 	for _, warning := range warnings {
-		message.Warn(warning)
 		l.Warn(warning)
 	}
 	p.cfg.Pkg = pkg
@@ -89,7 +85,6 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 				"if any repos contain helm charts you want to template and " +
 				"search for images, make sure to specify the helm chart path " +
 				"via the --repo-chart-path flag"
-			message.Note(msg)
 			l.Info(msg)
 			break
 		}
@@ -273,11 +268,9 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 
 		imgCompStart := time.Now()
 		l.Info("looking for images in component", "name", component.Name, "resourcesCount", len(resources))
-		spinner := message.NewProgressSpinner("Looking for images in component %q across %d resources", component.Name, len(resources))
-		defer spinner.Stop()
 
 		for _, resource := range resources {
-			if matchedImages, maybeImages, err = processUnstructuredImages(resource, matchedImages, maybeImages); err != nil {
+			if matchedImages, maybeImages, err = processUnstructuredImages(ctx, resource, matchedImages, maybeImages); err != nil {
 				return nil, fmt.Errorf("could not process the Kubernetes resource %s: %w", resource.GetName(), err)
 			}
 		}
@@ -300,11 +293,9 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 			for _, image := range sortedExpectedImages {
 				if descriptor, err := crane.Head(image, images.WithGlobalInsecureFlag()...); err != nil {
 					// Test if this is a real image, if not just quiet log to debug, this is normal
-					message.Debugf("Suspected image does not appear to be valid: %#v", err)
 					l.Debug("suspected image does not appear to be valid", "error", err)
 				} else {
 					// Otherwise, add to the list of images
-					message.Debugf("Imaged digest found: %s", descriptor.Digest)
 					l.Debug("imaged digest found", "digest", descriptor.Digest)
 					validImages = append(validImages, image)
 				}
@@ -319,7 +310,6 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 			}
 		}
 
-		spinner.Success()
 		l.Debug("done looking for images in component",
 			"name", component.Name,
 			"resourcesCount", len(resources),
@@ -330,12 +320,9 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 			if len(imagesMap[component.Name]) > 0 {
 				var cosignArtifactList []string
 				imgStart := time.Now()
-				spinner := message.NewProgressSpinner("Looking up cosign artifacts for discovered images (0/%d)", len(imagesMap[component.Name]))
-				defer spinner.Stop()
 				l.Info("looking up cosign artifacts for discovered images", "count", len(imagesMap[component.Name]))
 
-				for idx, image := range imagesMap[component.Name] {
-					spinner.Updatef("Looking up cosign artifacts for discovered images (%d/%d)", idx+1, len(imagesMap[component.Name]))
+				for _, image := range imagesMap[component.Name] {
 					l.Debug("looking up cosign artifacts for image", "name", imagesMap[component.Name])
 					cosignArtifacts, err := utils.GetCosignArtifacts(image)
 					if err != nil {
@@ -344,7 +331,6 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 					cosignArtifactList = append(cosignArtifactList, cosignArtifacts...)
 				}
 
-				spinner.Success()
 				l.Debug("done looking up cosign artifacts for discovered images", "count", len(imagesMap[component.Name]), "duration", time.Since(imgStart))
 
 				if len(cosignArtifactList) > 0 {
@@ -370,7 +356,8 @@ func (p *Packager) findImages(ctx context.Context) (map[string][]string, error) 
 	return imagesMap, nil
 }
 
-func processUnstructuredImages(resource *unstructured.Unstructured, matchedImages, maybeImages map[string]bool) (map[string]bool, map[string]bool, error) {
+func processUnstructuredImages(ctx context.Context, resource *unstructured.Unstructured, matchedImages, maybeImages map[string]bool) (map[string]bool, map[string]bool, error) {
+	l := logger.From(ctx)
 	contents := resource.UnstructuredContent()
 	b, err := resource.MarshalJSON()
 	if err != nil {
@@ -417,7 +404,7 @@ func processUnstructuredImages(resource *unstructured.Unstructured, matchedImage
 		// Capture any custom images
 		matches := imageCheck.FindAllStringSubmatch(string(b), -1)
 		for _, group := range matches {
-			message.Debugf("Found unknown match, Kind: %s, Value: %s", resource.GetKind(), group[1])
+			l.Debug("found unknown match", "kind", resource.GetKind(), "value", group[1])
 			matchedImages[group[1]] = true
 		}
 	}
@@ -425,7 +412,7 @@ func processUnstructuredImages(resource *unstructured.Unstructured, matchedImage
 	// Capture "maybe images" too for all kinds because they might be in unexpected places.... 👀
 	matches := imageFuzzyCheck.FindAllStringSubmatch(string(b), -1)
 	for _, group := range matches {
-		message.Debugf("Found possible fuzzy match, Kind: %s, Value: %s", resource.GetKind(), group[1])
+		l.Debug("found possible fuzzy match", "kind", resource.GetKind(), "value", group[1])
 		maybeImages[group[1]] = true
 	}
 

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -19,7 +19,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/creator"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -106,15 +105,12 @@ func (p *Packager) Publish(ctx context.Context) (err error) {
 		return err
 	}
 
-	message.HeaderInfof("📦 PACKAGE PUBLISH %s:%s", p.cfg.Pkg.Metadata.Name, ref)
-
 	// Publish the package/skeleton to the registry
 	if err := remote.PublishPackage(ctx, &p.cfg.Pkg, p.layout, config.CommonOptions.OCIConcurrency); err != nil {
 		return err
 	}
 	if p.cfg.CreateOpts.IsSkeleton {
 		l.Info("skeleton packages contain metadata and local resources to allow for remote component imports")
-		message.Title("How to import components from this skeleton:", "")
 		ex := []v1alpha1.ZarfComponent{}
 		for _, c := range p.cfg.Pkg.Components {
 			ex = append(ex, v1alpha1.ZarfComponent{

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -12,17 +12,17 @@ import (
 	"runtime"
 	"slices"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
 
+	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/message"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/packager/sources"
@@ -35,8 +35,6 @@ func (p *Packager) Remove(ctx context.Context) error {
 	if isClusterSource {
 		p.cluster = p.source.(*sources.ClusterSource).Cluster
 	}
-	spinner := message.NewProgressSpinner("Removing Zarf package %s", p.cfg.PkgOpts.PackageSource)
-	defer spinner.Stop()
 
 	// we do not want to allow removal of signed packages without a signature if there are remove actions
 	// as this is arbitrary code execution from an untrusted source
@@ -98,7 +96,7 @@ func (p *Packager) Remove(ctx context.Context) error {
 			continue
 		}
 
-		if deployedPackage, err = p.removeComponent(ctx, deployedPackage, dc, spinner); err != nil {
+		if deployedPackage, err = p.removeComponent(ctx, deployedPackage, dc); err != nil {
 			return fmt.Errorf("unable to remove the component '%s': %w", dc.Name, err)
 		}
 	}
@@ -107,6 +105,7 @@ func (p *Packager) Remove(ctx context.Context) error {
 }
 
 func (p *Packager) updatePackageSecret(ctx context.Context, deployedPackage types.DeployedPackage) error {
+	l := logger.From(ctx)
 	// Only attempt to update the package secret if we are actually connected to a cluster
 	if p.cluster != nil {
 		newPackageSecretData, err := json.Marshal(deployedPackage)
@@ -129,13 +128,14 @@ func (p *Packager) updatePackageSecret(ctx context.Context, deployedPackage type
 		_, err = p.cluster.Clientset.CoreV1().Secrets(*newPackageSecret.Namespace).Apply(ctx, newPackageSecret, metav1.ApplyOptions{Force: true, FieldManager: cluster.FieldManagerName})
 		// We warn and ignore errors because we may have removed the cluster that this package was inside of
 		if err != nil {
-			message.Warnf("Unable to apply the '%s' package secret: '%s' (this may be normal if the cluster was removed)", secretName, err.Error())
+			l.Warn("Unable to apply the package secret (this may be normal if the cluster was removed)", "secretName", secretName, "error", err.Error())
 		}
 	}
 	return nil
 }
 
-func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.DeployedPackage, deployedComponent types.DeployedComponent, spinner *message.Spinner) (*types.DeployedPackage, error) {
+func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.DeployedPackage, deployedComponent types.DeployedComponent) (*types.DeployedPackage, error) {
+	l := logger.From(ctx)
 	components := deployedPackage.Data.Components
 
 	c := helpers.Find(components, func(t v1alpha1.ZarfComponent) bool {
@@ -145,7 +145,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 	onRemove := c.Actions.OnRemove
 	onFailure := func() {
 		if err := actions.Run(ctx, onRemove.Defaults, onRemove.OnFailure, nil); err != nil {
-			message.Debugf("Unable to run the failure action: %s", err)
+			l.Debug("unable to run the failure action", "error", err)
 		}
 	}
 
@@ -155,8 +155,6 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 	}
 
 	for _, chart := range helpers.Reverse(deployedComponent.InstalledCharts) {
-		spinner.Updatef("Uninstalling chart '%s' from the '%s' component", chart.ChartName, deployedComponent.Name)
-
 		helmCfg := helm.NewClusterOnly(p.cfg, p.variableConfig, p.state, p.cluster)
 		if err := helmCfg.RemoveChart(ctx, chart.Namespace, chart.ChartName); err != nil {
 			if !errors.Is(err, driver.ErrReleaseNotFound) {
@@ -164,8 +162,8 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 				return deployedPackage, fmt.Errorf("unable to uninstall the helm chart %s in the namespace %s: %w",
 					chart.ChartName, chart.Namespace, err)
 			}
-			message.Warnf("Helm release for helm chart '%s' in the namespace '%s' was not found.  Was it already removed?",
-				chart.ChartName, chart.Namespace)
+			l.Warn("helm release for chart in the namespace was not found",
+				"chart", chart.ChartName, "namespace", chart.Namespace)
 		}
 
 		// Remove the uninstalled chart from the list of installed charts
@@ -204,11 +202,13 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 
 		// We warn and ignore errors because we may have removed the cluster that this package was inside of
 		if err != nil {
-			message.Warnf("Unable to delete the '%s' package secret: '%s' (this may be normal if the cluster was removed)", secretName, err.Error())
+			l.Warn("unable to delete package secret (this may be normal if the cluster was removed)",
+				"secretName", secretName, "error", err.Error())
 		} else {
 			err = p.cluster.Clientset.CoreV1().Secrets(packageSecret.Namespace).Delete(ctx, packageSecret.Name, metav1.DeleteOptions{})
 			if err != nil {
-				message.Warnf("Unable to delete the '%s' package secret: '%s' (this may be normal if the cluster was removed)", secretName, err.Error())
+				l.Warn("unable to delete package secret (this may be normal if the cluster was removed)",
+					"secretName", secretName, "error", err.Error())
 			}
 		}
 	} else {

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -158,7 +158,7 @@ func (p *Packager) removeComponent(ctx context.Context, deployedPackage *types.D
 		spinner.Updatef("Uninstalling chart '%s' from the '%s' component", chart.ChartName, deployedComponent.Name)
 
 		helmCfg := helm.NewClusterOnly(p.cfg, p.variableConfig, p.state, p.cluster)
-		if err := helmCfg.RemoveChart(ctx, chart.Namespace, chart.ChartName, spinner); err != nil {
+		if err := helmCfg.RemoveChart(ctx, chart.Namespace, chart.ChartName); err != nil {
 			if !errors.Is(err, driver.ErrReleaseNotFound) {
 				onFailure()
 				return deployedPackage, fmt.Errorf("unable to uninstall the helm chart %s in the namespace %s: %w",

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -89,7 +89,7 @@ func (s *OCISource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, f
 
 	if unarchiveAll {
 		for _, component := range pkg.Components {
-			if err := dst.Components.Unarchive(component); err != nil {
+			if err := dst.Components.Unarchive(ctx, component); err != nil {
 				if errors.Is(err, layout.ErrNotLoaded) {
 					_, err := dst.Components.Create(component)
 					if err != nil {

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -17,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
@@ -71,14 +70,9 @@ func (s *OCISource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, f
 	}
 
 	if !dst.IsLegacyLayout() {
-		spinner := message.NewProgressSpinner("Validating pulled layer checksums")
-		defer spinner.Stop()
-
 		if err := ValidatePackageIntegrity(dst, pkg.Metadata.AggregateChecksum, isPartial); err != nil {
 			return pkg, nil, err
 		}
-
-		spinner.Success()
 
 		if !s.SkipSignatureValidation {
 			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
@@ -134,20 +128,14 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 
 	if !dst.IsLegacyLayout() {
 		if wantSBOM {
-			spinner := message.NewProgressSpinner("Validating SBOM checksums")
-			defer spinner.Stop()
-
 			if err := ValidatePackageIntegrity(dst, pkg.Metadata.AggregateChecksum, true); err != nil {
 				return pkg, nil, err
 			}
-
-			spinner.Success()
 		}
 
 		if !s.SkipSignatureValidation {
 			if err := ValidatePackageSignature(ctx, dst, s.PublicKeyPath); err != nil {
 				if errors.Is(err, ErrPkgSigButNoKey) && skipValidation {
-					message.Warn("The package was signed but no public key was provided, skipping signature validation")
 					logger.From(ctx).Warn("the package was signed but no public key was provided, skipping signature validation")
 				} else {
 					return pkg, nil, err
@@ -187,15 +175,10 @@ func (s *OCISource) Collect(ctx context.Context, dir string) (string, error) {
 		return "", err
 	}
 
-	spinner := message.NewProgressSpinner("Validating full package checksums")
-	defer spinner.Stop()
 	logger.From(ctx).Debug("validating full package checksums")
-
 	if err := ValidatePackageIntegrity(loaded, pkg.Metadata.AggregateChecksum, false); err != nil {
 		return "", err
 	}
-
-	spinner.Success()
 
 	// TODO (@Noxsios) remove the suffix check at v1.0.0
 	isSkeleton := pkg.Build.Architecture == zoci.SkeletonArch || strings.HasSuffix(s.Repo().Reference.Reference, zoci.SkeletonArch)

--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -63,9 +63,9 @@ func (s *OCISource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, f
 	if err != nil {
 		return pkg, nil, fmt.Errorf("unable to pull the package: %w", err)
 	}
-	dst.SetFromLayers(layersFetched)
+	dst.SetFromLayers(ctx, layersFetched)
 
-	if err := dst.MigrateLegacy(); err != nil {
+	if err := dst.MigrateLegacy(ctx); err != nil {
 		return pkg, nil, err
 	}
 
@@ -115,14 +115,14 @@ func (s *OCISource) LoadPackageMetadata(ctx context.Context, dst *layout.Package
 	if err != nil {
 		return pkg, nil, err
 	}
-	dst.SetFromLayers(layersFetched)
+	dst.SetFromLayers(ctx, layersFetched)
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {
 		return pkg, nil, err
 	}
 
-	if err := dst.MigrateLegacy(); err != nil {
+	if err := dst.MigrateLegacy(ctx); err != nil {
 		return pkg, nil, err
 	}
 
@@ -167,7 +167,7 @@ func (s *OCISource) Collect(ctx context.Context, dir string) (string, error) {
 	}
 
 	loaded := layout.New(tmp)
-	loaded.SetFromLayers(fetched)
+	loaded.SetFromLayers(ctx, fetched)
 
 	var pkg v1alpha1.ZarfPackage
 

--- a/src/pkg/packager/sources/split.go
+++ b/src/pkg/packager/sources/split.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -105,7 +104,6 @@ func (s *SplitTarballSource) Collect(ctx context.Context, dir string) (string, e
 		_ = os.Remove(file)
 	}
 
-	message.Infof("Reassembled package to: %q", reassembled)
 	logger.From(ctx).Info("Reassembled package", "path", reassembled)
 
 	return reassembled, nil

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -38,8 +38,6 @@ type TarballSource struct {
 // LoadPackage loads a package from a tarball.
 func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePaths, filter filters.ComponentFilterStrategy, unarchiveAll bool) (pkg v1alpha1.ZarfPackage, warnings []string, err error) {
 	l := logger.From(ctx)
-	spinner := message.NewProgressSpinner("Loading package from %q", s.PackageSource)
-	defer spinner.Stop()
 	start := time.Now()
 	l.Info("loading package", "source", s.PackageSource)
 
@@ -123,7 +121,7 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 
 	if unarchiveAll {
 		for _, component := range pkg.Components {
-			if err := dst.Components.Unarchive(component); err != nil {
+			if err := dst.Components.Unarchive(ctx, component); err != nil {
 				if errors.Is(err, layout.ErrNotLoaded) {
 					_, err := dst.Components.Create(component)
 					if err != nil {
@@ -142,7 +140,6 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 		}
 	}
 
-	spinner.Success()
 	l.Debug("done loading package", "source", s.PackageSource, "duration", time.Since(start))
 
 	return pkg, warnings, nil

--- a/src/pkg/packager/sources/tarball.go
+++ b/src/pkg/packager/sources/tarball.go
@@ -85,7 +85,7 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 		return pkg, nil, err
 	}
 
-	dst.SetFromPaths(pathsExtracted)
+	dst.SetFromPaths(ctx, pathsExtracted)
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {
@@ -96,7 +96,7 @@ func (s *TarballSource) LoadPackage(ctx context.Context, dst *layout.PackagePath
 		return pkg, nil, err
 	}
 
-	if err := dst.MigrateLegacy(); err != nil {
+	if err := dst.MigrateLegacy(ctx); err != nil {
 		return pkg, nil, err
 	}
 
@@ -169,14 +169,14 @@ func (s *TarballSource) LoadPackageMetadata(ctx context.Context, dst *layout.Pac
 		}
 	}
 
-	dst.SetFromPaths(pathsExtracted)
+	dst.SetFromPaths(ctx, pathsExtracted)
 
 	pkg, warnings, err = dst.ReadZarfYAML()
 	if err != nil {
 		return pkg, nil, err
 	}
 
-	if err := dst.MigrateLegacy(); err != nil {
+	if err := dst.MigrateLegacy(ctx); err != nil {
 		return pkg, nil, err
 	}
 

--- a/src/pkg/packager/sources/validate.go
+++ b/src/pkg/packager/sources/validate.go
@@ -17,7 +17,6 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
@@ -31,7 +30,6 @@ var (
 // ValidatePackageSignature validates the signature of a package
 func ValidatePackageSignature(ctx context.Context, paths *layout.PackagePaths, publicKeyPath string) error {
 	if publicKeyPath != "" {
-		message.Debugf("Using public key %q for signature validation", publicKeyPath)
 		logger.From(ctx).Debug("using public key for signature validation", "key", publicKeyPath)
 	}
 

--- a/src/pkg/transform/types.go
+++ b/src/pkg/transform/types.go
@@ -4,5 +4,4 @@
 package transform
 
 // Log is a function that logs a message.
-// TODO(mkcp): Remove Log and port over to logger once we remove message.
 type Log func(string, ...any)

--- a/src/pkg/utils/cosign.go
+++ b/src/pkg/utils/cosign.go
@@ -30,7 +30,6 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 const (
@@ -129,11 +128,11 @@ func Sget(ctx context.Context, image, key string, out io.Writer) error {
 
 	for _, sig := range sp {
 		if cert, err := sig.Cert(); err == nil && cert != nil {
-			message.Debugf("Certificate subject: %s", cert.Subject)
+			l.Debug("utils.Sget", "subject", cert.Subject)
 
 			ce := cosign.CertExtensions{Cert: cert}
 			if issuerURL := ce.GetIssuer(); issuerURL != "" {
-				message.Debugf("Certificate issuer URL: %s", issuerURL)
+				l.Debug("utils.Sget", "issuerURL", issuerURL)
 			}
 		}
 
@@ -182,7 +181,6 @@ func CosignVerifyBlob(ctx context.Context, blobRef, sigRef, keyPath string) erro
 		return err
 	}
 
-	message.Successf("Package signature validated!")
 	logger.From(ctx).Debug("package signature validated", "key", keyPath)
 	return nil
 }

--- a/src/pkg/utils/network.go
+++ b/src/pkg/utils/network.go
@@ -19,7 +19,6 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 func parseChecksum(src string) (string, string, error) {
@@ -117,17 +116,10 @@ func httpGetFile(ctx context.Context, url string, destinationFile *os.File) (err
 		return fmt.Errorf("bad HTTP status: %s", resp.Status)
 	}
 
-	// Setup progress bar
-	// TODO(mkcp): Remove message on logger release
-	title := fmt.Sprintf("Downloading %s", filepath.Base(url))
-	progressBar := message.NewProgressBar(resp.ContentLength, title)
-	reader := io.TeeReader(resp.Body, progressBar)
 	// Copy response body to file
-	if _, err = io.Copy(destinationFile, reader); err != nil {
-		progressBar.Failf("Unable to save the file %s: %s", destinationFile.Name(), err.Error())
+	if _, err = io.Copy(destinationFile, resp.Body); err != nil {
 		return fmt.Errorf("unable to save the file %s: %w", destinationFile.Name(), err)
 	}
-	progressBar.Successf("Downloaded %s", url)
 	l.Debug("download successful", "url", url, "size", resp.ContentLength, "duration", time.Since(start))
 	return nil
 }

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -30,7 +31,7 @@ func isJSONPathWaitType(condition string) bool {
 }
 
 // ExecuteWait executes the wait-for command.
-func ExecuteWait(waitTimeout, waitNamespace, condition, kind, identifier string, timeout time.Duration) error {
+func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kind, identifier string, timeout time.Duration) error {
 	// Handle network endpoints.
 	switch kind {
 	case "http", "https", "tcp":

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -16,9 +16,8 @@ import (
 	"time"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
-
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 // isJSONPathWaitType checks if the condition is a JSONPath or condition.
@@ -32,10 +31,11 @@ func isJSONPathWaitType(condition string) bool {
 
 // ExecuteWait executes the wait-for command.
 func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kind, identifier string, timeout time.Duration) error {
+	l := logger.From(ctx)
 	// Handle network endpoints.
 	switch kind {
 	case "http", "https", "tcp":
-		return waitForNetworkEndpoint(kind, identifier, condition, timeout)
+		return waitForNetworkEndpoint(ctx, kind, identifier, condition, timeout)
 	}
 
 	// Type of wait, condition or JSONPath
@@ -76,12 +76,9 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 	// Setup the spinner messages.
 	conditionMsg := fmt.Sprintf("Waiting for %s%s%s to be %s.", kind, identifierMsg, namespaceMsg, condition)
 	existMsg := fmt.Sprintf("Waiting for %s%s to exist.", path.Join(kind, identifierMsg), namespaceMsg)
-	spinner := message.NewProgressSpinner(existMsg)
 
 	// Get the OS shell to execute commands in
 	shell, shellArgs := exec.GetOSShell(v1alpha1.Shell{Windows: "cmd"})
-
-	defer spinner.Stop()
 
 	for {
 		// Delay the check for 1 second
@@ -92,48 +89,48 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 			return errors.New("wait timed out")
 
 		default:
-			spinner.Updatef(existMsg)
+			l.Info(existMsg)
 			// Check if the resource exists.
 			zarfKubectlGet := fmt.Sprintf("%s tools kubectl get %s %s %s", zarfCommand, namespaceFlag, kind, identifier)
-			stdout, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
+			_, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
 			if err != nil {
-				message.Debug(stdout, stderr, err)
+				l.Debug("resource error", "error", err)
 				continue
 			}
 
 			resourceNotFound := strings.Contains(stderr, "No resources found") && identifier == ""
 			if resourceNotFound {
-				message.Debug(stdout, stderr, err)
+				l.Debug("resource not found", "error", err)
 				continue
 			}
 
 			// If only checking for existence, exit here.
 			switch condition {
 			case "", "exist", "exists":
-				spinner.Success()
 				return nil
 			}
 
-			spinner.Updatef(conditionMsg)
+			l.Info(conditionMsg)
 			// Wait for the resource to meet the given condition.
 			zarfKubectlWait := fmt.Sprintf("%s tools kubectl wait %s %s %s --for %s%s --timeout=%s",
 				zarfCommand, namespaceFlag, kind, identifier, waitType, condition, waitTimeout)
 
 			// If there is an error, log it and try again.
-			if stdout, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlWait)...); err != nil {
-				message.Debug(stdout, stderr, err)
+			if _, _, err := exec.Cmd(shell, append(shellArgs, zarfKubectlWait)...); err != nil {
+				l.Debug("wait error", "error", err)
 				continue
 			}
 
 			// And just like that, success!
-			spinner.Successf(conditionMsg)
+			l.Info(conditionMsg)
 			return nil
 		}
 	}
 }
 
 // waitForNetworkEndpoint waits for a network endpoint to respond.
-func waitForNetworkEndpoint(resource, name, condition string, timeout time.Duration) error {
+func waitForNetworkEndpoint(ctx context.Context, resource, name, condition string, timeout time.Duration) error {
+	l := logger.From(ctx)
 	// Set the timeout for the wait-for command.
 	expired := time.After(timeout)
 
@@ -142,8 +139,6 @@ func waitForNetworkEndpoint(resource, name, condition string, timeout time.Durat
 	if condition == "" {
 		condition = "success"
 	}
-	spinner := message.NewProgressSpinner("Waiting for network endpoint %s://%s to respond %s.", resource, name, condition)
-	defer spinner.Stop()
 
 	delay := 100 * time.Millisecond
 
@@ -168,7 +163,7 @@ func waitForNetworkEndpoint(resource, name, condition string, timeout time.Durat
 
 					// If the status code is not in the 2xx range, try again.
 					if err != nil || resp.StatusCode < 200 || resp.StatusCode > 299 {
-						message.Debug(err)
+						l.Debug(err.Error())
 						continue
 					}
 
@@ -188,25 +183,24 @@ func waitForNetworkEndpoint(resource, name, condition string, timeout time.Durat
 				// Try to get the URL and check the status code.
 				resp, err := http.Get(url)
 				if err != nil || resp.StatusCode != code {
-					message.Debug(err)
+					l.Debug(err.Error())
 					continue
 				}
 			default:
 				// Fallback to any generic protocol using net.Dial
 				conn, err := net.Dial(resource, name)
 				if err != nil {
-					message.Debug(err)
+					l.Debug(err.Error())
 					continue
 				}
 				err = conn.Close()
 				if err != nil {
-					message.Debug(err)
+					l.Debug(err.Error())
 					continue
 				}
 			}
 
 			// Yay, we made it!
-			spinner.Success()
 			return nil
 		}
 	}

--- a/src/pkg/utils/wait_test.go
+++ b/src/pkg/utils/wait_test.go
@@ -48,6 +48,7 @@ func (suite *TestIsJSONPathWaitTypeSuite) Test_0_IsJSONPathWaitType() {
 	}
 }
 
+// FIXME(mkcp): What is this doing?
 func TestIsJSONPathWaitType(t *testing.T) {
 	message.SetLogLevel(message.DebugLevel)
 	suite.Run(t, new(TestIsJSONPathWaitTypeSuite))

--- a/src/pkg/utils/wait_test.go
+++ b/src/pkg/utils/wait_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 type TestIsJSONPathWaitTypeSuite struct {
@@ -48,8 +47,6 @@ func (suite *TestIsJSONPathWaitTypeSuite) Test_0_IsJSONPathWaitType() {
 	}
 }
 
-// FIXME(mkcp): What is this doing?
 func TestIsJSONPathWaitType(t *testing.T) {
-	message.SetLogLevel(message.DebugLevel)
 	suite.Run(t, new(TestIsJSONPathWaitTypeSuite))
 }

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -46,12 +46,6 @@ func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods 
 	return &Remote{remote}, nil
 }
 
-// String provides a string representation of the Remote's reference.
-// REVIEW(mkcp): Does this function make sense? I use it for info logging in zoci/copier.go
-func (r *Remote) String() string {
-	return r.Repo().Reference.String()
-}
-
 // PlatformForSkeleton sets the target architecture for the remote to skeleton
 func PlatformForSkeleton() ocispec.Platform {
 	return ocispec.Platform{

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -6,13 +6,10 @@ package zoci
 
 import (
 	"context"
-	"log/slog"
-
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 const (
@@ -34,10 +31,7 @@ type Remote struct {
 // NewRemote returns an oras remote repository client and context for the given url
 // with zarf opination embedded
 func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
-	l := slog.New(message.ZarfHandler{})
-	if logger.Enabled(ctx) {
-		l = logger.From(ctx)
-	}
+	l := logger.From(ctx)
 	modifiers := append([]oci.Modifier{
 		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
 		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -46,6 +46,12 @@ func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods 
 	return &Remote{remote}, nil
 }
 
+// String provides a string representation of the Remote's reference.
+// REVIEW(mkcp): Does this function make sense? I use it for info logging in zoci/copier.go
+func (r *Remote) String() string {
+	return r.Repo().Reference.String()
+}
+
 // PlatformForSkeleton sets the target architecture for the remote to skeleton
 func PlatformForSkeleton() ocispec.Platform {
 	return ocispec.Platform{

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -6,6 +6,7 @@ package zoci
 
 import (
 	"context"
+
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/config"

--- a/src/pkg/zoci/copier.go
+++ b/src/pkg/zoci/copier.go
@@ -7,38 +7,29 @@ package zoci
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"oras.land/oras-go/v2/content"
 )
 
 // CopyPackage copies a zarf package from one OCI registry to another
 func CopyPackage(ctx context.Context, src *Remote, dst *Remote, concurrency int) (err error) {
+	l := logger.From(ctx)
 	if concurrency <= 0 {
 		concurrency = DefaultConcurrency
 	}
+
 	srcManifest, err := src.FetchRoot(ctx)
 	if err != nil {
 		return err
 	}
-	layers := append(srcManifest.Layers, srcManifest.Config)
-	size := oci.SumDescsSize(layers)
-
-	title := fmt.Sprintf("[0/%d] layers copied", len(layers))
-	progressBar := message.NewProgressBar(size, title)
-	defer func(progressBar *message.ProgressBar) {
-		err2 := progressBar.Close()
-		err = errors.Join(err, err2)
-	}(progressBar)
-
-	if err := oci.Copy(ctx, src.OrasRemote, dst.OrasRemote, nil, concurrency, progressBar); err != nil {
+	l.Info("copying package", "src", src.String(), "dst", dst.String())
+	if err := oci.Copy(ctx, src.OrasRemote, dst.OrasRemote, nil, concurrency, nil); err != nil {
 		return err
 	}
-	progressBar.Successf("Copied %s", src.Repo().Reference)
 
 	srcRoot, err := src.ResolveRoot(ctx)
 	if err != nil {

--- a/src/pkg/zoci/copier.go
+++ b/src/pkg/zoci/copier.go
@@ -8,10 +8,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"oras.land/oras-go/v2/content"
 )
 

--- a/src/pkg/zoci/copier.go
+++ b/src/pkg/zoci/copier.go
@@ -26,7 +26,9 @@ func CopyPackage(ctx context.Context, src *Remote, dst *Remote, concurrency int)
 	if err != nil {
 		return err
 	}
-	l.Info("copying package", "src", src.String(), "dst", dst.String())
+	l.Info("copying package",
+		"src", src.Repo().Reference.String(),
+		"dst", dst.Repo().Reference.String())
 	if err := oci.Copy(ctx, src.OrasRemote, dst.OrasRemote, nil, concurrency, nil); err != nil {
 		return err
 	}

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -55,12 +55,6 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	// TODO (@austinabro321) change this and other r.Log() calls to the proper slog format
 	r.Log().Info(fmt.Sprintf("Pulling %s, size: %s", r.Repo().Reference, utils.ByteFormat(float64(layerSize), 2)))
 
-	// Create a thread to update a progress bar as we save the package to disk
-	doneSaving := make(chan error)
-	successText := fmt.Sprintf("Pulling %q", helpers.OCIURLPrefix+r.Repo().Reference.String())
-
-	go utils.RenderProgressBarForLocalDirWrite(destinationDir, layerSize, doneSaving, "Pulling", successText)
-
 	dst, err := file.New(destinationDir)
 	if err != nil {
 		return nil, err
@@ -74,8 +68,6 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	copyOpts.Concurrency = concurrency
 
 	err = r.CopyToTarget(ctx, layersToPull, dst, copyOpts)
-	doneSaving <- err
-	<-doneSaving
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/zoci/push.go
+++ b/src/pkg/zoci/push.go
@@ -10,12 +10,9 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
-	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/layout"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 )
@@ -32,14 +29,10 @@ func (r *Remote) PublishPackage(ctx context.Context, pkg *v1alpha1.ZarfPackage, 
 	}(src)
 
 	r.Log().Info(fmt.Sprintf("Publishing package to %s", r.Repo().Reference))
-	spinner := message.NewProgressSpinner("")
-	defer spinner.Stop()
 
 	// Get all the layers in the package
 	var descs []ocispec.Descriptor
 	for name, path := range paths.Files() {
-		spinner.Updatef("Preparing layer %s", helpers.First30Last30(name))
-
 		mediaType := ZarfLayerMediaTypeBlob
 
 		desc, err := src.Add(ctx, name, mediaType, path)
@@ -48,11 +41,9 @@ func (r *Remote) PublishPackage(ctx context.Context, pkg *v1alpha1.ZarfPackage, 
 		}
 		descs = append(descs, desc)
 	}
-	spinner.Successf("Prepared all layers")
 
 	copyOpts := r.GetDefaultCopyOpts()
 	copyOpts.Concurrency = concurrency
-	total := oci.SumDescsSize(descs)
 
 	annotations := annotationsFromMetadata(&pkg.Metadata)
 
@@ -73,26 +64,12 @@ func (r *Remote) PublishPackage(ctx context.Context, pkg *v1alpha1.ZarfPackage, 
 		return err
 	}
 
-	total += manifestConfigDesc.Size
-
-	progressBar := message.NewProgressBar(total, fmt.Sprintf("Publishing %s:%s", r.Repo().Reference.Repository, r.Repo().Reference.Reference))
-	defer func(progressBar *message.ProgressBar) {
-		err2 := progressBar.Close()
-		err = errors.Join(err, err2)
-	}(progressBar)
-	r.SetProgressWriter(progressBar)
-	defer r.ClearProgressWriter()
-
 	publishedDesc, err := oras.Copy(ctx, src, root.Digest.String(), r.Repo(), "", copyOpts)
 	if err != nil {
 		return fmt.Errorf("failed to copy: %w", err)
 	}
-	if err := r.UpdateIndex(ctx, r.Repo().Reference.Reference, publishedDesc); err != nil {
-		return fmt.Errorf("failed to update index: %w", err)
-	}
 
-	progressBar.Successf("Published %s [%s]", r.Repo().Reference, ZarfLayerMediaTypeBlob)
-	return nil
+	return r.UpdateIndex(ctx, r.Repo().Reference.Reference, publishedDesc)
 }
 
 func annotationsFromMetadata(metadata *v1alpha1.ZarfMetadata) map[string]string {

--- a/src/test/e2e/29_config_file_test.go
+++ b/src/test/e2e/29_config_file_test.go
@@ -78,7 +78,6 @@ func TestConfigFileDefault(t *testing.T) {
 		"architecture: 509a38f0",
 		"log_level: 6a845a41",
 		"Disable log file creation (default true)",
-		"Disable fancy UI progress bars, spinners, logos, etc (default true)",
 		"zarf_cache: 978499a5",
 		"Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.",
 		"Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.",

--- a/src/test/e2e/29_config_file_test.go
+++ b/src/test/e2e/29_config_file_test.go
@@ -77,7 +77,6 @@ func TestConfigFileDefault(t *testing.T) {
 	globalFlags := []string{
 		"architecture: 509a38f0",
 		"log_level: 6a845a41",
-		"Disable log file creation (default true)",
 		"zarf_cache: 978499a5",
 		"Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.",
 		"Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.",

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/message"
 	"github.com/zarf-dev/zarf/src/test"
 )
 
@@ -42,8 +41,6 @@ func TestMain(m *testing.M) {
 	e2e.ZarfBinPath = zarfBinPath
 	e2e.ApplianceMode = os.Getenv(applianceModeEnvVar) == "true"
 	e2e.ApplianceModeKeep = os.Getenv(applianceModeKeepEnvVar) == "true"
-
-	message.SetLogLevel(message.TraceLevel)
 
 	if _, err := os.Stat(e2e.ZarfBinPath); err != nil {
 		log.Fatalf("zarf binary %s not found: %v", e2e.ZarfBinPath, err)


### PR DESCRIPTION
## Description
Within, we've removed `log-format="legacy"` from the  `cmd` layer while keeping `message` set up properly to print non-log messages like Yaml and tables. Next, we've chase down every `message` log statement, spinner, and progress bar in the main zarf codebase. 

## Related Issue

Fixes #3500 
Relates to #2576

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed