### PR TITLE
fix: restore ability to publish Zarf packages to root level of an OCI registry

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -877,20 +878,19 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 
 		// source registry reference
 		trimmed := strings.TrimPrefix(packageSource, helpers.OCIURLPrefix)
-		srcRegistry, err := registry.ParseReference(trimmed)
-
+		srcRef, err := registry.ParseReference(trimmed)
 		if err != nil {
 			return err
 		}
 
 		// Grab the package name and append it to the ref.repository to ensure package name and tag/digest match
-		srcParts := strings.Split(srcRegistry.Repository, "/")
-		srcPackageName := srcParts[len(srcParts)-1]
+		srcRepoParts := strings.Split(srcRef.Repository, "/")
+		srcPackageName := srcRepoParts[len(srcRepoParts)-1]
 
-		ref.Repository = fmt.Sprintf("%s/%s", ref.Repository, srcPackageName)
-		ref.Reference = srcRegistry.Reference
+		ref.Repository = path.Join(ref.Repository, srcPackageName)
+		ref.Reference = srcRef.Reference
 
-		return packager2.PublishFromOCI(cmd.Context(), srcRegistry, ref, ociOpts)
+		return packager2.PublishFromOCI(cmd.Context(), srcRef, ref, ociOpts)
 	}
 
 	publishPackageOpts := packager2.PublishPackageOpts{


### PR DESCRIPTION
## Description

Currently unable to do the following in Zarf v0.51.0:

```bash
$ zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http -a amd64 -l trace
2025-04-13 13:41:26 DBG logger successfully initialized cfg.level=debug cfg.format=console cfg.destination=os.Stderr cfg.color=true
2025-04-13 13:41:26 ERR invalid reference: invalid repository "/dos-games"
```

as a result of https://github.com/zarf-dev/zarf/pull/3495

This small change fixes that.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
