### PR TITLE
fix(archive): replace virtualfilesystem with sequential streaming

### DIFF
--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -50,7 +50,8 @@ func LoadFromTar(ctx context.Context, tarPath string, opt PackageLayoutOptions) 
 	if err != nil {
 		return nil, err
 	}
-	_, err = archive.Unarchive(ctx, tarPath, dirPath)
+	// Decompress the archive
+	err = archive.Decompress(ctx, tarPath, dirPath, archive.DecompressOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"maps"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
-	"github.com/mholt/archives"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
 
@@ -52,45 +50,7 @@ func LoadFromTar(ctx context.Context, tarPath string, opt PackageLayoutOptions) 
 	if err != nil {
 		return nil, err
 	}
-
-	// 1) Mount the archive as a virtual file system.
-	fsys, err := archives.FileSystem(ctx, tarPath, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open archive %q: %w", tarPath, err)
-	}
-
-	// 2) Walk every entry in the archive.
-	err = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		// skip directories
-		if d.IsDir() {
-			return nil
-		}
-		// ensure parent dirs exist in our temp dir
-		dst := filepath.Join(dirPath, path)
-		if err := os.MkdirAll(filepath.Dir(dst), helpers.ReadExecuteAllWriteUser); err != nil {
-			return err
-		}
-		// copy file contents
-		in, err := fsys.Open(path)
-		if err != nil {
-			return err
-		}
-		defer in.Close()
-
-		out, err := os.Create(dst)
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-
-		if _, err := io.Copy(out, in); err != nil {
-			return err
-		}
-		return nil
-	})
+	_, err = archive.Unarchive(ctx, tarPath, dirPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Zarf users of v0.55.2 are experiencing long package load times - impacting those loading large zarf packages. 

The root of the problem is the use of the virtual filesystem in the package load where all files are being loaded into the temporary directory. The random access semantics are great for situations where we need file lookup - but for unarchiving the entirety of a package this can be significantly slower than a sequential stream. 

Examples using `examples/longhorn`

### Deploy

This Branch:
```
real    0m2.499s
user    0m1.407s
sys     0m1.139s
```

Main:
```
real    1m3.592s
user    1m12.046s
sys     0m15.594s
```

### mirror-resources

This Branch:
```
real    0m4.133s
user    0m1.532s
sys     0m1.256s
```

Main:
```
real    1m4.817s
user    1m12.564s
sys     0m15.392s
```

## Related Issue

Fixes #3830


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
