### PR TITLE
fix(wait-for): return early on connection refused

### DIFF
--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -56,8 +56,14 @@ $ zarf tools wait-for http google.com success                           #  wait 
 ### Options inherited from parent commands
 
 ```
+  -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
+  -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --tmpdir string              Specify the temporary directory to use for intermediate files
+      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/src/cmd/vendor.go
+++ b/src/cmd/vendor.go
@@ -23,7 +23,6 @@ var vendorCmds = []string{
 	"k9s",
 	"monitor",
 	"m",
-	"wait-for",
 	"wait",
 	"w",
 	"crane",

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -94,6 +94,11 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 			zarfKubectlGet := fmt.Sprintf("%s tools kubectl get %s %s %s", zarfCommand, namespaceFlag, kind, identifier)
 			_, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
 			if err != nil {
+				// bail out immediately if the API server is refusing connections
+				if strings.Contains(stderr, "connect: connection refused") {
+					return fmt.Errorf("cannot reach Kubernetes API (connection refused): %s", stderr)
+				}
+				// otherwise just log and retry
 				l.Debug("resource error", "error", err)
 				continue
 			}

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -74,12 +74,14 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 	}
 
 	// Setup the spinner messages.
-	conditionMsg := fmt.Sprintf("Waiting for %s%s%s to be %s.", kind, identifierMsg, namespaceMsg, condition)
-	existMsg := fmt.Sprintf("Waiting for %s%s to exist.", path.Join(kind, identifierMsg), namespaceMsg)
+	conditionMsg := fmt.Sprintf("waiting for %s%s to be %s.", path.Join(kind, identifierMsg), namespaceMsg, condition)
+	existMsg := fmt.Sprintf("waiting for %s%s to exist.", path.Join(kind, identifierMsg), namespaceMsg)
+	completedMsg := fmt.Sprintf("wait for %s%s complete.", path.Join(kind, identifierMsg), namespaceMsg)
 
 	// Get the OS shell to execute commands in
 	shell, shellArgs := exec.GetOSShell(v1alpha1.Shell{Windows: "cmd"})
 
+	l.Info(existMsg)
 	for {
 		// Delay the check for 1 second
 		time.Sleep(time.Second)
@@ -89,17 +91,16 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 			return errors.New("wait timed out")
 
 		default:
-			l.Info(existMsg)
 			// Check if the resource exists.
 			zarfKubectlGet := fmt.Sprintf("%s tools kubectl get %s %s %s", zarfCommand, namespaceFlag, kind, identifier)
 			_, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
 			if err != nil {
-				// bail out immediately if the API server is refusing connections
 				if strings.Contains(stderr, "connect: connection refused") {
-					return fmt.Errorf("cannot reach Kubernetes API (connection refused): %s", stderr)
+					l.Info("api server unavailable")
+					continue
 				}
 				// otherwise just log and retry
-				l.Debug("resource error", "error", err)
+				l.Info("resource error", "error", err)
 				continue
 			}
 
@@ -127,7 +128,7 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 			}
 
 			// And just like that, success!
-			l.Info(conditionMsg)
+			l.Info(completedMsg)
 			return nil
 		}
 	}


### PR DESCRIPTION
## Description

Given an invalid kubeconfig or no connectivity to a cluster - zarf will still wait the full timeout period before exiting - giving the user a false sense of waiting for the resources in some scenarios.

Update:

Proposed changes include removing `wait-for` from the vendored commands list - enabling logging and all other persistentprerun logic. 

Logs were converted to `Info` to enable surfacing to users by default. We are now checking for cluster connectivity explicitly (every 1 second) and logging as such. This continues until the connection is both established and the handoff to the `kubectl wait` command has occurred. 

Example of zarf waiting for a cluster before then waiting for resource state
```bash
dev@dev:~/work/zarf$ ./build/zarf -l debug tools wait-for deploy coredns Available -n kube-system 
2025-05-07 22:56:57 DBG logger successfully initialized cfg.level=debug cfg.format=console cfg.destination=os.Stderr cfg.color=true
2025-05-07 22:56:57 INF using config file location=/home/dev/work/zarf/zarf-config.toml
2025-05-07 22:56:57 INF waiting for deploy/coredns in namespace kube-system to exist.
2025-05-07 22:56:59 INF api server unavailable
2025-05-07 22:57:00 INF api server unavailable
2025-05-07 22:57:01 INF api server unavailable
2025-05-07 22:57:02 INF api server unavailable
2025-05-07 22:57:03 INF api server unavailable
2025-05-07 22:57:04 INF api server unavailable
2025-05-07 22:57:05 INF api server unavailable
2025-05-07 22:57:06 INF api server unavailable
2025-05-07 22:57:07 INF api server unavailable
2025-05-07 22:57:08 INF api server unavailable
2025-05-07 22:57:09 INF api server unavailable
2025-05-07 22:57:10 INF waiting for deploy/coredns in namespace kube-system to be Available.
2025-05-07 22:57:28 INF wait for deploy/coredns in namespace kube-system complete.
```

## Related Issue

Fixes #2413

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
