### PR TITLE
fix: ensure variable uniqueness during compose

### DIFF
--- a/src/internal/packager2/layout/import.go
+++ b/src/internal/packager2/layout/import.go
@@ -148,7 +148,6 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 
 	pkg.Components = components
 	// Keep only first occurrence of each variable
-	pkg.Variables = []v1alpha1.InteractiveVariable{}
 	for _, v := range variables {
 		if slices.IndexFunc(pkg.Variables, func(existing v1alpha1.InteractiveVariable) bool {
 			return existing.Name == v.Name
@@ -158,7 +157,6 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 	}
 
 	// Keep only first occurrence of each constant
-	pkg.Constants = []v1alpha1.Constant{}
 	for _, c := range constants {
 		if slices.IndexFunc(pkg.Constants, func(existing v1alpha1.Constant) bool {
 			return existing.Name == c.Name

--- a/src/internal/packager2/layout/import.go
+++ b/src/internal/packager2/layout/import.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -147,23 +146,25 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 	}
 
 	pkg.Components = components
-	// Keep only first occurrence of each variable
+
+	varMap := map[string]bool{}
+	pkg.Variables = nil
 	for _, v := range variables {
-		if slices.IndexFunc(pkg.Variables, func(existing v1alpha1.InteractiveVariable) bool {
-			return existing.Name == v.Name
-		}) == -1 {
+		if _, present := varMap[v.Name]; !present {
 			pkg.Variables = append(pkg.Variables, v)
+			varMap[v.Name] = true
 		}
 	}
 
-	// Keep only first occurrence of each constant
+	constMap := map[string]bool{}
+	pkg.Constants = nil
 	for _, c := range constants {
-		if slices.IndexFunc(pkg.Constants, func(existing v1alpha1.Constant) bool {
-			return existing.Name == c.Name
-		}) == -1 {
+		if _, present := constMap[c.Name]; !present {
 			pkg.Constants = append(pkg.Constants, c)
+			constMap[c.Name] = true
 		}
 	}
+
 	l.Debug("done layout.ResolveImports",
 		"pkg", pkg.Metadata.Name,
 		"components", len(pkg.Components),

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -4,15 +4,12 @@
 package layout
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	goyaml "github.com/goccy/go-yaml"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
@@ -78,9 +75,6 @@ func TestResolveImports(t *testing.T) {
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
 			require.NoError(t, err)
 			expectedPkg, err := ParseZarfPackage(b)
-			otherB, err := goyaml.Marshal(resolvedPkg)
-			require.NoError(t, err)
-			fmt.Println(string(otherB))
 
 			require.NoError(t, err)
 			require.Equal(t, expectedPkg, resolvedPkg)

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -52,15 +52,15 @@ func TestResolveImports(t *testing.T) {
 			name: "variables and constants are resolved correctly",
 			path: "./testdata/import/variables",
 		},
-		// {
-		// 	name: "two separate chains of imports importing a common file",
-		// 	path: "./testdata/import/branch",
-		// },
-		// {
-		// 	name:   "flavor is preserved when importing",
-		// 	path:   "./testdata/import/flavor",
-		// 	flavor: "pistachio",
-		// },
+		{
+			name: "two separate chains of imports importing a common file",
+			path: "./testdata/import/branch",
+		},
+		{
+			name:   "flavor is preserved when importing",
+			path:   "./testdata/import/flavor",
+			flavor: "pistachio",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -77,13 +77,13 @@ func TestResolveImports(t *testing.T) {
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
 			require.NoError(t, err)
-			// expectedPkg, err := ParseZarfPackage(b)
+			expectedPkg, err := ParseZarfPackage(b)
 			otherB, err := goyaml.Marshal(resolvedPkg)
 			require.NoError(t, err)
 			fmt.Println(string(otherB))
 
-			// require.NoError(t, err)
-			// require.Equal(t, expectedPkg, resolvedPkg)
+			require.NoError(t, err)
+			require.Equal(t, expectedPkg, resolvedPkg)
 		})
 	}
 }

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -44,10 +44,10 @@ func TestResolveImports(t *testing.T) {
 		path   string
 		flavor string
 	}{
-		// {
-		// 	name: "two zarf.yaml files import each other",
-		// 	path: "./testdata/import/import-each-other",
-		// },
+		{
+			name: "two zarf.yaml files import each other",
+			path: "./testdata/import/import-each-other",
+		},
 		{
 			name: "variables and constants are resolved correctly",
 			path: "./testdata/import/variables",

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -4,12 +4,15 @@
 package layout
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	goyaml "github.com/goccy/go-yaml"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
@@ -41,23 +44,23 @@ func TestResolveImports(t *testing.T) {
 		path   string
 		flavor string
 	}{
-		{
-			name: "two zarf.yaml files import each other",
-			path: "./testdata/import/import-each-other",
-		},
+		// {
+		// 	name: "two zarf.yaml files import each other",
+		// 	path: "./testdata/import/import-each-other",
+		// },
 		{
 			name: "variables and constants are resolved correctly",
 			path: "./testdata/import/variables",
 		},
-		{
-			name: "two separate chains of imports importing a common file",
-			path: "./testdata/import/branch",
-		},
-		{
-			name:   "flavor is preserved when importing",
-			path:   "./testdata/import/flavor",
-			flavor: "pistachio",
-		},
+		// {
+		// 	name: "two separate chains of imports importing a common file",
+		// 	path: "./testdata/import/branch",
+		// },
+		// {
+		// 	name:   "flavor is preserved when importing",
+		// 	path:   "./testdata/import/flavor",
+		// 	flavor: "pistachio",
+		// },
 	}
 
 	for _, tc := range testCases {
@@ -74,9 +77,13 @@ func TestResolveImports(t *testing.T) {
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
 			require.NoError(t, err)
-			expectedPkg, err := ParseZarfPackage(b)
+			// expectedPkg, err := ParseZarfPackage(b)
+			otherB, err := goyaml.Marshal(resolvedPkg)
 			require.NoError(t, err)
-			require.Equal(t, expectedPkg, resolvedPkg)
+			fmt.Println(string(otherB))
+
+			// require.NoError(t, err)
+			// require.Equal(t, expectedPkg, resolvedPkg)
 		})
 	}
 }

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -75,6 +75,7 @@ func TestResolveImports(t *testing.T) {
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
 			require.NoError(t, err)
 			expectedPkg, err := ParseZarfPackage(b)
+
 			require.NoError(t, err)
 			require.Equal(t, expectedPkg, resolvedPkg)
 		})

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -75,7 +75,6 @@ func TestResolveImports(t *testing.T) {
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
 			require.NoError(t, err)
 			expectedPkg, err := ParseZarfPackage(b)
-
 			require.NoError(t, err)
 			require.Equal(t, expectedPkg, resolvedPkg)
 		})

--- a/src/internal/packager2/layout/testdata/import/variables/expected.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/expected.yaml
@@ -2,15 +2,17 @@ kind: ZarfPackageConfig
 metadata:
   name: parent-package
 constants:
-  - name: PARENT_CONSTANT
-    value: "value from parent"
-  - name: CHILD_CONSTANT
-    value: "value from child"
+- name: PARENT_CONSTANT
+  value: value from parent
+- name: CHILD_CONSTANT
+  value: value from child
 variables:
   - name: PARENT_VAR
-    value: "value from parent"
+    default: "default from parent"
   - name: CHILD_VAR
-    value: "value from child"
+    default: "default from child"
 components:
   - name: component-to-test-vars
+    required: true
+  - name: other-component-to-test-vars
     required: true

--- a/src/internal/packager2/layout/testdata/import/variables/expected.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/expected.yaml
@@ -11,8 +11,12 @@ variables:
     default: "default from parent"
   - name: CHILD_VAR
     default: "default from child"
+  - name: SECONDARY_CHILD_VAR
+    default: "default from child in component imported later"
 components:
-  - name: component-to-test-vars
+  - name: first-imported-component
     required: true
-  - name: other-component-to-test-vars
+  - name: same-package-imported-again
+    required: true
+  - name: component-from-different-package
     required: true

--- a/src/internal/packager2/layout/testdata/import/variables/import/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/import/zarf.yaml
@@ -12,7 +12,7 @@ variables:
   - name: CHILD_VAR
     default: "default from child"
 components:
-  - name: component-to-test-vars
+  - name: first-imported-component
     required: true
-  - name: other-component-to-test-vars
+  - name: same-package-imported-again
     required: true

--- a/src/internal/packager2/layout/testdata/import/variables/import/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/import/zarf.yaml
@@ -1,7 +1,6 @@
 kind: ZarfPackageConfig
 metadata:
-  name: parent-package
-
+  name: child-package
 constants:
   - name: PARENT_CONSTANT
     value: "value from child"
@@ -9,9 +8,11 @@ constants:
     value: "value from child"
 variables:
   - name: PARENT_VAR
-    value: "value from child"
+    default: "default from child"
   - name: CHILD_VAR
-    value: "value from child"
+    default: "default from child"
 components:
   - name: component-to-test-vars
+    required: true
+  - name: other-component-to-test-vars
     required: true

--- a/src/internal/packager2/layout/testdata/import/variables/secondImport/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/secondImport/zarf.yaml
@@ -1,0 +1,18 @@
+kind: ZarfPackageConfig
+metadata:
+  name: child-package
+constants:
+  - name: PARENT_CONSTANT
+    value: "value from child in component imported later"
+  - name: CHILD_CONSTANT
+    value: "value from child in component imported later"
+variables:
+  - name: PARENT_VAR
+    default: "default from child"
+  - name: CHILD_VAR
+    default: "default from child in component imported later"
+  - name: SECONDARY_CHILD_VAR
+    default: "default from child in component imported later"
+components:
+  - name: component-from-different-package
+    required: true

--- a/src/internal/packager2/layout/testdata/import/variables/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/zarf.yaml
@@ -1,15 +1,18 @@
 kind: ZarfPackageConfig
 metadata:
   name: parent-package
-
 constants:
   - name: PARENT_CONSTANT
     value: "value from parent"
 variables:
   - name: PARENT_VAR
-    value: "value from parent"
+    default: "default from parent"
 components:
   - name: component-to-test-vars
+    required: true
+    import:
+      path: import
+  - name: other-component-to-test-vars
     required: true
     import:
       path: import

--- a/src/internal/packager2/layout/testdata/import/variables/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/import/variables/zarf.yaml
@@ -8,11 +8,16 @@ variables:
   - name: PARENT_VAR
     default: "default from parent"
 components:
-  - name: component-to-test-vars
+  - name: first-imported-component
     required: true
     import:
       path: import
-  - name: other-component-to-test-vars
+  - name: same-package-imported-again
     required: true
     import:
       path: import
+
+  - name: component-from-different-package
+    required: true
+    import:
+      path: secondImport


### PR DESCRIPTION
## Description

There is a bug in compose that causes duplicates variables to appear. `slices.CompatFunc` was used to de-duplicate variables, however since it only compares consecutive elements there were a lot of opportunities for misses. 

## Related Issue

Fixes #3707

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
