### PR TITLE
fix(skeleton): resolve support for kustomizations in isolation

### DIFF
--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -665,8 +665,13 @@ func assembleSkeletonComponent(component v1alpha1.ZarfComponent, packagePath, bu
 
 		component.DataInjections[dataIdx].Source = rel
 	}
-
 	// Iterate over all manifests.
+	if len(component.Manifests) > 0 {
+		err := os.MkdirAll(filepath.Join(compBuildPath, string(ManifestsComponentDir)), 0o700)
+		if err != nil {
+			return err
+		}
+	}
 	for manifestIdx, manifest := range component.Manifests {
 		for fileIdx, path := range manifest.Files {
 			rel := filepath.Join(string(ManifestsComponentDir), fmt.Sprintf("%s-%d.yaml", manifest.Name, fileIdx))
@@ -686,6 +691,7 @@ func assembleSkeletonComponent(component v1alpha1.ZarfComponent, packagePath, bu
 			rel := filepath.Join(string(ManifestsComponentDir), kname)
 			dst := filepath.Join(compBuildPath, rel)
 
+			// Build() requires the path be present - otherwise will throw an error.
 			if err := kustomize.Build(filepath.Join(packagePath, path), dst, manifest.KustomizeAllowAnyDirectory); err != nil {
 				return fmt.Errorf("unable to build kustomization %s: %w", path, err)
 			}

--- a/src/internal/packager2/layout/create_test.go
+++ b/src/internal/packager2/layout/create_test.go
@@ -145,11 +145,13 @@ func TestCreateSkeleton(t *testing.T) {
 	require.Empty(t, warnings)
 	b, err := os.ReadFile(filepath.Join(pkgPath.Base, "checksums.txt"))
 	require.NoError(t, err)
-	expectedChecksum := `54f657b43323e1ebecb0758835b8d01a0113b61b7bab0f4a8156f031128d00f9 components/data-injections.tar
+	expectedChecksum := `0fea7403536c0c0e2a2d9b235d4b3716e86eefd8e78e7b14412dd5a750b77474 components/kustomizations.tar
+54f657b43323e1ebecb0758835b8d01a0113b61b7bab0f4a8156f031128d00f9 components/data-injections.tar
 879bfe82d20f7bdcd60f9e876043cc4343af4177a6ee8b2660c304a5b6c70be7 components/files.tar
 c497f1a56559ea0a9664160b32e4b377df630454ded6a3787924130c02f341a6 components/manifests.tar
 fb7ebee94a4479bacddd71195030a483b0b0b96d4f73f7fcd2c2c8e0fce0c5c6 components/helm-charts.tar
 `
+
 	require.Equal(t, expectedChecksum, string(b))
 }
 

--- a/src/internal/packager2/layout/testdata/zarf-skeleton-package/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/zarf-skeleton-package/zarf.yaml
@@ -39,3 +39,9 @@ components:
           - deployment.yaml
         kustomizations:
           - kustomize
+  - name: kustomizations
+    required: true
+    manifests:
+      - name: namespace
+        kustomizations:
+          - ./kustomize


### PR DESCRIPTION
## Description

Attempting to create a component using `manifests.kustomizations` without any `manifests.files` will fail because it silently relies on the manifests.files loop to create the parent directory `manifests` which `kustomize.Build()` expects to exist in order to write the file. 

Updated the `create_test.go` to include a component which has kustomizations in isolation in order to detect this going forward. 

## Related Issue

Fixes #3667 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
