### PR TITLE
fix: Replace all vars and consts in `actionCmdMutation`

### DIFF
--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -82,7 +82,7 @@ func runAction(ctx context.Context, defaultCfg v1alpha1.ZarfComponentActionDefau
 
 	actionDefaults := actionGetCfg(ctx, defaultCfg, action, variableConfig.GetAllTemplates())
 
-	if cmd, err = actionCmdMutation(ctx, cmd, actionDefaults.Shell); err != nil {
+	if cmd, err = actionCmdMutation(ctx, cmd, actionDefaults.Shell, runtime.GOOS); err != nil {
 		l.Error("error mutating command", "cmd", cmdEscaped, "err", err.Error())
 	}
 
@@ -209,7 +209,7 @@ func convertWaitToCmd(_ context.Context, wait v1alpha1.ZarfComponentActionWait, 
 }
 
 // Perform some basic string mutations to make commands more useful.
-func actionCmdMutation(ctx context.Context, cmd string, shellPref v1alpha1.Shell) (string, error) {
+func actionCmdMutation(ctx context.Context, cmd string, shellPref v1alpha1.Shell, goos string) (string, error) {
 	zarfCommand, err := utils.GetFinalExecutableCommand()
 	if err != nil {
 		return cmd, err
@@ -219,7 +219,7 @@ func actionCmdMutation(ctx context.Context, cmd string, shellPref v1alpha1.Shell
 	cmd = strings.ReplaceAll(cmd, "./zarf ", zarfCommand+" ")
 
 	// Make commands 'more' compatible with Windows OS PowerShell
-	if runtime.GOOS == "windows" && (exec.IsPowershell(shellPref.Windows) || shellPref.Windows == "") {
+	if goos == "windows" && (exec.IsPowershell(shellPref.Windows) || shellPref.Windows == "") {
 		// Replace "touch" with "New-Item" on Windows as it's a common command, but not POSIX so not aliased by M$.
 		// See https://mathieubuisson.github.io/powershell-linux-bash/ &
 		// http://web.cs.ucla.edu/~miryung/teaching/EE461L-Spring2012/labs/posix.html for more details.

--- a/src/pkg/packager/actions/actions_test.go
+++ b/src/pkg/packager/actions/actions_test.go
@@ -1,0 +1,103 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/utils"
+)
+
+func Test_actionCmdMutation(t *testing.T) {
+	zarfCmd, _ := utils.GetFinalExecutableCommand()
+	tests := []struct {
+		name      string
+		cmd       string
+		shellPref v1alpha1.Shell
+		goos      string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "linux without zarf",
+			cmd:       "echo \"this is zarf\"",
+			shellPref: v1alpha1.Shell{},
+			goos:      "linux",
+			want:      "echo \"this is zarf\"",
+			wantErr:   false,
+		},
+		{
+			name:      "linux including zarf",
+			cmd:       "./zarf deploy",
+			shellPref: v1alpha1.Shell{},
+			goos:      "linux",
+			want:      fmt.Sprintf("%s deploy", zarfCmd),
+			wantErr:   false,
+		},
+		{
+			name:      "windows including zarf",
+			cmd:       "./zarf deploy",
+			shellPref: v1alpha1.Shell{},
+			goos:      "windows",
+			want:      fmt.Sprintf("%s deploy", zarfCmd),
+			wantErr:   false,
+		},
+		{
+			name:      "windows env",
+			cmd:       "echo ${ZARF_VAR_ENV1}",
+			shellPref: v1alpha1.Shell{},
+			goos:      "windows",
+			want:      "echo $Env:ZARF_VAR_ENV1",
+			wantErr:   false,
+		},
+		{
+			name: "windows env pwsh",
+			cmd:  "echo ${ZARF_VAR_ENV1}",
+			shellPref: v1alpha1.Shell{
+				Windows: "pwsh",
+			},
+			goos:    "windows",
+			want:    "echo $Env:ZARF_VAR_ENV1",
+			wantErr: false,
+		},
+		{
+			name: "windows env powershell",
+			cmd:  "echo ${ZARF_VAR_ENV1}",
+			shellPref: v1alpha1.Shell{
+				Windows: "powershell",
+			},
+			goos:    "windows",
+			want:    "echo $Env:ZARF_VAR_ENV1",
+			wantErr: false,
+		},
+		{
+			name:      "windows multiple env",
+			cmd:       "echo ${ZARF_VAR_ENV1} ${ZARF_VAR_ENV2}",
+			shellPref: v1alpha1.Shell{},
+			goos:      "windows",
+			want:      "echo $Env:ZARF_VAR_ENV1 $Env:ZARF_VAR_ENV2",
+			wantErr:   false,
+		},
+		{
+			name:      "windows constants",
+			cmd:       "echo ${ZARF_CONST_ENV1}",
+			shellPref: v1alpha1.Shell{},
+			goos:      "windows",
+			want:      "echo $Env:ZARF_CONST_ENV1",
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := actionCmdMutation(context.Background(), tt.cmd, tt.shellPref, tt.goos)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("actionCmdMutation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("actionCmdMutation() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Replace all variables and constants in `cmd` actions for Windows

## Related Issue

Fixes #3798

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
