### PR TITLE
fix(mirror-resources): add cluster nil check before loading state

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -362,6 +362,9 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		if pkgConfig.InitOpts.RegistryInfo.Address == "" {
 			// if empty flag & zarf state available - execute
 			// otherwise return error
+			if c == nil {
+				return fmt.Errorf("no cluster connection detected - unable to obtain state")
+			}
 			state, err := c.LoadState(ctx)
 			if err != nil {
 				return fmt.Errorf("no registry URL provided and no zarf state found")
@@ -392,6 +395,9 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	if o.mirrorRepos && repos > 0 {
 		logger.From(ctx).Info("mirroring repos", "repos", repos)
 		if pkgConfig.InitOpts.GitServer.Address == "" {
+			if c == nil {
+				return fmt.Errorf("no cluster connection detected - unable to obtain state")
+			}
 			state, err := c.LoadState(ctx)
 			if err != nil {
 				return fmt.Errorf("no git URL provided and no zarf state found")


### PR DESCRIPTION
## Description

Does not resolve #3837 but is attributed to the problem where we did not check for the cluster object to be nil before attempting to call the `LoadState` method. 

## Related Issue

Relates to #3837

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
