### PR TITLE
test: improve http pull test

### DIFF
--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -78,6 +78,7 @@ func TestUseCLI(t *testing.T) {
 		shaSum := strings.TrimSpace(stdOut)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Helper()
 			if r.URL.Path == fmt.Sprintf("/zarf-package-http-pull-%s.tar.zst", e2e.Arch) {
 				w.WriteHeader(http.StatusOK)
 				file, err := os.Open(filepath.Join(tmpDir, fmt.Sprintf("zarf-package-http-pull-%s.tar.zst", e2e.Arch)))
@@ -85,7 +86,8 @@ func TestUseCLI(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
-				_, _ = io.Copy(w, file)
+				_, err = io.Copy(w, file)
+				require.NoError(t, err)
 				return
 			}
 			w.WriteHeader(http.StatusNotFound)

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -85,7 +85,11 @@ func TestUseCLI(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
-				defer file.Close()
+				defer func() {
+					if err := file.Close(); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+					}
+				}()
 				_, err = io.Copy(w, file)
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -85,6 +85,7 @@ func TestUseCLI(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
+				defer file.Close()
 				_, err = io.Copy(w, file)
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)

--- a/src/test/e2e/00_use_cli_test.go
+++ b/src/test/e2e/00_use_cli_test.go
@@ -78,7 +78,6 @@ func TestUseCLI(t *testing.T) {
 		shaSum := strings.TrimSpace(stdOut)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Helper()
 			if r.URL.Path == fmt.Sprintf("/zarf-package-http-pull-%s.tar.zst", e2e.Arch) {
 				w.WriteHeader(http.StatusOK)
 				file, err := os.Open(filepath.Join(tmpDir, fmt.Sprintf("zarf-package-http-pull-%s.tar.zst", e2e.Arch)))
@@ -87,7 +86,10 @@ func TestUseCLI(t *testing.T) {
 					return
 				}
 				_, err = io.Copy(w, file)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
 				return
 			}
 			w.WriteHeader(http.StatusNotFound)

--- a/src/test/packages/00-http-pull/zarf.yaml
+++ b/src/test/packages/00-http-pull/zarf.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: http-pull
+
+components:
+  - name: foo


### PR DESCRIPTION
## Description

Cuts execution time of the pull HTTP test (10s -> 3s on local machine). Removes reliance upon GitHub release artifact and reduces local IO usage. Re-architects test to be more ready to be transitioned to a proper unit test.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
