### PR TITLE
fix(cli): add log for explicit flag use

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -858,10 +858,15 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageRemoveOptions) preRun(_ *cobra.Command, _ []string) {
+func (o *packageRemoveOptions) preRun(cmd *cobra.Command, _ []string) {
 	// If --insecure was provided, set --skip-signature-validation to match
 	if config.CommonOptions.Insecure {
 		pkgConfig.PkgOpts.SkipSignatureValidation = true
+	}
+
+	// Check for the required --confirm flag and provide a clear error message for remediation
+	if !config.CommonOptions.Confirm {
+		logger.From(cmd.Context()).Error("The --confirm flag is required to remove a package.")
 	}
 }
 


### PR DESCRIPTION
## Description

Adds an error log to the pre-run if the `--confirm` flag is not set on removal. Feedback in the issue suggested that the default cobra messaging was not sufficient. There are no hooks into the error message returned from cobra and as such opted for a prerun validation. 

```bash
dev@dev:~/work/zarf$ zarf package remove init
2025-05-01 15:39:23 INF using config file location=/home/dev/work/zarf/zarf-config.toml
2025-05-01 15:39:23 ERR required flag(s) "confirm" not set
dev@dev:~/work/zarf$ ./build/zarf package remove init
2025-05-01 15:39:32 INF using config file location=/home/dev/work/zarf/zarf-config.toml
2025-05-01 15:39:32 ERR The --confirm flag is required to remove a package.
2025-05-01 15:39:32 ERR required flag(s) "confirm" not set
```

## Related Issue

Fixes #926 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
