### PR TITLE
fix: support importing components with multiple charts

### DIFF
--- a/src/pkg/packager/composer/pathfixer.go
+++ b/src/pkg/packager/composer/pathfixer.go
@@ -25,13 +25,19 @@ func fixPaths(child *v1alpha1.ZarfComponent, relativeToHead string) {
 		child.Files[fileIdx].Source = composed
 	}
 
+	// Fix chart paths.
 	for chartIdx, chart := range child.Charts {
 		for valuesIdx, valuesFile := range chart.ValuesFiles {
 			composed := makePathRelativeTo(valuesFile, relativeToHead)
 			child.Charts[chartIdx].ValuesFiles[valuesIdx] = composed
 		}
 		if child.Charts[chartIdx].LocalPath != "" {
-			composed := makePathRelativeTo(chart.LocalPath, relativeToHead)
+			// When importing multiple charts, update the path from "chart" to "charts"
+			localPath := chart.LocalPath
+			if len(child.Charts) > 1 && localPath == "chart" {
+				localPath = "charts"
+			}
+			composed := makePathRelativeTo(localPath, relativeToHead)
 			child.Charts[chartIdx].LocalPath = composed
 		}
 	}


### PR DESCRIPTION
## Description

When composing components, if the imported component has more than one chart, Zarf is unable to load the chart because it looks for `.zarf-cache/oci/dirs/abcdf...wxyz/chart` instead of `.zarf-cache/oci/dirs/abcdf...wxyz/charts`.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
