### PR TITLE
chore: move v1beta1 internal

### DIFF
--- a/src/api/internal/v1beta1/component.go
+++ b/src/api/internal/v1beta1/component.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package v1beta1 holds the definition of the v1beta1 Zarf Package
 package v1beta1
 
 import (

--- a/src/api/internal/v1beta1/package.go
+++ b/src/api/internal/v1beta1/package.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package v1beta1 holds the definition of the v1beta1 Zarf Package
+// Package v1beta1 holds the definition of the v1beta1 Zarf Package. This API is work in progress and not yet used within Zarf
 package v1beta1
 
 import (

--- a/src/api/internal/v1beta1/package_test.go
+++ b/src/api/internal/v1beta1/package_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package v1beta1 holds the definition of the v1beta1 Zarf Package
 package v1beta1
 
 import (

--- a/src/api/internal/v1beta1/translate.go
+++ b/src/api/internal/v1beta1/translate.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package v1beta1 holds the definition of the v1beta1 Zarf Package
 package v1beta1
 
 import (

--- a/src/api/internal/v1beta1/translate_test.go
+++ b/src/api/internal/v1beta1/translate_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package v1beta1 holds the definition of the v1beta1 Zarf Package
 package v1beta1
 
 import (


### PR DESCRIPTION
## Description

We have had users confused on why v1beta1 doesn't work with the rest of Zarf. V1beta1 is work in progress. This PR moves it to an internal package to avoid confusion. 

Relates to #3433 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
