### PR TITLE
fix(images): support for insecure skip tls verify on image push/pull

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -337,14 +337,15 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	}()
 
 	mirrorOpt := packager2.MirrorOptions{
-		Cluster:         c,
-		PkgLayout:       pkgLayout,
-		RegistryInfo:    pkgConfig.InitOpts.RegistryInfo,
-		GitInfo:         pkgConfig.InitOpts.GitServer,
-		NoImageChecksum: pkgConfig.MirrorOpts.NoImgChecksum,
-		Retries:         pkgConfig.PkgOpts.Retries,
-		OCIConcurrency:  config.CommonOptions.OCIConcurrency,
-		PlainHTTP:       config.CommonOptions.PlainHTTP,
+		Cluster:               c,
+		PkgLayout:             pkgLayout,
+		RegistryInfo:          pkgConfig.InitOpts.RegistryInfo,
+		GitInfo:               pkgConfig.InitOpts.GitServer,
+		NoImageChecksum:       pkgConfig.MirrorOpts.NoImgChecksum,
+		Retries:               pkgConfig.PkgOpts.Retries,
+		OCIConcurrency:        config.CommonOptions.OCIConcurrency,
+		PlainHTTP:             config.CommonOptions.PlainHTTP,
+		InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 	}
 	err = packager2.Mirror(ctx, mirrorOpt)
 	if err != nil {

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -27,25 +27,27 @@ import (
 
 // PullConfig is the configuration for pulling images.
 type PullConfig struct {
-	OCIConcurrency       int
-	DestinationDirectory string
-	ImageList            []transform.Image
-	Arch                 string
-	RegistryOverrides    map[string]string
-	CacheDirectory       string
-	PlainHTTP            bool
+	OCIConcurrency        int
+	DestinationDirectory  string
+	ImageList             []transform.Image
+	Arch                  string
+	RegistryOverrides     map[string]string
+	CacheDirectory        string
+	PlainHTTP             bool
+	InsecureSkipTLSVerify bool
 }
 
 // PushConfig is the configuration for pushing images.
 type PushConfig struct {
-	OCIConcurrency  int
-	SourceDirectory string
-	ImageList       []transform.Image
-	RegistryInfo    types.RegistryInfo
-	NoChecksum      bool
-	Arch            string
-	Retries         int
-	PlainHTTP       bool
+	OCIConcurrency        int
+	SourceDirectory       string
+	ImageList             []transform.Image
+	RegistryInfo          types.RegistryInfo
+	NoChecksum            bool
+	Arch                  string
+	Retries               int
+	PlainHTTP             bool
+	InsecureSkipTLSVerify bool
 }
 
 const (

--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -140,13 +140,14 @@ func CreatePackage(ctx context.Context, packagePath string, opt CreateOptions) (
 			return nil, err
 		}
 		pullCfg := images.PullConfig{
-			OCIConcurrency:       opt.OCIConcurrency,
-			DestinationDirectory: filepath.Join(buildPath, ImagesDir),
-			ImageList:            componentImages,
-			Arch:                 pkg.Metadata.Architecture,
-			RegistryOverrides:    opt.RegistryOverrides,
-			CacheDirectory:       filepath.Join(cachePath, ImagesDir),
-			PlainHTTP:            config.CommonOptions.PlainHTTP,
+			OCIConcurrency:        opt.OCIConcurrency,
+			DestinationDirectory:  filepath.Join(buildPath, ImagesDir),
+			ImageList:             componentImages,
+			Arch:                  pkg.Metadata.Architecture,
+			RegistryOverrides:     opt.RegistryOverrides,
+			CacheDirectory:        filepath.Join(cachePath, ImagesDir),
+			PlainHTTP:             config.CommonOptions.PlainHTTP,
+			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 		}
 		manifests, err := images.Pull(ctx, pullCfg)
 		if err != nil {

--- a/src/pkg/packager/creator/normal.go
+++ b/src/pkg/packager/creator/normal.go
@@ -186,13 +186,14 @@ func (pc *PackageCreator) Assemble(ctx context.Context, dst *layout.PackagePaths
 			return err
 		}
 		pullCfg := images.PullConfig{
-			OCIConcurrency:       config.CommonOptions.OCIConcurrency,
-			DestinationDirectory: dst.Images.Base,
-			ImageList:            imageList,
-			Arch:                 arch,
-			RegistryOverrides:    pc.createOpts.RegistryOverrides,
-			CacheDirectory:       filepath.Join(cachePath, layout.ImagesDir),
-			PlainHTTP:            config.CommonOptions.PlainHTTP,
+			OCIConcurrency:        config.CommonOptions.OCIConcurrency,
+			DestinationDirectory:  dst.Images.Base,
+			ImageList:             imageList,
+			Arch:                  arch,
+			RegistryOverrides:     pc.createOpts.RegistryOverrides,
+			CacheDirectory:        filepath.Join(cachePath, layout.ImagesDir),
+			PlainHTTP:             config.CommonOptions.PlainHTTP,
+			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 		}
 
 		_, err = images.Pull(ctx, pullCfg)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -536,14 +536,15 @@ func (p *Packager) pushImagesToRegistry(ctx context.Context, componentImages []s
 	}
 
 	pushCfg := images.PushConfig{
-		OCIConcurrency:  config.CommonOptions.OCIConcurrency,
-		SourceDirectory: p.layout.Images.Base,
-		ImageList:       imageList,
-		RegistryInfo:    p.state.RegistryInfo,
-		NoChecksum:      noImgChecksum,
-		Arch:            p.cfg.Pkg.Build.Architecture,
-		Retries:         p.cfg.PkgOpts.Retries,
-		PlainHTTP:       config.CommonOptions.PlainHTTP,
+		OCIConcurrency:        config.CommonOptions.OCIConcurrency,
+		SourceDirectory:       p.layout.Images.Base,
+		ImageList:             imageList,
+		RegistryInfo:          p.state.RegistryInfo,
+		NoChecksum:            noImgChecksum,
+		Arch:                  p.cfg.Pkg.Build.Architecture,
+		Retries:               p.cfg.PkgOpts.Retries,
+		PlainHTTP:             config.CommonOptions.PlainHTTP,
+		InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 	}
 
 	return images.Push(ctx, pushCfg)


### PR DESCRIPTION
## Description

Fix support for images.Pull/Push honoring the `--insecure-skip-tls-verify` flag. 

## Related Issue

Fixes #3724
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
