### PR TITLE
test: increase timeout for in cluster test health check

### DIFF
--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -89,7 +89,7 @@ func (suite *ExtInClusterTestSuite) SetupSuite() {
 		},
 	}
 	ctx := logger.WithContext(context.Background(), test.GetLogger(suite.T()))
-	waitCtx, waitCancel := context.WithTimeout(ctx, 60*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer waitCancel()
 	err = healthchecks.WaitForReady(waitCtx, c.Watcher, objs)
 	suite.NoError(err)


### PR DESCRIPTION
## Description

I noticed this flake here, seemingly because it took too long. https://github.com/zarf-dev/zarf/actions/runs/14092394407/job/39472052129

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
