### PR TITLE
feat: allow unused flavors with a warning

### DIFF
--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -310,8 +310,8 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 		"setVariables", setVariables,
 	)
 
-	if err := validateFlavorExists(pkg, flavor); err != nil {
-		return err
+	if !packageUsesFlavor(pkg, flavor) {
+		l.Warn("flavor not used in package", "flavor", flavor)
 	}
 	if err := lint.ValidatePackage(pkg); err != nil {
 		return fmt.Errorf("package validation failed: %w", err)
@@ -338,16 +338,16 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 	return nil
 }
 
-func validateFlavorExists(pkg v1alpha1.ZarfPackage, flavor string) error {
+func packageUsesFlavor(pkg v1alpha1.ZarfPackage, flavor string) bool {
 	if flavor == "" {
-		return nil
+		return false
 	}
 	for _, comp := range pkg.Components {
 		if comp.Only.Flavor == flavor {
-			return nil
+			return true
 		}
 	}
-	return fmt.Errorf("could not find flavor %s in package definition %s", flavor, pkg.Metadata.Name)
+	return false
 }
 
 func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfComponent, packagePath, buildPath string) error {

--- a/src/internal/packager2/layout/create_test.go
+++ b/src/internal/packager2/layout/create_test.go
@@ -264,7 +264,7 @@ func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {
 	require.NoError(t, err)
 }
 
-func TestCheckIfFlavorIsUsed(t *testing.T) {
+func TestPackageUsesFlavor(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
## Description

In #3597 I added validation for flavors, however I did not anticipate that users intentionally created packages with unused flavors to set different tags on the package. As we don't have an alternative at the moment, this PR allows unused flavors again, but with a warning


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
