### PR TITLE
fix: require username and password for `zarf tools registry login`

### DIFF
--- a/src/cmd/crane.go
+++ b/src/cmd/crane.go
@@ -105,6 +105,14 @@ func newRegistryCommand() *cobra.Command {
 func newRegistryLoginCommand() *cobra.Command {
 	cmd := craneCmd.NewCmdAuthLogin()
 	cmd.Example = ""
+	err := cmd.MarkFlagRequired("username")
+	if err != nil {
+		logger.Default().Error("failed to mark username flag required", "error", err.Error())
+	}
+	err = cmd.MarkFlagRequired("password")
+	if err != nil {
+		logger.Default().Error("failed to mark password flag required", "error", err.Error())
+	}
 	return cmd
 }
 


### PR DESCRIPTION
## Description

Looks like Crane has a bug in their validation - https://github.com/google/go-containerregistry/pull/2088

## Related Issue

Fixes #3644

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
