### PR TITLE
fix(helm): Allow empty version for localpath chart

### DIFF
--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -75,6 +75,9 @@ func ChartFromZarfManifest(manifest v1alpha1.ZarfManifest, manifestPath, package
 
 // StandardName generates a predictable full path for a helm chart for Zarf.
 func StandardName(destination string, chart v1alpha1.ZarfChart) string {
+	if chart.Version == "" {
+		return filepath.Join(destination, chart.Name)
+	}
 	return filepath.Join(destination, chart.Name+"-"+chart.Version)
 }
 

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -87,15 +87,9 @@ func PackageChartFromLocalFiles(ctx context.Context, chart v1alpha1.ZarfChart, c
 	}
 
 	if chart.Version != "" && chart.Version != loadedChart.Metadata.Version {
-		// warn the user - alternatively we could return an error here if the expectation is improved provenance
-		l.Warn("chart version mismatch",
-			"expected", chart.Version,
-			"actual", loadedChart.Metadata.Version,
-		)
+		// this is important as deploy will use teh chart version to find the chart tarball location
+		return fmt.Errorf("expected chart version %s does not match the actual chart metadata version %s", chart.Version, loadedChart.Metadata.Version)
 	}
-
-	// Explicitly set the chart version to the one in the chart.yaml
-	chart.Version = loadedChart.Metadata.Version
 
 	// Handle the chart directory or tarball
 	var saved string

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -81,10 +81,21 @@ func PackageChartFromLocalFiles(ctx context.Context, chart v1alpha1.ZarfChart, c
 	)
 
 	// Load and validate the chart
-	cl, _, err := loadAndValidateChart(chart.LocalPath)
+	cl, loadedChart, err := loadAndValidateChart(chart.LocalPath)
 	if err != nil {
 		return err
 	}
+
+	if chart.Version != "" && chart.Version != loadedChart.Metadata.Version {
+		// warn the user - alternatively we could return an error here if the expectation is improved provenance
+		l.Warn("chart version mismatch",
+			"expected", chart.Version,
+			"actual", loadedChart.Metadata.Version,
+		)
+	}
+
+	// Explicitly set the chart version to the one in the chart.yaml
+	chart.Version = loadedChart.Metadata.Version
 
 	// Handle the chart directory or tarball
 	var saved string

--- a/src/pkg/lint/validate.go
+++ b/src/pkg/lint/validate.go
@@ -279,7 +279,7 @@ func validateChart(chart v1alpha1.ZarfChart) error {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartURLOrPath, chart.Name))
 	}
 
-	if chart.Version == "" {
+	if chart.Version == "" && chart.LocalPath == "" {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartVersion, chart.Name))
 	}
 

--- a/src/test/packages/25-helm-release-history/zarf.yaml
+++ b/src/test/packages/25-helm-release-history/zarf.yaml
@@ -8,5 +8,5 @@ components:
     charts:
       - name: chart
         namespace: helm-release-history
-        version: v0.1.0
+        version: 0.1.0
         localPath: chart


### PR DESCRIPTION
## Description

chart version can be any value for `localPath` helm charts and this is used in the naming of the helm archive within the zarf package. This can result in confusion and inaccuracy of artifact versions were one to inspect/decompress a package. 

Given that a chart name in the `ZarfPackageConfig` must be unique (and is enforced during create) - then allowing for version being not present should not create any collisions.

This PR makes the following assumptions:
- `localPath` charts should not require a version be specified
-  return an error when expected and actual versions mismatch. 

This PR helps decide on paths forward. 

## Related Issue

Fixes #3813


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
