### PR TITLE
feat: add logic to include crc32 tag on helm chart

### DIFF
--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -58,6 +58,7 @@ type PushConfig struct {
 const (
 	DockerMediaTypeManifest     = "application/vnd.docker.distribution.manifest.v2+json"
 	DockerMediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+	HelmMediaTypeManifest       = "application/vnd.cncf.helm.config.v1+json"
 )
 
 const (
@@ -141,6 +142,13 @@ func isManifest(mediaType string) bool {
 func isIndex(mediaType string) bool {
 	switch mediaType {
 	case ocispec.MediaTypeImageIndex, DockerMediaTypeManifestList:
+		return true
+	}
+	return false
+}
+func isChart(mediaType string) bool {
+	switch mediaType {
+	case HelmMediaTypeManifest:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Description

This adds logic to the push logic to change the `org.opencontainers.image.version` to include the crc32 hash on helm charts

## Related Issue

Fixes #3435

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
