### PR TITLE
feat: use websockets for port forwards

### DIFF
--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -16,10 +16,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -456,12 +458,10 @@ func (tunnel *Tunnel) establish(ctx context.Context) (string, error) {
 
 	l.Debug("using URL to create portforward", "url", portForwardCreateURL)
 
-	// Construct the spdy client required by the client-go portforward library.
-	transport, upgrader, err := spdy.RoundTripperFor(tunnel.restConfig)
+	dialer, err := createDialer("POST", portForwardCreateURL, tunnel.restConfig)
 	if err != nil {
-		return "", fmt.Errorf("unable to create the spdy client %w", err)
+		return "", fmt.Errorf("unable to create the dialer %w", err)
 	}
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", portForwardCreateURL)
 
 	// Construct a new PortForwarder struct that manages the instructed port forward tunnel.
 	ports := []string{fmt.Sprintf("%d:%d", localPort, tunnel.remotePort)}
@@ -529,4 +529,24 @@ func (tunnel *Tunnel) getAttachablePodForService(ctx context.Context) (string, e
 		return "", fmt.Errorf("no pods found for service %s", tunnel.resourceName)
 	}
 	return podList.Items[0].Name, nil
+}
+
+// taken from https://github.com/kubernetes/kubernetes/blob/680ea07dbb2c6050d13b93660fa4d27d2d28d6eb/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go#L139-L156
+func createDialer(method string, url *url.URL, config *rest.Config) (httpstream.Dialer, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
+	if !cmdutil.PortForwardWebsockets.IsDisabled() {
+		tunnelingDialer, err := portforward.NewSPDYOverWebsocketDialer(url, config)
+		if err != nil {
+			return nil, err
+		}
+		// First attempt tunneling (websocket) dialer, then fallback to spdy dialer.
+		dialer = portforward.NewFallbackDialer(tunnelingDialer, dialer, func(err error) bool {
+			return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+		})
+	}
+	return dialer, nil
 }


### PR DESCRIPTION
## Description

This updates the tunnel package to use the Kubernetes portforward websocket feature. This should resolve long standing issues in the community that makes Zarf incompatible with tools like aws ssm as the current port forward method does not work well with proxies or gateways. 

## Related Issue

Fixes #3715

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
