### PR TITLE
fix: require one of `password` or `password-stdin` in `zarf tools registry login`

### DIFF
--- a/src/cmd/crane.go
+++ b/src/cmd/crane.go
@@ -109,10 +109,7 @@ func newRegistryLoginCommand() *cobra.Command {
 	if err != nil {
 		logger.Default().Error("failed to mark username flag required", "error", err.Error())
 	}
-	err = cmd.MarkFlagRequired("password")
-	if err != nil {
-		logger.Default().Error("failed to mark password flag required", "error", err.Error())
-	}
+	cmd.MarkFlagsOneRequired("password", "password-stdin")
 	return cmd
 }
 


### PR DESCRIPTION
## Description

In #3676 I added validation to the `username` and `password` flags without accounting for the `password-stdin` flag. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
