### PR TITLE
feat: add retries to image push

### DIFF
--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -96,8 +96,8 @@ func Push(ctx context.Context, cfg PushConfig) error {
 		return copyImage(ctx, src, remoteRepo, srcName, dstName, cfg.OCIConcurrency, defaultPlatform)
 	}
 
-	err = retry.Do(func() error {
-		for _, img := range cfg.ImageList {
+	for _, img := range cfg.ImageList {
+		err = retry.Do(func() error {
 			l.Info("pushing image", "name", img.Reference)
 			// If this is not a no checksum image push it for use with the Zarf agent
 			if !cfg.NoChecksum {
@@ -122,11 +122,10 @@ func Push(ctx context.Context, cfg PushConfig) error {
 				return err
 			}
 			return nil
+		}, retry.Context(ctx), retry.Attempts(uint(cfg.Retries)), retry.Delay(500*time.Millisecond))
+		if err != nil {
+			return err
 		}
-		return nil
-	}, retry.Context(ctx), retry.Attempts(uint(cfg.Retries)), retry.Delay(500*time.Millisecond))
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -104,6 +104,7 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			return copyImage(ctx, src, remoteRepo, srcName, dstName, cfg.OCIConcurrency, defaultPlatform)
 		}
 		pushed := []string{}
+		// Delete the images that were already successfully pushed so that they aren't attempted on the next retry
 		defer func() {
 			for _, refInfo := range pushed {
 				delete(toPush, refInfo)

--- a/src/internal/packager2/mirror.go
+++ b/src/internal/packager2/mirror.go
@@ -39,7 +39,7 @@ type MirrorOptions struct {
 
 // Mirror mirrors the package contents to the given registry and git server.
 func Mirror(ctx context.Context, opt MirrorOptions) error {
-	err := pushImagesToRegistry(ctx, opt.PkgLayout, opt.RegistryInfo, opt.NoImageChecksum, opt.PlainHTTP, opt.OCIConcurrency)
+	err := pushImagesToRegistry(ctx, opt.PkgLayout, opt.RegistryInfo, opt.NoImageChecksum, opt.PlainHTTP, opt.OCIConcurrency, opt.Retries)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func Mirror(ctx context.Context, opt MirrorOptions) error {
 	return nil
 }
 
-func pushImagesToRegistry(ctx context.Context, pkgLayout *layout.PackageLayout, registryInfo types.RegistryInfo, noImgChecksum bool, plainHTTP bool, concurrency int) error {
+func pushImagesToRegistry(ctx context.Context, pkgLayout *layout.PackageLayout, registryInfo types.RegistryInfo, noImgChecksum bool, plainHTTP bool, concurrency int, retries int) error {
 	refs := []transform.Image{}
 	for _, component := range pkgLayout.Pkg.Components {
 		for _, img := range component.Images {
@@ -72,6 +72,7 @@ func pushImagesToRegistry(ctx context.Context, pkgLayout *layout.PackageLayout, 
 		PlainHTTP:       plainHTTP,
 		NoChecksum:      noImgChecksum,
 		Arch:            pkgLayout.Pkg.Build.Architecture,
+		Retries:         retries,
 	}
 	err := images.Push(ctx, pushConfig)
 	if err != nil {


### PR DESCRIPTION
## Description

In #3559 we moved from Crane to ORAS. As part of that move, the retry logic was removed on image push.  ORAS does have builtin retries but these do not account for failures on the port-forward. For example, an HPA may spin down the Zarf registry and break, these situations can only be saved by retrying and creating another tunnel. By adding back in retries at the Zarf level, we can account for these situations. 

To manually test a pod failure, I restarted the Zarf registry mid push. I verified that I got a failure doing this on current Zarf, and verified that this will recover when trying with the change in this PR
![image](https://github.com/user-attachments/assets/e413b142-c178-428c-ba68-d23e299d65a3)


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
