### PR TITLE
fix(unit): resolve TestRepository host git configuration dependency

### DIFF
--- a/src/internal/git/repository_test.go
+++ b/src/internal/git/repository_test.go
@@ -54,10 +54,8 @@ func TestRepository(t *testing.T) {
 	}
 	initRepo, err := git.InitWithOptions(storer, fs, options)
 	require.NoError(t, err)
-
 	w, err := initRepo.Worktree()
 	require.NoError(t, err)
-
 	filePath := "test.txt"
 	newFile, err := fs.Create(filePath)
 	require.NoError(t, err)
@@ -78,7 +76,6 @@ func TestRepository(t *testing.T) {
 		URLs: []string{repoAddress},
 	})
 	require.NoError(t, err)
-	t.Log(initRepo.Head())
 	err = initRepo.Push(&git.PushOptions{
 		RemoteName: "origin",
 	})


### PR DESCRIPTION
## Description

Current test logic is coupled with the hosts ~/.gitconfig. If the host has 
```
[init]
        defaultBranch = main
```
Then the `TestRepository` unit test at `src/internal/git/repository_test.go` will fail. 

Undetermined how to decouple this fully within `go-git` as of yet. Issues are unclear and mixed results as far as consuming `$HOME/.gitconfig` are concerned and all explicit definition of `main` for `defaultBranch` still results in the `HEAD` containing the hosts default branch and not the configuration. 

This change re-writes the `HEAD` file to match the explicit `InitOptions` such that it will now pass when the hosts `.gitconfig` does not align to the original workflow. 

## Related Issue

Fixes #3567

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
