### PR TITLE
feat: disable crc32 hashing when resource includes label

### DIFF
--- a/src/internal/agent/hooks/common.go
+++ b/src/internal/agent/hooks/common.go
@@ -13,3 +13,5 @@ func getLabelPatch(currLabels map[string]string) operations.PatchOperation {
 	currLabels["zarf-agent"] = "patched"
 	return operations.ReplacePatchOperation("/metadata/labels", currLabels)
 }
+
+const HashingLabel string = "zarf.dev/hashing"

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -97,7 +97,17 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 			patchedURL = fmt.Sprintf("%s:%s", patchedURL, src.Spec.Reference.Tag)
 		}
 
-		patchedSrc, err := transform.ImageTransformHost(registryAddress, patchedURL)
+		var (
+			patchedSrc string
+			err        error
+		)
+
+		if (src.ObjectMeta.Labels != nil) && (src.ObjectMeta.Labels[HashingLabel] == "disabled") {
+			patchedSrc, err = transform.ImageTransformHostWithoutChecksum(registryAddress, patchedURL)
+		} else {
+			patchedSrc, err = transform.ImageTransformHost(registryAddress, patchedURL)
+		}
+
 		if err != nil {
 			return nil, fmt.Errorf("unable to transform the OCIRepo URL: %w", err)
 		}


### PR DESCRIPTION
## Description

I was asked to see what the implementation would look for using a label instead of using the `LayerSelector` on the oci-repo resource.

## Related Issue

Relates to #3435

Other draft PR: #3720

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
