### PR TITLE
feat(utils): add user interrupts to wait-for on network protocols

### DIFF
--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -162,6 +162,8 @@ func waitForNetworkEndpoint(ctx context.Context, resource, name, condition strin
 		select {
 		case <-expired:
 			return errors.New("wait timed out")
+		case <-ctx.Done():
+			return errors.New("received interrupt")
 		default:
 			switch resource {
 			case "http", "https":

--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -90,11 +90,16 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 		select {
 		case <-expired:
 			return errors.New("wait timed out")
+		case <-ctx.Done():
+			return errors.New("received interrupt")
 
 		default:
 			// Check if the resource exists.
+			l.Debug("checking resource existence", "namespace", namespaceFlag, "kind", kind, "identifier", identifier)
 			zarfKubectlGet := fmt.Sprintf("%s tools kubectl get %s %s %s", zarfCommand, namespaceFlag, kind, identifier)
-			_, stderr, err := exec.Cmd(shell, append(shellArgs, zarfKubectlGet)...)
+			cmd := append(shellArgs, zarfKubectlGet)
+			stdout, stderr, err := exec.Cmd(shell, cmd...)
+			l.Debug("cmd done", "cmd", cmd, "stdout", stdout, "stderr", stderr, "error", err)
 			if err != nil {
 				if strings.Contains(stderr, "connect: connection refused") {
 					l.Info("api server unavailable")


### PR DESCRIPTION
## Description
Follow up to #3846, this PR adds the same hook for user-interrupts in the network protocol loop as in the main loop of `utils.ExecuteWait`

See:
<img width="1077" alt="Screenshot 2025-05-22 at 10 17 56" src="https://github.com/user-attachments/assets/b32e4719-408c-47ec-a6cd-f5459838992c" />

## Related Issue
Relates to #3846, #3844

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
