### PR TITLE
chore: use setup-zarf from zarf-dev 

### DIFF
--- a/.github/workflows/publish-application-packages.yml
+++ b/.github/workflows/publish-application-packages.yml
@@ -25,7 +25,7 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Install The Latest Release Version of Zarf
-        uses: defenseunicorns/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
+        uses: zarf-dev/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
 
       - name: "Login to GHCR"
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -77,7 +77,7 @@ jobs:
           chmod +x build/zarf
 
       - name: Install release version of Zarf
-        uses: defenseunicorns/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
+        uses: zarf-dev/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
         with:
           download-init-package: true
 


### PR DESCRIPTION
## Description

The setup-zarf action was moved from the defense unicorns organization to zarf-dev

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
