### PR TITLE
fix(CLI): migrate to Packager2 for init package downloads

### DIFF
--- a/src/pkg/packager/sources/oci.go
+++ b/src/pkg/packager/sources/oci.go
@@ -164,7 +164,14 @@ func (s *OCISource) Collect(ctx context.Context, dir string) (string, error) {
 		return "", err
 	}
 	defer os.RemoveAll(tmp)
-	fetched, err := s.PullPackage(ctx, tmp, config.CommonOptions.OCIConcurrency)
+
+	root, err := s.FetchRoot(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Pull all the layers
+	fetched, err := s.PullPackage(ctx, tmp, config.CommonOptions.OCIConcurrency, root.Layers...)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -27,6 +27,11 @@ var (
 
 // PullPackage pulls the package from the remote repository and saves it to the given path.
 func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurrency int, layersToPull ...ocispec.Descriptor) (_ []ocispec.Descriptor, err error) {
+	// layersToPull is an explicit requirement for pulling package layers
+	if len(layersToPull) == 0 {
+		return nil, fmt.Errorf("no layers to pull")
+	}
+
 	layerSize := oci.SumDescsSize(layersToPull)
 	// TODO (@austinabro321) change this and other r.Log() calls to the proper slog format
 	r.Log().Info(fmt.Sprintf("Pulling %s, size: %s", r.Repo().Reference, utils.ByteFormat(float64(layerSize), 2)))


### PR DESCRIPTION
## Description

`zarf init` and `zarf tools download-init` currently fail because they utilize `packager.sources.Collect()` methods which did not pass the explicit layers required.

This PR updates `init` and `tools download-init` to use `packager2.Pull()` - Adds an early exit error for quick identification - and fixes the problem in `packager1.source.Collect()` to always pull all layers in the event there is another area impacted by this change. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
