### PR TITLE
fix: avoid panic during wait-for HTTP server

### DIFF
--- a/src/internal/packager2/actions/actions.go
+++ b/src/internal/packager2/actions/actions.go
@@ -140,7 +140,7 @@ retryCmd:
 		}
 
 		// Run the command on repeat until success or timeout.
-		l.Info("waiting for action", "cmd", cmdEscaped, "timeout", actionDefaults.MaxTotalSeconds)
+		l.Info("waiting for action", "cmd", cmdEscaped, "timeout", fmt.Sprintf("%d seconds", actionDefaults.MaxTotalSeconds))
 		select {
 		// On timeout break the loop to abort.
 		case <-timeout:

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -174,7 +174,7 @@ func waitForNetworkEndpoint(ctx context.Context, resource, name, condition strin
 
 					// If the status code is not in the 2xx range, try again.
 					if resp.StatusCode < 200 || resp.StatusCode > 299 {
-						l.Debug("did not receive 2xx status code", "error", err)
+						l.Debug("did not receive 2xx status code", "response_code", resp.StatusCode)
 						continue
 					}
 

--- a/src/pkg/utils/wait_test.go
+++ b/src/pkg/utils/wait_test.go
@@ -58,7 +58,6 @@ func TestIsJSONPathWaitType(t *testing.T) {
 
 func TestWaitForNetworkEndpoint(t *testing.T) {
 	t.Parallel()
-	// Create a test server
 	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -72,7 +71,6 @@ func TestWaitForNetworkEndpoint(t *testing.T) {
 	successServerURL := strings.TrimPrefix(successServer.URL, "http://")
 	notFoundServerURL := strings.TrimPrefix(notFoundServer.URL, "http://")
 
-	// Test cases
 	tests := []struct {
 		name      string
 		host      string


### PR DESCRIPTION
## Description

Currently there is a panic when an HTTP server that someone is waiting for returns an error code that is not the expected error code. This is because it will try to call the `.Error()` function on a nil err.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
