### PR TITLE
fix(release): remove grype cve report from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ jobs:
       - name: Install tools
         uses: ./.github/actions/install-tools
 
-      - name: install grype
-        env:
-          VERSION: v0.74.6
-        run: "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $VERSION"
-        shell: bash
-
       - name: Build CLI
         run: |
           make build-cli-linux-amd
@@ -79,10 +73,6 @@ jobs:
         run: |
           make publish-init-package ARCH=amd64 REPOSITORY_URL=ghcr.io/zarf-dev/packages
           make publish-init-package ARCH=arm64 REPOSITORY_URL=ghcr.io/zarf-dev/packages
-
-      # Create a CVE report based on this build
-      - name: Create release time CVE report
-        run: "make cve-report"
 
       # Upload the contents of the build directory for later stages to use
       - name: Upload build artifacts
@@ -194,12 +184,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}
-
-      - name: Save CVE report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: cve-report
-          path: build/zarf-known-cves.csv
 
       - name: Report disk space on failure
         if: failure()


### PR DESCRIPTION
## Description

This change removes grype and the cve-report generation from the release workflow. Future iteration will be to align CVE scanning and reporting with developer operations and enable consumers to get more accurate scanning results by improving the recommendation and documentation. 
## Related Issue

Fixes #3839 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
