### PR TITLE
refactor: include all workload resources

### DIFF
--- a/src/pkg/packager/prepare.go
+++ b/src/pkg/packager/prepare.go
@@ -365,6 +365,27 @@ func processUnstructuredImages(ctx context.Context, resource *unstructured.Unstr
 	}
 
 	switch resource.GetKind() {
+	case "Pod":
+		var pod corev1.Pod
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(contents, &pod); err != nil {
+			return nil, nil, fmt.Errorf("could not parse pod: %w", err)
+		}
+		matchedImages = appendToImageMap(matchedImages, pod.Spec)
+
+	case "CronJob":
+		var cronJob batchv1.CronJob
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(contents, &cronJob); err != nil {
+			return nil, nil, fmt.Errorf("could not parse cronjob: %w", err)
+		}
+		matchedImages = appendToImageMap(matchedImages, cronJob.Spec.JobTemplate.Spec.Template.Spec)
+
+	case "ReplicationController":
+		var rc corev1.ReplicationController
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(contents, &rc); err != nil {
+			return nil, nil, fmt.Errorf("could not parse replicationcontroller: %w", err)
+		}
+		matchedImages = appendToImageMap(matchedImages, rc.Spec.Template.Spec)
+
 	case "Deployment":
 		var deployment v1.Deployment
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(contents, &deployment); err != nil {


### PR DESCRIPTION
add pod, cronjob, and replicationcontroller to minimize usage of standard submatching

## Description

This pull request does not add any features or changes any code flow.

The `processUnstructuredImages()` function iterates over resources and passes child PodSpec resources into `appendToImageMap()` to grab a list of all required images. 

While following logic, thought it would be more cohesive to support **all** resources that include Pod specs, include Pod itself, CronJob and ReplicationController (although legacy).

...

## Related Issue

Not related to any existing issues. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
