### PR TITLE
feat(utils): support user interrupts in utils.ExecuteWait and add debug logging

### DIFF
--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -90,11 +90,16 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 		select {
 		case <-expired:
 			return errors.New("wait timed out")
+		case <-ctx.Done():
+			return errors.New("received interrupt")
 
 		default:
 			// Check if the resource exists.
+			l.Debug("checking resource existence", "namespace", namespaceFlag, "kind", kind, "identifier", identifier)
 			zarfKubectlGet := fmt.Sprintf("%s tools kubectl get %s %s %s", zarfCommand, namespaceFlag, kind, identifier)
-			_, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
+			cmd := append(shellArgs, zarfKubectlGet)
+			stdout, stderr, err := exec.Cmd(shell, cmd...)
+			l.Debug("cmd done", "cmd", cmd, "stdout", stdout, "stderr", stderr, "error", err)
 			if err != nil {
 				if strings.Contains(stderr, "connect: connection refused") {
 					l.Info("api server unavailable")


### PR DESCRIPTION
## Description
Previously, `zarf tools wait-for` would require two ctrl-c's from a user to interrupt the process. This PR adds a `ctx.Done()` to `utils.ExecuteWait`'s select and some extra debugging to help trace #3844.

## Related Issue
Relates to #3844

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
