### PR TITLE
fix: stop warning users when flavors are not used

### DIFF
--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -310,7 +310,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 		"setVariables", setVariables,
 	)
 
-	if !packageUsesFlavor(pkg, flavor) {
+	if flavor != "" && !packageUsesFlavor(pkg, flavor) {
 		l.Warn("flavor not used in package", "flavor", flavor)
 	}
 	if err := lint.ValidatePackage(pkg); err != nil {
@@ -339,9 +339,6 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 }
 
 func packageUsesFlavor(pkg v1alpha1.ZarfPackage, flavor string) bool {
-	if flavor == "" {
-		return false
-	}
 	for _, comp := range pkg.Components {
 		if comp.Only.Flavor == flavor {
 			return true

--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -310,7 +310,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 		"setVariables", setVariables,
 	)
 
-	if flavor != "" && !packageHasFlavor(pkg, flavor) {
+	if hasFlavoredComponent(pkg, flavor) {
 		l.Warn("flavor not used in package", "flavor", flavor)
 	}
 	if err := lint.ValidatePackage(pkg); err != nil {
@@ -338,7 +338,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 	return nil
 }
 
-func packageHasFlavor(pkg v1alpha1.ZarfPackage, flavor string) bool {
+func hasFlavoredComponent(pkg v1alpha1.ZarfPackage, flavor string) bool {
 	for _, comp := range pkg.Components {
 		if comp.Only.Flavor == flavor {
 			return true

--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -310,7 +310,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 		"setVariables", setVariables,
 	)
 
-	if flavor != "" && !packageUsesFlavor(pkg, flavor) {
+	if flavor != "" && !packageHasFlavor(pkg, flavor) {
 		l.Warn("flavor not used in package", "flavor", flavor)
 	}
 	if err := lint.ValidatePackage(pkg); err != nil {
@@ -338,7 +338,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 	return nil
 }
 
-func packageUsesFlavor(pkg v1alpha1.ZarfPackage, flavor string) bool {
+func packageHasFlavor(pkg v1alpha1.ZarfPackage, flavor string) bool {
 	for _, comp := range pkg.Components {
 		if comp.Only.Flavor == flavor {
 			return true

--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -310,7 +310,7 @@ func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string,
 		"setVariables", setVariables,
 	)
 
-	if hasFlavoredComponent(pkg, flavor) {
+	if !hasFlavoredComponent(pkg, flavor) {
 		l.Warn("flavor not used in package", "flavor", flavor)
 	}
 	if err := lint.ValidatePackage(pkg); err != nil {

--- a/src/internal/packager2/layout/create_test.go
+++ b/src/internal/packager2/layout/create_test.go
@@ -274,6 +274,23 @@ func TestPackageUsesFlavor(t *testing.T) {
 		expected bool
 	}{
 		{
+			name: "when flavor is not set",
+			pkg: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: "do-nothing",
+					},
+					{
+						Name: "do-nothing-flavored",
+						Only: v1alpha1.ZarfComponentOnlyTarget{
+							Flavor: "cashew",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "when flavor is not used",
 			pkg: v1alpha1.ZarfPackage{
 				Components: []v1alpha1.ZarfComponent{
@@ -305,7 +322,7 @@ func TestPackageUsesFlavor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.expected, packageHasFlavor(tt.pkg, tt.flavor))
+			require.Equal(t, tt.expected, hasFlavoredComponent(tt.pkg, tt.flavor))
 		})
 	}
 }

--- a/src/internal/packager2/layout/create_test.go
+++ b/src/internal/packager2/layout/create_test.go
@@ -274,17 +274,6 @@ func TestPackageUsesFlavor(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "when flavor is not set",
-			pkg: v1alpha1.ZarfPackage{
-				Components: []v1alpha1.ZarfComponent{
-					{
-						Name: "do-nothing",
-					},
-				},
-			},
-			expected: false,
-		},
-		{
 			name: "when flavor is not used",
 			pkg: v1alpha1.ZarfPackage{
 				Components: []v1alpha1.ZarfComponent{
@@ -315,7 +304,8 @@ func TestPackageUsesFlavor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, packageUsesFlavor(tt.pkg, tt.flavor))
+			t.Parallel()
+			require.Equal(t, tt.expected, packageHasFlavor(tt.pkg, tt.flavor))
 		})
 	}
 }


### PR DESCRIPTION
## Description

In #3683 I implemented flavors with a warning if a flavor is not used. However there was a mistake in the logic so it warns even when flavor aren't used

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
