### PR TITLE
feat: disable crc32 hashing on helm charts for resource `ocirepo`

### DIFF
--- a/src/internal/agent/hooks/flux-ocirepo_test.go
+++ b/src/internal/agent/hooks/flux-ocirepo_test.go
@@ -119,6 +119,44 @@ func TestFluxOCIMutationWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "mute helm chart, but don't include crc32 hash",
+			admissionReq: createFluxOCIRepoAdmissionRequest(t, v1.Update, &flux.OCIRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mutate-this",
+				},
+				Spec: flux.OCIRepositorySpec{
+					URL: "oci://ghcr.io/stefanprodan/charts/podinfo",
+					LayerSelector: &flux.OCILayerSelector{
+						MediaType: "application/vnd.cncf.helm.config.v1+json",
+					},
+					Reference: &flux.OCIRepositoryRef{
+						Tag: "6.4.0",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/url",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.AddPatchOperation(
+					"/spec/secretRef",
+					fluxmeta.LocalObjectReference{Name: config.ZarfImagePullSecretName},
+				),
+				operations.ReplacePatchOperation(
+					"/spec/ref/tag",
+					"6.4.0",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "should be mutated with internal service registry",
 			admissionReq: createFluxOCIRepoAdmissionRequest(t, v1.Create, &flux.OCIRepository{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

I have brought up using an annotation in #3436 however there was some concern about keeping the agent simple, which makes sense to me. So I'm not sure that is will be any better but I did want see what the maintainers and community thought about checking the `MediaType` of the `LayerSelector` (if present) and not preforming the hashing if it is a known helm type.

### Additional comments

When I brought this up during a community meeting earlier in the year, we thought it might be a possible idea to query the internal registry and look at the media-type in there; I think that it might be a bit more reliable to check against the available meta-data versus making a network call and holding up the admission process

## Related Issue

Relates to #3435

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
