### PR TITLE
fix: set default user for git and registry state during `zarf package deploy`

### DIFF
--- a/src/types/k8s.go
+++ b/src/types/k8s.go
@@ -146,6 +146,10 @@ func (gs *GitServerInfo) FillInEmptyValues() error {
 		}
 	}
 
+	if gs.PushUsername == "" && gs.IsInternal() {
+		gs.PushUsername = ZarfGitPushUser
+	}
+
 	// Set read-user information if using an internal repository, otherwise copy from the push-user
 	if gs.PullUsername == "" {
 		if gs.IsInternal() {
@@ -236,6 +240,10 @@ func (ri *RegistryInfo) FillInEmptyValues() error {
 		if ri.PushPassword, err = helpers.RandomString(ZarfGeneratedPasswordLen); err != nil {
 			return fmt.Errorf("%s: %w", lang.ErrUnableToGenerateRandomSecret, err)
 		}
+	}
+
+	if ri.PushUsername == "" && ri.IsInternal() {
+		ri.PushUsername = ZarfRegistryPushUser
 	}
 
 	// Set pull-username if not provided by init flag


### PR DESCRIPTION
## Description

There is a bug right now when a user runs `zarf package deploy <init-package>` it won't set the default push user or git repository. I believe this was introduced when cmd was refactored to not use `init()`s at startup. The `init()` seemed to be changing state for `zarf init`, but this behavior was also required by `zarf package deploy`. Regardless, it makes more sense for these default functions to not know what Zarf sets to defaults at the cmd level. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
