### PR TITLE
chore: update gitea chart to `12.3.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ build-cli: build-cli-linux-amd build-cli-linux-arm build-cli-mac-intel build-cli
 docs-and-schema: ## Generate the Zarf Documentation and Schema
 	ZARF_CONFIG=hack/empty-config.toml go run main.go internal gen-cli-docs
 	hack/schema/create-zarf-schema.sh
+	hack/cots/update-gitea.sh
 
 init-package-with-agent: build build-local-agent-image init-package
 

--- a/hack/cots/update-gitea.sh
+++ b/hack/cots/update-gitea.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT_DIR=$(builtin cd "$SCRIPT_DIR"/../.. && pwd)
+
+TEST_GO_FILE="$REPO_ROOT_DIR/src/test/e2e/06_create_sbom_test.go"
+echo "::debug::TEST_GO_FILE='$TEST_GO_FILE'"
+
+GITEA_IMAGE=$(yq -oy '.package.create.set.gitea_image' $REPO_ROOT_DIR/zarf-config.toml | sed 's!/!_!g; s!:!_!g')
+echo "::debug::GITEA_IMAGE='$GITEA_IMAGE'"
+
+SED_REPLACE=$(printf 's!ghcr.io_go-gitea_gitea_[0-9\.]+-rootless!%s!g' "$GITEA_IMAGE")
+echo "::debug::SED_REPLACE='$SED_REPLACE'"
+
+sed -i -E "$SED_REPLACE" -- $TEST_GO_FILE

--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -54,5 +54,8 @@ postgresql-ha:
 redis-cluster:
   enabled: false
 
+valkey-cluster:
+  enabled: false
+
 strategy:
   type: "Recreate"

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -59,7 +59,7 @@ components:
       - name: gitea
         releaseName: zarf-gitea
         url: oci://registry-1.docker.io/giteacharts/gitea
-        version: 12.0.0
+        version: 12.1.2
         namespace: zarf
         valuesFiles:
           - gitea-values.yaml

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -59,7 +59,7 @@ components:
       - name: gitea
         releaseName: zarf-gitea
         url: oci://registry-1.docker.io/giteacharts/gitea
-        version: 12.1.2
+        version: 12.3.0
         namespace: zarf
         valuesFiles:
           - gitea-values.yaml

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -58,8 +58,8 @@ components:
     charts:
       - name: gitea
         releaseName: zarf-gitea
-        url: https://dl.gitea.io/charts
-        version: 10.1.1
+        url: oci://registry-1.docker.io/giteacharts/gitea
+        version: 12.0.0
         namespace: zarf
         valuesFiles:
           - gitea-values.yaml

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -69,8 +69,8 @@ func TestCreateSBOM(t *testing.T) {
 
 	// Test that we preserve the filepath
 	require.FileExists(t, filepath.Join(outSbomPath, "dos-games", "sbom-viewer-ghcr.io_zarf-dev_doom-game_0.0.1.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-ghcr.io_go-gitea_gitea_1.24.3-rootless.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.24.3-rootless.json"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-ghcr.io_go-gitea_gitea_1.24.6-rootless.html"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.24.6-rootless.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-zarf-component-k3s.html"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "zarf-component-k3s.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "compare.html"))

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -69,8 +69,8 @@ func TestCreateSBOM(t *testing.T) {
 
 	// Test that we preserve the filepath
 	require.FileExists(t, filepath.Join(outSbomPath, "dos-games", "sbom-viewer-ghcr.io_zarf-dev_doom-game_0.0.1.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-docker.io_gitea_gitea_1.21.5-rootless.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "docker.io_gitea_gitea_1.21.5-rootless.json"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-ghcr.io_go-gitea_gitea_1.24.3-rootless.html"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.24.3-rootless.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-zarf-component-k3s.html"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "zarf-component-k3s.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "compare.html"))

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -11,4 +11,4 @@ registry_image = 'library/registry'
 registry_image_tag = '3.0.0'
 
 # The image reference to use for the optional git-server Zarf deploys
-gitea_image = 'ghcr.io/go-gitea/gitea:1.24.3-rootless'
+gitea_image = 'ghcr.io/go-gitea/gitea:1.24.6-rootless'

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -11,4 +11,4 @@ registry_image = 'library/registry'
 registry_image_tag = '3.0.0'
 
 # The image reference to use for the optional git-server Zarf deploys
-gitea_image = 'gitea/gitea:1.21.5-rootless'
+gitea_image = 'ghcr.io/go-gitea/gitea:1.23.8-rootless'

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -11,4 +11,4 @@ registry_image = 'library/registry'
 registry_image_tag = '3.0.0'
 
 # The image reference to use for the optional git-server Zarf deploys
-gitea_image = 'ghcr.io/go-gitea/gitea:1.23.8-rootless'
+gitea_image = 'ghcr.io/go-gitea/gitea:1.24.3-rootless'


### PR DESCRIPTION
## Description

Updates `gitea` chart to 12.3.0:

- The upstream chart replaces `redis` with `valkey`, so I disabled the `valkey` cluster.
- Changed url to use OCI chart
- Changed `gitea_image` to use `ghcr.io` endpoint to avoid rate-limiting
  - Might want to consider changing `registry_image_*` to use ghcr.io endpoints

## Related Issue

Fixes #N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
