### PR TITLE
chore: remove invopop/jsonschema dependency from root go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/golang-cz/devslog v0.0.12
 	github.com/google/go-containerregistry v0.20.3
 	github.com/gosuri/uitable v0.0.4
-	github.com/invopop/jsonschema v0.13.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/phsym/console-slog v0.3.1
@@ -243,7 +242,6 @@ require (
 	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/becheran/wildmatch-go v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
@@ -251,7 +249,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v2 v2.0.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.8.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/buildkite/agent/v3 v3.81.0 // indirect
 	github.com/buildkite/go-pipeline v0.13.1 // indirect
 	github.com/buildkite/interpolate v0.1.3 // indirect
@@ -520,7 +517,6 @@ require (
 	github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651 // indirect
 	github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b // indirect
 	github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/go-gitlab v0.109.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,6 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8/go.mod h1:2JF49jcDOrLStIXN/j/K1EKRq8a8R2qRnlZA6/o/c7c=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -527,8 +525,6 @@ github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdb
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v1.0.5-0.20150529004307-13fd6b8acda0 h1:s7+5BfS4WFJoVF9pnB8kBk03S7pZXRdKamnV0FOl5Sc=
 github.com/bugsnag/bugsnag-go v1.0.5-0.20150529004307-13fd6b8acda0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
@@ -1171,8 +1167,6 @@ github.com/in-toto/in-toto-golang v0.9.0/go.mod h1:xsBVrVsHNsB61++S6Dy2vWosKhuA3
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.6.5 h1:9PgMJOVBedpgYLI56jQRJYqngxYAAzfEUua+3NgSqAo=
@@ -1763,8 +1757,6 @@ github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b h1:uWNQ0khA
 github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b/go.mod h1:ewlIKbKV8l+jCj8rkdXIs361ocR5x3qGyoCSca47Gx8=
 github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 h1:0KGbf+0SMg+UFy4e1A/CPVvXn21f1qtWdeJwxZFoQG8=
 github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/go-gitlab v0.109.0 h1:RcRme5w8VpLXTSTTMZdVoQWY37qTJWg+gwdQl4aAttE=

--- a/hack/schema/create-zarf-schema.sh
+++ b/hack/schema/create-zarf-schema.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+cd $SCRIPT_DIR
+
 add_yaml_extensions() {
   local src=$1
   local dst=$2
@@ -21,8 +23,8 @@ add_yaml_extensions() {
   ' "$src" > "$dst"
 }
 
-go run "$SCRIPT_DIR/main.go" > "zarf_package_v1alpha1.schema.json"
+go run main.go > "zarf_package_v1alpha1.schema.json"
 
-add_yaml_extensions "zarf_package_v1alpha1.schema.json" "$SCRIPT_DIR/../../zarf.schema.json"
+add_yaml_extensions "zarf_package_v1alpha1.schema.json" "../../zarf.schema.json"
 
 rm zarf_package_v1alpha1.schema.json

--- a/hack/schema/go.mod
+++ b/hack/schema/go.mod
@@ -6,7 +6,7 @@ replace github.com/zarf-dev/zarf => ../..
 
 require (
 	github.com/invopop/jsonschema v0.13.0
-	github.com/zarf-dev/zarf v0.38.2
+	github.com/zarf-dev/zarf v0.0.0-local // grabbed from local
 )
 
 require (

--- a/src/api/internal/v1beta1/component.go
+++ b/src/api/internal/v1beta1/component.go
@@ -4,7 +4,6 @@
 package v1beta1
 
 import (
-	"github.com/invopop/jsonschema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -326,19 +325,6 @@ type ZarfComponentImport struct {
 	Path string `json:"path,omitempty"`
 	// [beta] The URL to a Zarf package to import via OCI.
 	URL string `json:"url,omitempty" jsonschema:"pattern=^oci://.*$"`
-}
-
-// JSONSchemaExtend extends the generated json schema during `zarf internal gen-config-schema`
-func (ZarfComponentImport) JSONSchemaExtend(schema *jsonschema.Schema) {
-	path, _ := schema.Properties.Get("path")
-	url, _ := schema.Properties.Get("url")
-
-	notSchema := &jsonschema.Schema{
-		Pattern: ZarfPackageTemplatePrefix,
-	}
-
-	path.Not = notSchema
-	url.Not = notSchema
 }
 
 // Shell represents the desired shell to use for a given command

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -4,10 +4,6 @@
 // Package v1alpha1 holds the definition of the v1alpha1 Zarf Package
 package v1alpha1
 
-import (
-	"github.com/invopop/jsonschema"
-)
-
 // ZarfComponent is the primary functional grouping of assets to deploy by Zarf.
 type ZarfComponent struct {
 	// The name of the component.
@@ -337,19 +333,6 @@ type ZarfComponentImport struct {
 	Path string `json:"path,omitempty"`
 	// [beta] The URL to a Zarf package to import via OCI.
 	URL string `json:"url,omitempty" jsonschema:"pattern=^oci://.*$"`
-}
-
-// JSONSchemaExtend extends the generated json schema during `zarf internal gen-config-schema`
-func (ZarfComponentImport) JSONSchemaExtend(schema *jsonschema.Schema) {
-	path, _ := schema.Properties.Get("path")
-	url, _ := schema.Properties.Get("url")
-
-	notSchema := &jsonschema.Schema{
-		Pattern: ZarfPackageTemplatePrefix,
-	}
-
-	path.Not = notSchema
-	url.Not = notSchema
 }
 
 // Shell represents the desired shell to use for a given command

--- a/src/internal/packager2/layout/import.go
+++ b/src/internal/packager2/layout/import.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -175,6 +176,9 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 
 func validateComponentCompose(c v1alpha1.ZarfComponent) error {
 	errs := []error{}
+	if strings.Contains(c.Import.Path, v1alpha1.ZarfPackageTemplatePrefix) || strings.Contains(c.Import.URL, v1alpha1.ZarfPackageTemplatePrefix) {
+		errs = append(errs, errors.New("package templates are not supported for import path or URL"))
+	}
 	if c.Import.Path == "" && c.Import.URL == "" {
 		errs = append(errs, errors.New("neither a path nor a URL was provided"))
 	}

--- a/src/internal/packager2/layout/import_test.go
+++ b/src/internal/packager2/layout/import_test.go
@@ -159,6 +159,30 @@ func TestValidateComponentCompose(t *testing.T) {
 				"URL is not a valid OCI URL",
 			},
 		},
+		{
+			name: "package template path provided",
+			component: v1alpha1.ZarfComponent{
+				Name: "template",
+				Import: v1alpha1.ZarfComponentImport{
+					Path: "###ZARF_PKG_TMPL_PATH###",
+				},
+			},
+			expectedErrs: []string{
+				"package templates are not supported for import path or URL",
+			},
+		},
+		{
+			name: "package template URL provided",
+			component: v1alpha1.ZarfComponent{
+				Name: "template",
+				Import: v1alpha1.ZarfComponentImport{
+					URL: "oci://registry.com/my-image:###ZARF_PKG_TMPL_TAG###",
+				},
+			},
+			expectedErrs: []string{
+				"package templates are not supported for import path or URL",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/pkg/lint/schema_test.go
+++ b/src/pkg/lint/schema_test.go
@@ -5,7 +5,6 @@
 package lint
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,10 +68,6 @@ func TestZarfSchema(t *testing.T) {
 						Only: v1alpha1.ZarfComponentOnlyTarget{
 							LocalOS: "unsupportedOS",
 						},
-						Import: v1alpha1.ZarfComponentImport{
-							Path: fmt.Sprintf("start%send", v1alpha1.ZarfPackageTemplatePrefix),
-							URL:  fmt.Sprintf("oci://start%send", v1alpha1.ZarfPackageTemplatePrefix),
-						},
 					},
 					{
 						Name: "actions",
@@ -114,8 +109,6 @@ func TestZarfSchema(t *testing.T) {
 				"components.0.only.localOS: components.0.only.localOS must be one of the following: \"linux\", \"darwin\", \"windows\"",
 				"components.1.actions.onCreate.before.0.setVariables.0.name: Does not match pattern '^[A-Z0-9_]+$'",
 				"components.1.actions.onRemove.onSuccess.0.setVariables.0.name: Does not match pattern '^[A-Z0-9_]+$'",
-				"components.0.import.path: Must not validate the schema (not)",
-				"components.0.import.url: Must not validate the schema (not)",
 				"apiVersion: apiVersion must be one of the following: \"zarf.dev/v1alpha1\"",
 			},
 		},

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -792,16 +792,10 @@
           "description": "The name of the component to import from the referenced zarf.yaml."
         },
         "path": {
-          "not": {
-            "pattern": "###ZARF_PKG_TMPL_"
-          },
           "type": "string",
           "description": "The path to the directory containing the zarf.yaml to import."
         },
         "url": {
-          "not": {
-            "pattern": "###ZARF_PKG_TMPL_"
-          },
           "type": "string",
           "pattern": "^oci://.*$",
           "description": "[beta] The URL to a Zarf package to import via OCI."


### PR DESCRIPTION
## Description

In #2886 the json schema was separated in another directory under hack. However the main zarf go.mod still contained the jsonschema dependency because it was implementing one of the methods to add extra items to the schema outside of what was possible with json/jsonschema tags. 

This was originally added to the schema so users would know that package templates for imports don't work, however since compose runs before the schema checks these schema checks were not reached. By adding explicit validation we can remove the jsonschema dependency and make the error message show up in the relevant workflows.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
