### PR TITLE
docs: remove old reference to `go-containertools`

### DIFF
--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -41,7 +41,7 @@ Collection of additional tools to make airgap easier
 * [zarf tools helm](/commands/zarf_tools_helm/)	 - Subset of the Helm CLI included with Zarf to help manage helm charts.
 * [zarf tools kubectl](/commands/zarf_tools_kubectl/)	 - Kubectl command. See https://kubernetes.io/docs/reference/kubectl/overview/ for more information.
 * [zarf tools monitor](/commands/zarf_tools_monitor/)	 - Launches a terminal UI to monitor the connected cluster using K9s.
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 * [zarf tools sbom](/commands/zarf_tools_sbom/)	 - Generates a Software Bill of Materials (SBOM) for the given package
 * [zarf tools update-creds](/commands/zarf_tools_update-creds/)	 - Updates the credentials for deployed Zarf services. Pass a service key to update credentials for a single service
 * [zarf tools wait-for](/commands/zarf_tools_wait-for/)	 - Waits for a given Kubernetes resource to be ready

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -8,7 +8,7 @@ tableOfContents: false
 
 ## zarf tools registry
 
-Tools for working with container registries using go-containertools
+Tools for working with container registries using oras
 
 ### Options
 

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -46,5 +46,5 @@ $ zarf tools registry catalog reg.example.com
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -36,5 +36,5 @@ zarf tools registry copy SRC DST [flags]
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -45,5 +45,5 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -47,5 +47,5 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -36,5 +36,5 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -47,5 +47,5 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -34,5 +34,5 @@ zarf tools registry prune [flags]
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -48,5 +48,5 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -51,5 +51,5 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -40,5 +40,5 @@ zarf tools registry version [flags]
 
 ### SEE ALSO
 
-* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using go-containertools
+* [zarf tools registry](/commands/zarf_tools_registry/)	 - Tools for working with container registries using oras
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -362,7 +362,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton`
 	CmdToolsArchiverCompressShort   = "Compresses a collection of sources based off of the destination file extension."
 	CmdToolsArchiverDecompressShort = "Decompresses an archive or Zarf package based off of the source file extension."
 
-	CmdToolsRegistryShort     = "Tools for working with container registries using go-containertools"
+	CmdToolsRegistryShort     = "Tools for working with container registries using oras"
 	CmdToolsRegistryZarfState = "Retrieving registry information from Zarf state"
 	CmdToolsRegistryTunnel    = "Opening a tunnel from %s locally to %s in the cluster"
 


### PR DESCRIPTION
## Description

Remove reference to `go-containertools`.

## Related Issue

Relates to #3434

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
