### PR TITLE
test: improve archive test

### DIFF
--- a/src/test/common.go
+++ b/src/test/common.go
@@ -5,21 +5,18 @@
 package test
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 
 	"slices"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory" // used for docker test registry
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -116,10 +113,14 @@ func (e2e *ZarfE2ETest) Zarf(t *testing.T, args ...string) (_ string, _ string, 
 
 // ZarfInDir executes a Zarf command in specific directory.
 func (e2e *ZarfE2ETest) ZarfInDir(t *testing.T, dir string, args ...string) (_ string, _ string, err error) {
-	if !slices.Contains(args, "tools") {
+	isToolCall := slices.Contains(args, "tools")
+	isCI := os.Getenv("CI") == "true"
+	isWindows := runtime.GOOS == "windows"
+
+	if !isToolCall {
 		args = append(args, "--log-format=console", "--no-color")
 	}
-	if !slices.Contains(args, "--tmpdir") && !slices.Contains(args, "tools") {
+	if !slices.Contains(args, "--tmpdir") && !isToolCall {
 		tmpdir, err := os.MkdirTemp("", "zarf-")
 		if err != nil {
 			return "", "", err
@@ -130,7 +131,7 @@ func (e2e *ZarfE2ETest) ZarfInDir(t *testing.T, dir string, args ...string) (_ s
 		}(tmpdir)
 		args = append(args, "--tmpdir", tmpdir)
 	}
-	if !slices.Contains(args, "--zarf-cache") && !slices.Contains(args, "tools") && os.Getenv("CI") == "true" && runtime.GOOS == "windows" {
+	if !slices.Contains(args, "--zarf-cache") && !isToolCall && isCI && isWindows {
 		// We make the cache dir relative to the working directory to make it work on the Windows Runners
 		// - they use two drives which filepath.Rel cannot cope with.
 		cwd, err := os.Getwd()
@@ -154,9 +155,7 @@ func (e2e *ZarfE2ETest) ZarfInDir(t *testing.T, dir string, args ...string) (_ s
 
 // Kubectl executes `zarf tools kubectl ...`
 func (e2e *ZarfE2ETest) Kubectl(t *testing.T, args ...string) (string, string, error) {
-	tk := []string{"tools", "kubectl"}
-	args = append(tk, args...)
-	return e2e.Zarf(t, args...)
+	return e2e.Zarf(t, append([]string{"tools", "kubectl"}, args...)...)
 }
 
 // CleanFiles removes files and directories that have been created during the test.
@@ -180,32 +179,7 @@ func (e2e *ZarfE2ETest) GetMismatchedArch() string {
 
 // GetZarfVersion returns the current build/zarf version
 func (e2e *ZarfE2ETest) GetZarfVersion(t *testing.T) string {
-	// Get the version of the CLI
 	stdOut, stdErr, err := e2e.Zarf(t, "version")
 	require.NoError(t, err, stdOut, stdErr)
 	return strings.Trim(stdOut, "\n")
-}
-
-// NormalizeYAMLFilenames normalizes YAML filenames / paths across Operating Systems (i.e Windows vs Linux)
-func (e2e *ZarfE2ETest) NormalizeYAMLFilenames(input string) string {
-	if runtime.GOOS != "windows" {
-		return input
-	}
-
-	// Match YAML lines that have files in them https://regex101.com/r/C78kRD/1
-	fileMatcher := regexp.MustCompile(`^(?P<start>.* )(?P<file>[^:\n]+\/.*)$`)
-	scanner := bufio.NewScanner(strings.NewReader(input))
-
-	output := ""
-	for scanner.Scan() {
-		line := scanner.Text()
-		get, err := helpers.MatchRegex(fileMatcher, line)
-		if err != nil {
-			output += line + "\n"
-			continue
-		}
-		output += fmt.Sprintf("%s\"%s\"\n", get("start"), strings.ReplaceAll(get("file"), "/", "\\\\"))
-	}
-
-	return output
 }

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -133,11 +133,11 @@ func TestUseCLI(t *testing.T) {
 	t.Run("zarf package to test archive path", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir, "--confirm")
-		require.NoError(t, err, stdOut, stdErr)
+		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir, "--confirm")
+		require.NoError(t, err)
 
 		path := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-archive-path-%s.tar.zst", e2e.Arch))
-		stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
+		_, _, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
 		require.NoError(t, err)
 
 		require.FileExists(t, "src/test/e2e/packages/00-archive-path/output.txt")

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -140,9 +140,13 @@ func TestUseCLI(t *testing.T) {
 		_, _, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
 		require.NoError(t, err)
 
-		require.FileExists(t, "src/test/e2e/packages/00-archive-path/output.txt")
+		require.FileExists(t, "src/test/packages/00-archive-path/output.txt")
 
-		e2e.CleanFiles(t, "src/test/e2e/packages/00-archive-path/output.txt")
+		b, err := os.ReadFile("src/test/packages/00-archive-path/output.txt")
+		require.NoError(t, err)
+		require.Equal(t, "Hello World!\n", string(b))
+
+		e2e.CleanFiles(t, "src/test/packages/00-archive-path/output.txt")
 	})
 
 	t.Run("zarf package create with tmpdir and cache", func(t *testing.T) {

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -130,19 +130,19 @@ func TestUseCLI(t *testing.T) {
 		require.Contains(t, stdErr, expectedOutString, "The log level should be changed to 'debug'")
 	})
 
-	t.Run("zarf package to test archive path", func(t *testing.T) {
+	t.Run("zarf package to test extract path", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir, "--flavor", runtime.GOOS, "--confirm")
+		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-extract-path", "-o", tmpDir, "--flavor", runtime.GOOS, "--confirm")
 		require.NoError(t, err)
 
-		path := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-archive-path-%s.tar.zst", e2e.Arch))
+		path := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-extract-path-%s.tar.zst", e2e.Arch))
 		_, _, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
 		require.NoError(t, err)
 
-		require.FileExists(t, "src/test/packages/00-archive-path/output.txt")
+		require.FileExists(t, "src/test/packages/00-extract-path/output.txt")
 
-		e2e.CleanFiles(t, "src/test/packages/00-archive-path/output.txt")
+		e2e.CleanFiles(t, "src/test/packages/00-extract-path/output.txt")
 	})
 
 	t.Run("zarf package create with tmpdir and cache", func(t *testing.T) {

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -133,7 +133,7 @@ func TestUseCLI(t *testing.T) {
 	t.Run("zarf package to test archive path", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir,"--flavor", runtime.GOOS,  "--confirm")
+		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir, "--flavor", runtime.GOOS, "--confirm")
 		require.NoError(t, err)
 
 		path := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-archive-path-%s.tar.zst", e2e.Arch))
@@ -141,10 +141,6 @@ func TestUseCLI(t *testing.T) {
 		require.NoError(t, err)
 
 		require.FileExists(t, "src/test/packages/00-archive-path/output.txt")
-
-		b, err := os.ReadFile("src/test/packages/00-archive-path/output.txt")
-		require.NoError(t, err)
-		require.Equal(t, "Hello World!\n", string(b))
 
 		e2e.CleanFiles(t, "src/test/packages/00-archive-path/output.txt")
 	})

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -133,7 +133,7 @@ func TestUseCLI(t *testing.T) {
 	t.Run("zarf package to test archive path", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir, "--confirm")
+		_, _, err := e2e.Zarf(t, "package", "create", "src/test/packages/00-archive-path", "-o", tmpDir,"--flavor", runtime.GOOS,  "--confirm")
 		require.NoError(t, err)
 
 		path := filepath.Join(tmpDir, fmt.Sprintf("zarf-package-archive-path-%s.tar.zst", e2e.Arch))

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -4,7 +4,6 @@ metadata:
   name: archive-path
 
 x-untar: &base-untar
-  name: untar
   required: true
   files:
     - source: archive.tar
@@ -27,14 +26,14 @@ x-untar: &base-untar
           mute: true
 
 components:
-  - only:
+  - name: untar-linux
+    only:
       localOS: linux
     <<: *base-untar
-    name: untar-linux
-  - only:
+  - name: untar-darwin
+    only:
       localOS: darwin
     <<: *base-untar
-    name: untar-darwin
   - name: untar-windows
     required: true
     only:

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -30,10 +30,12 @@ components:
   - only:
       localOS: linux
     <<: *base-untar
+    name: untar-linux
   - only:
       localOS: darwin
     <<: *base-untar
-  - name: untar
+    name: untar-darwin
+  - name: untar-windows
     required: true
     only:
       localOS: windows

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -26,18 +26,18 @@ x-untar: &base-untar
           mute: true
 
 components:
-  - name: untar-linux
+  - name: untar
     only:
-      localOS: linux
+      flavor: linux
     <<: *base-untar
-  - name: untar-darwin
+  - name: darwin
     only:
-      localOS: darwin
+      flavor: darwin
     <<: *base-untar
   - name: untar-windows
     required: true
     only:
-      localOS: windows
+      flavor: windows
     files:
       - source: archive.tar
         target: src/test/packages/00-archive-path/output.txt

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -2,11 +2,41 @@
 kind: ZarfPackageConfig
 metadata:
   name: archive-path
-  description: Deploy a EKS K8s cluster
+
+x-untar: &base-untar
+  name: untar
+  required: true
+  files:
+    - source: archive.tar
+      target: src/test/packages/00-archive-path/output.txt
+      shasum: 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
+      extractPath: archive/content/data.txt
+  actions:
+    onCreate:
+      before:
+        - cmd: mkdir -p archive/content
+          mute: true
+        - cmd: echo "Hello World!" > archive/content/data.txt
+          mute: true
+        - cmd: tar -cf archive.tar archive
+          mute: true
+      onFailure:
+        - cmd: rm -f archive/content/* archive.tar
+      after:
+        - cmd: rm -f archive/content/* archive.tar && rmdir archive/content && rmdir archive
+          mute: true
 
 components:
+  - only:
+      localOS: linux
+    <<: *base-untar
+  - only:
+      localOS: darwin
+    <<: *base-untar
   - name: untar
     required: true
+    only:
+      localOS: windows
     files:
       - source: archive.tar
         target: src/test/packages/00-archive-path/output.txt
@@ -15,14 +45,14 @@ components:
     actions:
       onCreate:
         before:
-          - cmd: mkdir -p archive/content
+          - cmd: mkdir -Force -Path archive/content
             mute: true
-          - cmd: echo "Hello World!" > archive/content/data.txt
+          - cmd: echo "Hello World!" | Out-File -FilePath "archive/content/data.txt" -Encoding UTF8
             mute: true
           - cmd: tar -cf archive.tar archive
             mute: true
         onFailure:
-          - cmd: rm -f archive/content/* archive.tar
+          - cmd: Remove-Item -Path "archive/content/*", "archive.tar" -Force -ErrorAction SilentlyContinue
         after:
-          - cmd: rm -f archive/content/* archive.tar && rmdir archive/content && rmdir archive
+          - cmd: Remove-Item -Path "archive/content/*", "archive.tar" -Force -ErrorAction SilentlyContinue
             mute: true

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -9,7 +9,7 @@ components:
     required: true
     files:
       - source: archive.tar
-        target: src/test/e2e/packages/00-archive-path/output.txt
+        target: src/test/packages/00-archive-path/output.txt
         shasum: 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
         extractPath: archive/content/data.txt
     actions:

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -30,18 +30,18 @@ components:
     only:
       flavor: linux
     <<: *base-untar
-  - name: darwin
+  - name: untar
     only:
       flavor: darwin
     <<: *base-untar
-  - name: untar-windows
+  - name: untar
     required: true
     only:
       flavor: windows
     files:
       - source: archive.tar
         target: src/test/packages/00-archive-path/output.txt
-        shasum: 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
+        shasum: 6ba6c3d1a3636d168baaa59a25b503a6160d9987f492cae4b279c8e77dc913f3
         extractPath: archive/content/data.txt
     actions:
       onCreate:

--- a/src/test/packages/00-archive-path/zarf.yaml
+++ b/src/test/packages/00-archive-path/zarf.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=../../../../zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: archive-path
+  description: Deploy a EKS K8s cluster
+
+components:
+  - name: untar
+    required: true
+    files:
+      - source: archive.tar
+        target: src/test/e2e/packages/00-archive-path/output.txt
+        shasum: 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
+        extractPath: archive/content/data.txt
+    actions:
+      onCreate:
+        before:
+          - cmd: mkdir -p archive/content
+            mute: true
+          - cmd: echo "Hello World!" > archive/content/data.txt
+            mute: true
+          - cmd: tar -cf archive.tar archive
+            mute: true
+        onFailure:
+          - cmd: rm -f archive/content/* archive.tar
+        after:
+          - cmd: rm -f archive/content/* archive.tar && rmdir archive/content && rmdir archive
+            mute: true

--- a/src/test/packages/00-extract-path/zarf.yaml
+++ b/src/test/packages/00-extract-path/zarf.yaml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=../../../../zarf.schema.json
 kind: ZarfPackageConfig
 metadata:
-  name: archive-path
+  name: extract-path
 
 x-untar: &base-untar
   required: true
   files:
     - source: archive.tar
-      target: src/test/packages/00-archive-path/output.txt
+      target: src/test/packages/00-extract-path/output.txt
       shasum: 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
       extractPath: archive/content/data.txt
   actions:
@@ -40,7 +40,7 @@ components:
       flavor: windows
     files:
       - source: archive.tar
-        target: src/test/packages/00-archive-path/output.txt
+        target: src/test/packages/00-extract-path/output.txt
         shasum: 6ba6c3d1a3636d168baaa59a25b503a6160d9987f492cae4b279c8e77dc913f3
         extractPath: archive/content/data.txt
     actions:


### PR DESCRIPTION
## Description

Cuts down `TestUseCLI/zarf_package_to_test_archive_path` from 60s to 3s by not using the eks distro package (100Mb) as the test package. Instead a test package is created with similarly structured data. The eks distro package is still built and deployed in nightly.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
