### PR TITLE
test: avoid dockerhub flake in agent ignore test

### DIFF
--- a/src/test/packages/26-agent-ignore/manifests/deployment.yaml
+++ b/src/test/packages/26-agent-ignore/manifests/deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: httpd-deployment
+  name: podinfo-deployment
 spec:
   selector:
     matchLabels:
-      app: httpd
+      app: podinfo
   replicas: 2 # tells deployment to run 2 pods matching the template
   template:
     metadata:
       labels:
-        app: httpd
+        app: podinfo
     spec:
       containers:
-      - name: httpd
+      - name: podinfo
         # This is explicitly a different tag than examples/manifests to ensure it has to pull the image from outside the cluster
-        image: "httpd:alpine"
+        image: "ghcr.io/stefanprodan/podinfo:6.2.0"
         ports:
         - containerPort: 80

--- a/src/test/packages/26-agent-ignore/manifests/namespace.yaml
+++ b/src/test/packages/26-agent-ignore/manifests/namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: httpd-ignored
+  name: podinfo-ignored
   labels:
     zarf.dev/agent: ignore

--- a/src/test/packages/26-agent-ignore/zarf.yaml
+++ b/src/test/packages/26-agent-ignore/zarf.yaml
@@ -4,11 +4,11 @@ metadata:
   description: Simple test to check that Zarf respects ignored namespaces.
 
 components:
-  - name: httpd-deployment
+  - name: podinfo-deployment
     required: true
     manifests:
-      - name: agent-ignore-httpd
-        namespace: httpd-ignored
+      - name: agent-ignore-podinfo
+        namespace: podinfo-ignored
         files:
           - manifests/deployment.yaml
           - manifests/namespace.yaml
@@ -18,6 +18,6 @@ components:
           - wait:
               cluster:
                 kind: deployment
-                name: httpd-deployment
-                namespace: httpd-ignored
+                name: podinfo-deployment
+                namespace: podinfo-ignored
                 condition: "{.status.readyReplicas}=2"


### PR DESCRIPTION
## Description

I've frequently noticed a flake happening around our agent ignore test. https://github.com/zarf-dev/zarf/actions/runs/14672162347/job/41181212190. The reason for this flake is that Kuberentes is trying to pull from dockerhub, but is getting rate limited. By switching to ghcr we can avoid the rate limit

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
