### PR TITLE
feat: respect filters for all package sources in `LoadPackage`

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -317,7 +317,6 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	mirrorOpt := packager2.MirrorOptions{
 		Cluster:         c,
 		PkgLayout:       pkgLayout,
-		Filter:          filter,
 		RegistryInfo:    pkgConfig.InitOpts.RegistryInfo,
 		GitInfo:         pkgConfig.InitOpts.GitServer,
 		NoImageChecksum: pkgConfig.MirrorOpts.NoImgChecksum,

--- a/src/internal/packager2/load.go
+++ b/src/internal/packager2/load.go
@@ -37,6 +37,9 @@ type LoadOptions struct {
 
 // LoadPackage optionally fetches and loads the package from the given source.
 func LoadPackage(ctx context.Context, opt LoadOptions) (*layout.PackageLayout, error) {
+	if opt.Filter == nil {
+		opt.Filter = filters.Empty()
+	}
 	srcType, err := identifySource(opt.Source)
 	if err != nil {
 		return nil, err
@@ -83,6 +86,7 @@ func LoadPackage(ctx context.Context, opt LoadOptions) (*layout.PackageLayout, e
 		PublicKeyPath:           opt.PublicKeyPath,
 		SkipSignatureValidation: opt.SkipSignatureValidation,
 		IsPartial:               isPartial,
+		Filter:                  opt.Filter,
 	}
 	pkgLayout, err := layout.LoadFromTar(ctx, tarPath, layoutOpt)
 	if err != nil {

--- a/src/internal/packager2/publish_test.go
+++ b/src/internal/packager2/publish_test.go
@@ -32,7 +32,7 @@ func pullFromRemote(t *testing.T, ctx context.Context, packageRef string, archit
 	_, tarPath, err := pullOCI(context.Background(), packageRef, tmpdir, "", architecture, filters.Empty(), oci.WithPlainHTTP(true))
 	require.NoError(t, err)
 
-	layoutActual, err := layout.LoadFromTar(ctx, tarPath, layout.PackageLayoutOptions{})
+	layoutActual, err := layout.LoadFromTar(ctx, tarPath, layout.PackageLayoutOptions{Filter: filters.Empty()})
 	require.NoError(t, err)
 
 	return layoutActual
@@ -231,7 +231,7 @@ func TestPublishPackage(t *testing.T) {
 			require.NoError(t, err)
 
 			// We want to pull the package and sure the content is the same as the local package
-			layoutExpected, err := layout.LoadFromTar(ctx, tc.path, layout.PackageLayoutOptions{})
+			layoutExpected, err := layout.LoadFromTar(ctx, tc.path, layout.PackageLayoutOptions{Filter: filters.Empty()})
 			require.NoError(t, err)
 			// Publish creates a local oci manifest file using the package name, delete this to clean up test name
 			defer os.Remove(layoutExpected.Pkg.Metadata.Name)

--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -35,6 +35,9 @@ import (
 // TODO: Add options struct
 // Pull fetches the Zarf package from the given sources.
 func Pull(ctx context.Context, src, dir, shasum, architecture string, filter filters.ComponentFilterStrategy, publicKeyPath string, skipSignatureValidation bool) error {
+	if filter == nil {
+		filter = filters.Empty()
+	}
 	l := logger.From(ctx)
 	start := time.Now()
 	u, err := url.Parse(src)
@@ -80,6 +83,7 @@ func Pull(ctx context.Context, src, dir, shasum, architecture string, filter fil
 		PublicKeyPath:           publicKeyPath,
 		SkipSignatureValidation: skipSignatureValidation,
 		IsPartial:               isPartial,
+		Filter:                  filter,
 	}
 	_, err = layout.LoadFromTar(ctx, tmpPath, layoutOpt)
 	if err != nil {


### PR DESCRIPTION
## Description

`LoadPackage` accepts a filter, but only respects it when pulling an OCI package. This did not cause any bugs because Zarf always applies the filter after we get the package back. It is a more intuitive and less duplication to apply the filter in `LoadPackage`

`LoadFromTar` and `LoadFromDir` now accept filters as well.

All public functions that take a filter will set the filter to `filters.Empty()` if it is `nil`

## Related Issue

Relates to #3649

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
