### PR TITLE
feat!: Add debug granularity to package create validation and update error message

### DIFF
--- a/src/internal/packager2/layout/create_test.go
+++ b/src/internal/packager2/layout/create_test.go
@@ -250,7 +250,7 @@ func TestLoadPackageWithFlavors(t *testing.T) {
 			t.Parallel()
 			_, err := LoadPackage(context.Background(), filepath.Join("testdata", "package-with-flavors"), tt.flavor, map[string]string{})
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.ErrorContains(t, err, tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR adds some debug logging and the package name to resolving and validating imports. We also append the package name to a flavor validation error - the error message is otherwise unchanged.

Before:
<img width="1192" alt="Screenshot 2025-04-04 at 14 08 18" src="https://github.com/user-attachments/assets/eb895833-f2f4-4f13-b413-ec69ebf84ce5" />

After:
<img width="1512" alt="Screenshot 2025-04-04 at 14 02 16" src="https://github.com/user-attachments/assets/76039dc9-5f30-430a-afc4-ac63c5aadc2d" />


## Related Issue
#3597 



## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
