### PR TITLE
fix: set flavor on composed component

### DIFF
--- a/src/internal/packager2/layout/import.go
+++ b/src/internal/packager2/layout/import.go
@@ -139,7 +139,6 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 	pkg.Constants = slices.CompactFunc(constants, func(l, r v1alpha1.Constant) bool {
 		return l.Name == r.Name
 	})
-	importStack = importStack[0 : len(importStack)-1]
 	return pkg, nil
 }
 
@@ -272,6 +271,11 @@ func overrideMetadata(comp v1alpha1.ZarfComponent, override v1alpha1.ZarfCompone
 	// Override description if it was provided.
 	if override.Description != "" {
 		comp.Description = override.Description
+	}
+
+	// If the imported component has a flavor, mark the component with that flavor
+	if override.Only.Flavor != "" {
+		comp.Only.Flavor = override.Only.Flavor
 	}
 
 	if override.Only.LocalOS != "" {

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -37,8 +37,9 @@ func TestResolveImports(t *testing.T) {
 	ctx := testutil.TestContext(t)
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	testCases := []struct {
-		name string
-		path string
+		name   string
+		path   string
+		flavor string
 	}{
 		{
 			name: "two zarf.yaml files import each other",
@@ -52,6 +53,11 @@ func TestResolveImports(t *testing.T) {
 			name: "two separate chains of imports importing a common file",
 			path: "./testdata/import/branch",
 		},
+		{
+			name:   "flavor is preserved when importing",
+			path:   "./testdata/import/flavor",
+			flavor: "pistachio",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -63,7 +69,7 @@ func TestResolveImports(t *testing.T) {
 			pkg, err := ParseZarfPackage(b)
 			require.NoError(t, err)
 
-			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", "", []string{})
+			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{})
 			require.NoError(t, err)
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))

--- a/src/internal/packager2/layout/testdata/import/flavor/child/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/flavor/child/zarf.yaml
@@ -1,0 +1,10 @@
+kind: ZarfPackageConfig
+metadata:
+  name: example-package-flavors-child
+
+components:
+  - name: has-no-flavor
+
+  - name: child-has-flavor
+    only:
+      flavor: pistachio

--- a/src/internal/packager2/layout/testdata/import/flavor/expected.yaml
+++ b/src/internal/packager2/layout/testdata/import/flavor/expected.yaml
@@ -1,0 +1,12 @@
+kind: ZarfPackageConfig
+metadata:
+  name: example-package-flavors
+components:
+  - name: has-flavor
+    description: this already has a flavor so it shouldn't get overwritten
+    only:
+      flavor: pistachio
+  - name: child-has-flavor
+    description: this doesn't have a flavor so it should get it's child's flavor
+    only:
+      flavor: pistachio

--- a/src/internal/packager2/layout/testdata/import/flavor/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/flavor/zarf.yaml
@@ -1,0 +1,17 @@
+kind: ZarfPackageConfig
+metadata:
+  name: example-package-flavors
+
+components:
+  - name: has-flavor
+    description: this already has a flavor so it shouldn't get overwritten
+    import:
+      path: child
+      name: has-no-flavor
+    only:
+      flavor: pistachio
+
+  - name: child-has-flavor
+    description: this doesn't have a flavor so it should get it's child's flavor
+    import:
+      path: child


### PR DESCRIPTION
## Description

A bug was introduced in #3597 which caused validation to improperly fail when a flavor is used by a child component but not used by a parent component. It stems from the fact that flavors are not set on the composed component when a child component has one. This PR updates the behavior to set the flavor on the newly composed

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
