### PR TITLE
feat(mirror-resources): support for State fallback without flags

### DIFF
--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -52,10 +52,12 @@ $ zarf package mirror-resources <your-package.tar.zst> \
       --git-push-username string        Username to access to the git server Zarf is configured to use. User must be able to create repositories via 'git push' (default "zarf-git-user")
       --git-url string                  External git server url to use for this Zarf cluster
   -h, --help                            help for mirror-resources
+      --images                          mirror only the images
       --no-img-checksum                 Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images.
       --registry-push-password string   Password for the push-user to connect to the registry
       --registry-push-username string   Username to access to the registry Zarf is configured to use (default "zarf-push")
       --registry-url string             External registry url address to use for this Zarf cluster
+      --repos                           mirror only the git repositories
       --retries int                     Number of retries to perform for Zarf deploy operations like git/image pushes or Helm installs (default 3)
       --shasum string                   Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --skip-signature-validation       Skip validating the signature of the Zarf package

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -348,17 +348,17 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		images += len(component.Images)
 		repos += len(component.Repos)
 	}
-	logger.From(ctx).Debug("Package contains images and repos", "images", images, "repos", repos)
+	logger.From(ctx).Debug("package contains images and repos", "images", images, "repos", repos)
 
 	// We don't yet know if the targets are internal or external
 	c, _ := cluster.New(ctx) //nolint:errcheck
 
 	if images == 0 && o.mirrorImages {
-		logger.From(ctx).Warn("No images found in package to mirror")
+		logger.From(ctx).Warn("no images found in package to mirror")
 	}
 
 	if o.mirrorImages && images > 0 {
-		logger.From(ctx).Info("Mirroring images", "images", images)
+		logger.From(ctx).Info("mirroring images", "images", images)
 		if pkgConfig.InitOpts.RegistryInfo.Address == "" {
 			// if empty flag & zarf state available - execute
 			// otherwise return error
@@ -366,7 +366,7 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 			if err != nil {
 				return fmt.Errorf("no registry URL provided and no zarf state found")
 			}
-			logger.From(ctx).Debug("No registry URL provided, using zarf state", "address", state.RegistryInfo.Address)
+			logger.From(ctx).Debug("no registry URL provided, using zarf state", "address", state.RegistryInfo.Address)
 			pkgConfig.InitOpts.RegistryInfo = state.RegistryInfo
 		}
 		mirrorOpt := packager2.MirrorOptions{
@@ -386,17 +386,17 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	}
 
 	if repos == 0 && o.mirrorRepos {
-		logger.From(ctx).Warn("No git repositories found in package to mirror")
+		logger.From(ctx).Warn("no git repositories found in package to mirror")
 	}
 
 	if o.mirrorRepos && repos > 0 {
-		logger.From(ctx).Info("Mirroring repos", "repos", repos)
+		logger.From(ctx).Info("mirroring repos", "repos", repos)
 		if pkgConfig.InitOpts.GitServer.Address == "" {
 			state, err := c.LoadState(ctx)
 			if err != nil {
 				return fmt.Errorf("no git URL provided and no zarf state found")
 			}
-			logger.From(ctx).Debug("No git URL provided, using zarf state", "address", state.GitServer.Address)
+			logger.From(ctx).Debug("no git URL provided, using zarf state", "address", state.GitServer.Address)
 			pkgConfig.InitOpts.GitServer = state.GitServer
 		}
 

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -353,7 +353,7 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	// We don't yet know if the targets are internal or external
 	c, _ := cluster.New(ctx) //nolint:errcheck
 
-	if images == 0 {
+	if images == 0 && o.mirrorImages {
 		logger.From(ctx).Warn("No images found in package to mirror")
 	}
 
@@ -385,7 +385,7 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		}
 	}
 
-	if repos == 0 {
+	if repos == 0 && o.mirrorRepos {
 		logger.From(ctx).Warn("No git repositories found in package to mirror")
 	}
 

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -328,6 +328,14 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		err = errors.Join(err, pkgLayout.Cleanup())
 	}()
 
+	images, repos := 0, 0
+	// Let's count the images and repos in the package
+	for _, component := range pkgLayout.Pkg.Components {
+		images += len(component.Images)
+		repos += len(component.Repos)
+	}
+	logger.From(ctx).Info("Package contains images and repos", "images", images, "repos", repos)
+
 	// We don't yet know if the targets are internal or external
 	c, _ := cluster.New(ctx) //nolint:errcheck
 
@@ -338,8 +346,6 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		if err != nil {
 			return fmt.Errorf("no registry URL provided and no zarf state found")
 		}
-		// default registry address will be 127.0.0.1:31999 - we need to update this in order to tunnel
-		state.RegistryInfo.Address = "http://zarf-docker-registry.zarf.svc.cluster.local:5000"
 		logger.From(ctx).Debug("No registry URL provided, using zarf state", "address", state.RegistryInfo.Address)
 		pkgConfig.InitOpts.RegistryInfo = state.RegistryInfo
 	}

--- a/src/internal/packager2/mirror.go
+++ b/src/internal/packager2/mirror.go
@@ -39,12 +39,16 @@ type MirrorOptions struct {
 }
 
 // Mirror mirrors the package contents to the given registry and git server.
-func Mirror(ctx context.Context, opt MirrorOptions) error {
+func MirrorImages(ctx context.Context, opt MirrorOptions) error {
 	err := pushImagesToRegistry(ctx, opt.PkgLayout, opt.RegistryInfo, opt.NoImageChecksum, opt.PlainHTTP, opt.OCIConcurrency, opt.Retries, opt.InsecureSkipTLSVerify)
 	if err != nil {
 		return err
 	}
-	err = pushReposToRepository(ctx, opt.Cluster, opt.PkgLayout, opt.GitInfo, opt.Retries)
+	return nil
+}
+
+func MirrorRepos(ctx context.Context, opt MirrorOptions) error {
+	err := pushReposToRepository(ctx, opt.Cluster, opt.PkgLayout, opt.GitInfo, opt.Retries)
 	if err != nil {
 		return err
 	}

--- a/src/test/e2e/39_crane_to_oras_test.go
+++ b/src/test/e2e/39_crane_to_oras_test.go
@@ -45,7 +45,7 @@ func TestCraneToORAS(t *testing.T) {
 	_, _, err = e2e.Zarf(t, "package", "deploy", cranePkgPath, "--confirm")
 	require.NoError(t, err)
 	cranePkgMirrorResourcesArgs := []string{"package", "mirror-resources", cranePkgPath, "--confirm"}
-	cranePkgMirrorResourcesArgs = append(cranePkgMirrorResourcesArgs, mirrorResourcesCreds...)
+	// mirror-resources now detects internal registry from state when resourcesCreds are not provided
 	_, _, err = e2e.Zarf(t, cranePkgMirrorResourcesArgs...)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Support for falling-back to zarf state when using `zarf package mirror-resources` without supplying URL flags otherwise returning an error that is clear.

## Related Issue

Fixes #2389 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
