### PR TITLE
chore: lint src/internal/packager

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,7 +77,7 @@ linters:
       - legacy
     paths:
       - src/cmd/helm
-      - src/internal/packager
+      - src/internal/packager/sbom
       - src/pkg/packager
       - src/internal/packager2
       - third_party$

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -125,7 +125,10 @@ func InstallOrUpgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, ch
 		removeMsg := "if you need to remove the failed chart, use `zarf package remove`"
 		installErr := fmt.Errorf("unable to install chart after %d attempts: %w: %s", opts.Retries, err, removeMsg)
 
-		releases, _ := histClient.Run(zarfChart.ReleaseName)
+		releases, err := histClient.Run(zarfChart.ReleaseName)
+		if err != nil {
+			return nil, "", errors.Join(err, installErr)
+		}
 		previouslyDeployedVersion := 0
 
 		// Check for previous releases that successfully deployed
@@ -368,7 +371,11 @@ func migrateDeprecatedAPIs(ctx context.Context, c *cluster.Cluster, actionConfig
 			return fmt.Errorf("failed to unmarshal manifest: %w", err)
 		}
 
-		rawData, manifestModified, _ := handleDeprecations(rawData, *kubeGitVersion)
+		rawData, manifestModified, err := handleDeprecations(rawData, *kubeGitVersion)
+		if err != nil {
+			// avoid returning the err here in case pluto uses an invalid semver
+			logger.From(ctx).Error("unable to update deprecated resource", "name", resource.Name, "err", err.Error())
+		}
 		manifestContent, err := yaml.Marshal(rawData)
 		if err != nil {
 			return fmt.Errorf("failed to marshal raw manifest after deprecation check: %w", err)

--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -40,6 +40,7 @@ import (
 // Use same default as Helm CLI does.
 const maxHelmHistory = 10
 
+// InstallUpgradeOpts provide options for the Helm install/upgrade operation
 type InstallUpgradeOpts struct {
 	// AdoptExistingResources is true if the chart should adopt existing namespaces
 	AdoptExistingResources bool

--- a/src/internal/packager/images/common.go
+++ b/src/internal/packager/images/common.go
@@ -71,8 +71,7 @@ const (
 
 func isLayer(mediaType string) bool {
 	switch mediaType {
-	// many of these layers are deprecated now, but older images could still be using them
-	//nolint: staticcheck
+	//nolint: staticcheck // some of these layers are deprecated now, but they're included in this check since older images could still be using them
 	case DockerLayer, DockerUncompressedLayer, ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayerZstd, ocispec.MediaTypeImageLayer,
 		DockerForeignLayer, ocispec.MediaTypeImageLayerNonDistributableZstd, ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip:
 		return true

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -53,7 +53,7 @@ func Push(ctx context.Context, cfg PushConfig) error {
 	}
 
 	// The user may or may not have a cluster available, if it's available then use it to connect to the registry
-	c, _ := cluster.New(ctx)
+	c, _ := cluster.New(ctx) //nolint: errcheck
 	err = retry.Do(func() error {
 		// reset concurrency to user-provided value on each component retry
 		ociConcurrency := cfg.OCIConcurrency

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -80,7 +80,10 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			}),
 		}
 
-		client.Client.Transport = orasTransport(cfg.InsecureSkipTLSVerify, cfg.ResponseHeaderTimeout)
+		client.Client.Transport, err = orasTransport(cfg.InsecureSkipTLSVerify, cfg.ResponseHeaderTimeout)
+		if err != nil {
+			return err
+		}
 
 		plainHTTP := cfg.PlainHTTP
 


### PR DESCRIPTION
## Description

src/internal/packager was excluded from lint on the basis that the packages would be replaced in the packager refactor (#3525), however only src/internal/packager/sbom will be replaced. This PR lints the long lived packages that were excluded.  

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
