### PR TITLE
feat: remove user submitted digest from OCI pull log

### DIFF
--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -63,7 +63,7 @@ func Pull(ctx context.Context, src, dir, shasum, architecture string, filter fil
 	isPartial := false
 	switch u.Scheme {
 	case "oci":
-		l.Info("starting pull from oci source", "src", src, "digest", shasum)
+		l.Info("starting pull from oci source", "src", src)
 		isPartial, tmpPath, err = pullOCI(ctx, src, tmpDir, shasum, architecture, filter)
 		if err != nil {
 			return err

--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -45,7 +45,7 @@ func Pull(ctx context.Context, src, dir, shasum, architecture string, filter fil
 		return err
 	}
 	if u.Scheme == "" {
-		return errors.New("scheme cannot be empty")
+		return errors.New("scheme must be either oci:// or http(s)://")
 	}
 	if u.Host == "" {
 		return errors.New("host cannot be empty")


### PR DESCRIPTION
## Description

Agree with below issue that the empty digest log can be confusing. I could have added to the log with conditionals, but given that the shasum is strictly user input and is more traditionally given on oci objects with the `@sha256:..` format I believe it's simpler to remove. 

For example a user could run
```bash
starting pull from oci source src=oci://ghcr.io/austinabro321/helm-charts:0.0.1@sha256:bce489695b38ac0e6c3660c8fbc8498aee9d2180db9887d62d79fd3c7508e00c digest=
```

They are using a digest in this situation, but since it's on the OCI object it looks like it's empty.

I kept the log on `http(s)` pulls as the digest is required 

## Related Issue

Fixes #3622

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
