### PR TITLE
fix: segfault during destroy w/o state

### DIFF
--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -65,7 +65,7 @@ func (o *destroyOptions) run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// If Zarf deployed the cluster, burn it all down
-	if state.ZarfAppliance || (state.Distro == "") {
+	if state != nil && (state.ZarfAppliance || (state.Distro == "")) {
 		// Check if we have the scripts to destroy everything
 		fileInfo, err := os.Stat(config.ZarfCleanupScriptsPath)
 		if errors.Is(err, os.ErrNotExist) || !fileInfo.IsDir() {


### PR DESCRIPTION
## Description

Fixes a segfault that can occur when a cluster has no state secret in it.

## Related Issue

Fixes #N/A
https://kubernetes.slack.com/archives/C03B6BJAUJ3/p1748374811253029

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
