### PR TITLE
refactor: move zoci into layout

### DIFF
--- a/src/internal/packager2/inspect.go
+++ b/src/internal/packager2/inspect.go
@@ -23,7 +23,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
@@ -71,7 +70,7 @@ func InspectPackageResources(ctx context.Context, source string, opts InspectPac
 		Architecture:            opts.Architecture,
 		PublicKeyPath:           opts.PublicKeyPath,
 		SkipSignatureValidation: opts.SkipSignatureValidation,
-		LayersSelector:          zoci.ComponentLayers,
+		LayersSelector:          layout.ComponentLayers,
 		Filter:                  filters.BySelectState(opts.Components),
 	}
 
@@ -305,7 +304,7 @@ func InspectPackageSBOM(ctx context.Context, source string, opts InspectPackageS
 		Architecture:            opts.Architecture,
 		PublicKeyPath:           opts.PublicKeyPath,
 		SkipSignatureValidation: opts.SkipSignatureValidation,
-		LayersSelector:          zoci.SbomLayers,
+		LayersSelector:          layout.SbomLayers,
 		Filter:                  filters.Empty(),
 	}
 	pkgLayout, err := LoadPackage(ctx, loadOpts)
@@ -342,7 +341,7 @@ type InspectPackageDefinitionOptions struct {
 func InspectPackageDefinition(ctx context.Context, source string, opts InspectPackageDefinitionOptions) (InspectPackageDefinitionResult, error) {
 	cluster, _ := cluster.New(ctx) //nolint:errcheck
 
-	pkg, err := GetPackageFromSourceOrCluster(ctx, cluster, source, opts.SkipSignatureValidation, opts.PublicKeyPath, zoci.MetadataLayers)
+	pkg, err := GetPackageFromSourceOrCluster(ctx, cluster, source, opts.SkipSignatureValidation, opts.PublicKeyPath, layout.MetadataLayers)
 	if err != nil {
 		return InspectPackageDefinitionResult{}, fmt.Errorf("unable to load the package: %w", err)
 	}
@@ -368,7 +367,7 @@ type InspectPackageImagesOptions struct {
 func InspectPackageImages(ctx context.Context, source string, opts InspectPackageImagesOptions) (InspectPackageImageResult, error) {
 	cluster, _ := cluster.New(ctx) //nolint:errcheck
 
-	pkg, err := GetPackageFromSourceOrCluster(ctx, cluster, source, opts.SkipSignatureValidation, opts.PublicKeyPath, zoci.MetadataLayers)
+	pkg, err := GetPackageFromSourceOrCluster(ctx, cluster, source, opts.SkipSignatureValidation, opts.PublicKeyPath, layout.MetadataLayers)
 	if err != nil {
 		return InspectPackageImageResult{}, fmt.Errorf("unable to load the package: %w", err)
 	}

--- a/src/internal/packager2/layout/create.go
+++ b/src/internal/packager2/layout/create.go
@@ -41,7 +41,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -167,7 +166,7 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 			ImageList:             componentImages,
 			Arch:                  pkg.Metadata.Architecture,
 			RegistryOverrides:     opt.RegistryOverrides,
-			CacheDirectory:        filepath.Join(cachePath, zoci.ImageCacheDirectory),
+			CacheDirectory:        filepath.Join(cachePath, ImageCacheDirectory),
 			PlainHTTP:             config.CommonOptions.PlainHTTP,
 			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 		}
@@ -246,7 +245,7 @@ func CreateSkeleton(ctx context.Context, packagePath string, opt SkeletonCreateO
 	if err != nil {
 		return "", err
 	}
-	pkg.Metadata.Architecture = zoci.SkeletonArch
+	pkg.Metadata.Architecture = SkeletonArch
 
 	buildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {

--- a/src/internal/packager2/layout/import.go
+++ b/src/internal/packager2/layout/import.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 )
 
 func getComponentToImportName(component v1alpha1.ZarfComponent) string {
@@ -99,7 +98,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 				return v1alpha1.ZarfPackage{}, err
 			}
 		} else if component.Import.URL != "" {
-			remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton())
+			remote, err := NewRemote(ctx, component.Import.URL, PlatformForSkeleton())
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
@@ -225,7 +224,7 @@ func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, pac
 	}
 
 	// Get the descriptor for the component.
-	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton())
+	remote, err := NewRemote(ctx, component.Import.URL, PlatformForSkeleton())
 	if err != nil {
 		return "", err
 	}

--- a/src/internal/packager2/layout/oci.go
+++ b/src/internal/packager2/layout/oci.go
@@ -4,23 +4,17 @@
 package layout
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
-	"oras.land/oras-go/v2/content/file"
 	ociDirectory "oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/registry"
 
@@ -95,83 +89,6 @@ func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods 
 	return &Remote{remote}, nil
 }
 
-// Push pushes the given package layout to the remote registry.
-func (r *Remote) Push(ctx context.Context, pkgLayout *PackageLayout, concurrency int) (err error) {
-	logger.From(ctx).Info("pushing package to registry",
-		"destination", r.Repo().Reference.String(),
-		"architecture", pkgLayout.Pkg.Build.Architecture)
-
-	src, err := file.New("")
-	if err != nil {
-		return err
-	}
-	defer func(src *file.Store) {
-		err2 := src.Close()
-		err = errors.Join(err, err2)
-	}(src)
-
-	descs := []ocispec.Descriptor{}
-	files, err := pkgLayout.Files()
-	if err != nil {
-		return err
-	}
-	for path, name := range files {
-		desc, err := src.Add(ctx, name, ZarfLayerMediaTypeBlob, path)
-		if err != nil {
-			return err
-		}
-		descs = append(descs, desc)
-	}
-
-	// Sort by Digest string
-	sort.Slice(descs, func(i, j int) bool {
-		return descs[i].Digest < descs[j].Digest
-	})
-
-	annotations := annotationsFromMetadata(pkgLayout.Pkg.Metadata)
-
-	// Perform the conversion of the string timestamp to the appropriate format in order to maintain backwards compatibility
-
-	t, err := time.Parse(CreateTimestampFormat, pkgLayout.Pkg.Build.Timestamp)
-	if err != nil {
-		// if we change the format of the timestamp, we need to update the conversion here
-		// and also account for an error state for mismatch with older formats
-		return fmt.Errorf("unable to parse timestamp: %w", err)
-	}
-	annotations[ocispec.AnnotationCreated] = t.Format(OCITimestampFormat)
-
-	manifestConfigDesc, err := r.CreateAndPushManifestConfig(ctx, annotations, ZarfConfigMediaType)
-	if err != nil {
-		return err
-	}
-	// here is where the manifest is created and written to the filesystem given the file.store Push() functionality
-	root, err := r.PackAndTagManifest(ctx, src, descs, manifestConfigDesc, annotations)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		// remove the dangling manifest file created by the PackAndTagManifest
-		// should this behavior change, we should expect this to begin producing an error
-		err2 := os.Remove(pkgLayout.Pkg.Metadata.Name)
-		err = errors.Join(err, err2)
-	}()
-
-	copyOpts := r.GetDefaultCopyOpts()
-	copyOpts.Concurrency = concurrency
-	publishedDesc, err := oras.Copy(ctx, src, root.Digest.String(), r.Repo(), "", copyOpts)
-	if err != nil {
-		return err
-	}
-
-	err = r.UpdateIndex(ctx, r.Repo().Reference.Reference, publishedDesc)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ReferenceFromMetadata creates an OCI reference using the package metadata
 func ReferenceFromMetadata(registryLocation string, pkg v1alpha1.ZarfPackage) (string, error) {
 	if len(pkg.Metadata.Version) == 0 {
@@ -225,46 +142,4 @@ func PlatformForSkeleton() ocispec.Platform {
 		OS:           oci.MultiOS,
 		Architecture: SkeletonArch,
 	}
-}
-
-// CopyPackage copies a zarf package from one OCI registry to another
-func CopyPackage(ctx context.Context, src *Remote, dst *Remote, concurrency int) (err error) {
-	l := logger.From(ctx)
-	if concurrency <= 0 {
-		concurrency = DefaultConcurrency
-	}
-
-	srcManifest, err := src.FetchRoot(ctx)
-	if err != nil {
-		return err
-	}
-	l.Info("copying package",
-		"src", src.Repo().Reference.String(),
-		"dst", dst.Repo().Reference.String())
-	if err := oci.Copy(ctx, src.OrasRemote, dst.OrasRemote, nil, concurrency, nil); err != nil {
-		return err
-	}
-
-	srcRoot, err := src.ResolveRoot(ctx)
-	if err != nil {
-		return err
-	}
-
-	b, err := srcManifest.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	expected := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, b)
-
-	if err := dst.Repo().Manifests().PushReference(ctx, expected, bytes.NewReader(b), srcRoot.Digest.String()); err != nil {
-		return err
-	}
-
-	tag := src.Repo().Reference.Reference
-	if err := dst.UpdateIndex(ctx, tag, expected); err != nil {
-		return err
-	}
-
-	src.Log().Info(fmt.Sprintf("Published %s to %s", src.Repo().Reference, dst.Repo().Reference))
-	return nil
 }

--- a/src/internal/packager2/layout/pull.go
+++ b/src/internal/packager2/layout/pull.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package layout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/defenseunicorns/pkg/helpers/v2"
+	"github.com/defenseunicorns/pkg/oci"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/layout"
+	"github.com/zarf-dev/zarf/src/pkg/transform"
+	"github.com/zarf-dev/zarf/src/pkg/utils"
+	"oras.land/oras-go/v2/content/file"
+)
+
+var (
+	// PackageAlwaysPull is a list of paths that will always be pulled from the remote repository.
+	PackageAlwaysPull = []string{layout.ZarfYAML, layout.Checksums, layout.Signature}
+)
+
+// PullPackage pulls the package from the remote repository and saves it to the given path.
+func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurrency int, layersToPull ...ocispec.Descriptor) (_ []ocispec.Descriptor, err error) {
+	// layersToPull is an explicit requirement for pulling package layers
+	if len(layersToPull) == 0 {
+		return nil, fmt.Errorf("no layers to pull")
+	}
+
+	layerSize := oci.SumDescsSize(layersToPull)
+	// TODO (@austinabro321) change this and other r.Log() calls to the proper slog format
+	r.Log().Info(fmt.Sprintf("Pulling %s, size: %s", r.Repo().Reference, utils.ByteFormat(float64(layerSize), 2)))
+
+	dst, err := file.New(destinationDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func(dst *file.Store) {
+		err2 := dst.Close()
+		err = errors.Join(err, err2)
+	}(dst)
+
+	copyOpts := r.GetDefaultCopyOpts()
+	copyOpts.Concurrency = concurrency
+
+	err = r.CopyToTarget(ctx, layersToPull, dst, copyOpts)
+	if err != nil {
+		return nil, err
+	}
+	return layersToPull, nil
+}
+
+// AssembleLayers returns all layers for the given zarf package to pull from OCI.
+func (r *Remote) AssembleLayers(ctx context.Context, requestedComponents []v1alpha1.ZarfComponent, isSkeleton bool, layersSelector LayersSelector) ([]ocispec.Descriptor, error) {
+	layerMap := make(map[LayersSelector][]ocispec.Descriptor, 0)
+
+	// fetching the root manifest is the common denominator for all layers
+	root, err := r.FetchRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store all layers
+	layerMap[AllLayers] = root.Layers
+
+	// We always pull the metadata layers provided we can locate them
+	alwaysPull := make([]ocispec.Descriptor, 0)
+	for _, path := range PackageAlwaysPull {
+		desc := root.Locate(path)
+		if !oci.IsEmptyDescriptor(desc) {
+			alwaysPull = append(alwaysPull, desc)
+		}
+	}
+	layerMap[MetadataLayers] = alwaysPull
+	// component layers are required for standard pulls and manifest inspects
+	pkg, err := r.FetchZarfYAML(ctx)
+	if err != nil {
+		return nil, err
+	}
+	componentLayers, images, err := r.LayersFromComponents(ctx, pkg, requestedComponents)
+	if err != nil {
+		return nil, err
+	}
+	layerMap[ComponentLayers] = componentLayers
+	// there may not be any image layers - let's create the slice such that map key is present
+	imageLayers := make([]ocispec.Descriptor, 0)
+	if len(images) > 0 && !isSkeleton {
+		// images layers are required for standard pulls
+		imageLayers, err = r.LayersFromImages(ctx, images)
+		if err != nil {
+			return nil, err
+		}
+	}
+	layerMap[ImageLayers] = imageLayers
+	// there may not be any sbom layers - let's create the slice such that map key is present
+	sbomLayers := make([]ocispec.Descriptor, 0)
+	sbomsDescriptor := root.Locate(layout.SBOMTar)
+	if !oci.IsEmptyDescriptor(sbomsDescriptor) {
+		sbomLayers = append(sbomLayers, sbomsDescriptor)
+	}
+	layerMap[SbomLayers] = sbomLayers
+
+	return filterLayers(layerMap, layersSelector)
+}
+
+// LayersFromComponents returns the layers for the given components to pull from OCI.
+func (r *Remote) LayersFromComponents(ctx context.Context, pkg v1alpha1.ZarfPackage, requestedComponents []v1alpha1.ZarfComponent) ([]ocispec.Descriptor, map[string]bool, error) {
+	root, err := r.FetchRoot(ctx)
+	if err != nil {
+		return []ocispec.Descriptor{}, map[string]bool{}, err
+	}
+
+	layers := make([]ocispec.Descriptor, 0)
+
+	images := map[string]bool{}
+	tarballFormat := "%s.tar"
+	for _, rc := range requestedComponents {
+		component := helpers.Find(pkg.Components, func(component v1alpha1.ZarfComponent) bool {
+			return component.Name == rc.Name
+		})
+		if component.Name == "" {
+			return nil, nil, fmt.Errorf("component %s does not exist in this package", rc.Name)
+		}
+		for _, image := range component.Images {
+			images[image] = true
+		}
+		desc := root.Locate(filepath.Join(layout.ComponentsDir, fmt.Sprintf(tarballFormat, component.Name)))
+		layers = append(layers, desc)
+	}
+	return layers, images, nil
+}
+
+// LayersFromImages returns the layers for the given images to pull from OCI.
+func (r *Remote) LayersFromImages(ctx context.Context, images map[string]bool) ([]ocispec.Descriptor, error) {
+	root, err := r.FetchRoot(ctx)
+	if err != nil {
+		return []ocispec.Descriptor{}, err
+	}
+
+	index, err := r.FetchImagesIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	layers := make([]ocispec.Descriptor, 0)
+
+	layers = append(layers, root.Locate(layout.IndexPath), root.Locate(layout.OCILayoutPath))
+
+	for image := range images {
+		// use docker's transform lib to parse the image ref
+		// this properly mirrors the logic within create
+		refInfo, err := transform.ParseImageRef(image)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse image ref %q: %w", image, err)
+		}
+
+		manifestDescriptor := helpers.Find(index.Manifests, func(layer ocispec.Descriptor) bool {
+			return layer.Annotations[ocispec.AnnotationBaseImageName] == refInfo.Reference ||
+				// A backwards compatibility shim for older Zarf versions that would leave docker.io off of image annotations
+				(layer.Annotations[ocispec.AnnotationBaseImageName] == refInfo.Path+refInfo.TagOrDigest && refInfo.Host == "docker.io")
+		})
+
+		// even though these are technically image manifests, we store them as Zarf blobs
+		manifestDescriptor.MediaType = ZarfLayerMediaTypeBlob
+
+		manifest, err := r.FetchManifest(ctx, manifestDescriptor)
+		if err != nil {
+			return nil, err
+		}
+
+		layers = append(layers, root.Locate(filepath.Join(layout.ImagesBlobsDir, manifestDescriptor.Digest.Encoded())))
+		layers = append(layers, root.Locate(filepath.Join(layout.ImagesBlobsDir, manifest.Config.Digest.Encoded())))
+
+		for _, layer := range manifest.Layers {
+			layerPath := filepath.Join(layout.ImagesBlobsDir, layer.Digest.Encoded())
+			layers = append(layers, root.Locate(layerPath))
+		}
+	}
+	return layers, nil
+}
+
+// FilterLayers filters the layers based on the LayersSelector.
+func filterLayers(layerMap map[LayersSelector][]ocispec.Descriptor, layersSelector LayersSelector) ([]ocispec.Descriptor, error) {
+	layers := make([]ocispec.Descriptor, 0)
+
+	switch layersSelector {
+	case "":
+		layers = append(layers, layerMap[AllLayers]...)
+	case "sbom":
+		layers = append(layers, layerMap[MetadataLayers]...)
+		layers = append(layers, layerMap[SbomLayers]...)
+	case "metadata":
+		layers = append(layers, layerMap[MetadataLayers]...)
+	case "manifests":
+		layers = append(layers, layerMap[MetadataLayers]...)
+		layers = append(layers, layerMap[ComponentLayers]...)
+	case "components":
+		layers = append(layers, layerMap[MetadataLayers]...)
+		layers = append(layers, layerMap[ComponentLayers]...)
+	case "images":
+		layers = append(layers, layerMap[MetadataLayers]...)
+		layers = append(layers, layerMap[ImageLayers]...)
+	default:
+		return nil, fmt.Errorf("unknown inspect target %s", layersSelector)
+	}
+	return layers, nil
+}
+
+// PullPackageMetadata pulls the package metadata from the remote repository and saves it to `destinationDir`.
+func (r *Remote) PullPackageMetadata(ctx context.Context, destinationDir string) ([]ocispec.Descriptor, error) {
+	return r.PullPaths(ctx, destinationDir, PackageAlwaysPull)
+}
+
+// PullPackageSBOM pulls the package's sboms.tar from the remote repository and saves it to `destinationDir`.
+func (r *Remote) PullPackageSBOM(ctx context.Context, destinationDir string) ([]ocispec.Descriptor, error) {
+	return r.PullPaths(ctx, destinationDir, []string{layout.SBOMTar})
+}
+
+// FetchZarfYAML fetches the zarf.yaml file from the remote repository.
+func (r *Remote) FetchZarfYAML(ctx context.Context) (v1alpha1.ZarfPackage, error) {
+	manifest, err := r.FetchRoot(ctx)
+	if err != nil {
+		return v1alpha1.ZarfPackage{}, err
+	}
+	result, err := oci.FetchYAMLFile[v1alpha1.ZarfPackage](ctx, r.FetchLayer, manifest, layout.ZarfYAML)
+	if err != nil {
+		return v1alpha1.ZarfPackage{}, err
+	}
+	return result, nil
+}
+
+// FetchImagesIndex fetches the images/index.json file from the remote repository.
+func (r *Remote) FetchImagesIndex(ctx context.Context) (*ocispec.Index, error) {
+	manifest, err := r.FetchRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result, err := oci.FetchJSONFile[*ocispec.Index](ctx, r.FetchLayer, manifest, layout.IndexPath)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/src/internal/packager2/layout/pull_test.go
+++ b/src/internal/packager2/layout/pull_test.go
@@ -37,7 +37,7 @@ func createRegistry(t *testing.T, ctx context.Context) registry.Reference { //no
 }
 
 func TestAssembleLayers(t *testing.T) {
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	tt := []struct {
 		name string
 		path string
@@ -45,7 +45,7 @@ func TestAssembleLayers(t *testing.T) {
 	}{
 		{
 			name: "Assemble layers from a package",
-			path: "testdata/basic",
+			path: "testdata/pull/basic",
 			opts: packager2.PublishPackageOpts{
 				WithPlainHTTP: true,
 				Architecture:  "amd64",

--- a/src/internal/packager2/layout/pull_test.go
+++ b/src/internal/packager2/layout/pull_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package layout_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/defenseunicorns/pkg/helpers/v2"
+	"github.com/defenseunicorns/pkg/oci"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/internal/packager2"
+	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
+	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
+	"github.com/zarf-dev/zarf/src/pkg/lint"
+	"github.com/zarf-dev/zarf/src/pkg/zoci"
+	"github.com/zarf-dev/zarf/src/test/testutil"
+	"oras.land/oras-go/v2/registry"
+)
+
+func createRegistry(t *testing.T, ctx context.Context) registry.Reference { //nolint:revive
+	// Setup destination registry
+	dstPort, err := helpers.GetAvailablePort()
+	require.NoError(t, err)
+	dstRegistryURL := testutil.SetupInMemoryRegistry(ctx, t, dstPort)
+	dstRegistryRef := registry.Reference{
+		Registry:   dstRegistryURL,
+		Repository: "my-namespace",
+	}
+
+	return dstRegistryRef
+}
+
+func TestAssembleLayers(t *testing.T) {
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
+	tt := []struct {
+		name string
+		path string
+		opts packager2.PublishPackageOpts
+	}{
+		{
+			name: "Assemble layers from a package",
+			path: "testdata/basic",
+			opts: packager2.PublishPackageOpts{
+				WithPlainHTTP: true,
+				Architecture:  "amd64",
+				Concurrency:   3,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.TestContext(t)
+			registryRef := createRegistry(t, ctx)
+			tmpdir := t.TempDir()
+			config.CommonOptions.CachePath = tmpdir
+
+			// create the package
+			opt := packager2.CreateOptions{
+				Output:         tmpdir,
+				OCIConcurrency: tc.opts.Concurrency,
+			}
+			err := packager2.Create(ctx, tc.path, opt)
+			require.NoError(t, err)
+			src := fmt.Sprintf("%s/%s-%s-0.0.1.tar.zst", tmpdir, "zarf-package-basic-pod", tc.opts.Architecture)
+
+			// Publish test package
+			err = packager2.PublishPackage(ctx, src, registryRef, tc.opts)
+			require.NoError(t, err)
+
+			// We want to pull the package and sure the content is the same as the local package
+			layoutExpected, err := layout.LoadFromTar(ctx, src, layout.PackageLayoutOptions{Filter: filters.Empty()})
+			require.NoError(t, err)
+			// Publish creates a local oci manifest file using the package name, delete this to clean up test name
+			defer os.Remove(layoutExpected.Pkg.Metadata.Name) //nolint:errcheck
+			// Format url and instantiate remote
+			packageRef, err := zoci.ReferenceFromMetadata(registryRef.String(), &layoutExpected.Pkg.Metadata, &layoutExpected.Pkg.Build)
+			require.NoError(t, err)
+
+			platform := oci.PlatformForArch(tc.opts.Architecture)
+			remote, err := zoci.NewRemote(ctx, packageRef, platform, oci.WithPlainHTTP(tc.opts.WithPlainHTTP))
+			require.NoError(t, err)
+
+			// get all layers
+			layers, err := remote.AssembleLayers(ctx, layoutExpected.Pkg.Components, false, zoci.AllLayers)
+			require.NoError(t, err)
+			require.Len(t, layers, 9)
+
+			nonDeterministicLayers := []string{"zarf.yaml", "checksums.txt"}
+
+			// get sbom layers - it appears as though the sbom layers are not deterministic
+			sbomInspectLayers, err := remote.AssembleLayers(ctx, layoutExpected.Pkg.Components, false, zoci.SbomLayers)
+			require.NoError(t, err)
+			require.Len(t, sbomInspectLayers, 3)
+
+			// get image layers
+			expectedImageLayers := []string{"sha256:da324ac903c3287a9ab7f12d10fea0177251ca5d1aae156b293f042a722c414d",
+				"sha256:18f0797eab35a4597c1e9624aa4f15fd91f6254e5538c1e0d193b2a95dd4acc6",
+				"sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474",
+				"sha256:aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b",
+				"sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870"}
+			imageInspectLayers, err := remote.AssembleLayers(ctx, layoutExpected.Pkg.Components, false, zoci.ImageLayers)
+			require.NoError(t, err)
+			require.Len(t, imageInspectLayers, 7)
+			for _, layer := range imageInspectLayers {
+				if !slices.Contains(nonDeterministicLayers, layer.Annotations["org.opencontainers.image.title"]) {
+					t.Logf("Layer: %s, Title: %s", layer.Digest.String(), layer.Annotations["org.opencontainers.image.title"])
+					require.Contains(t, expectedImageLayers, layer.Digest.String())
+				}
+			}
+
+			// get component layers
+			componentLayers, err := remote.AssembleLayers(ctx, layoutExpected.Pkg.Components, false, zoci.ComponentLayers)
+			require.NoError(t, err)
+			require.Len(t, componentLayers, 3)
+		})
+	}
+}

--- a/src/internal/packager2/layout/push.go
+++ b/src/internal/packager2/layout/push.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package layout
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/defenseunicorns/pkg/oci"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/file"
+)
+
+// Push pushes the given package layout to the remote registry.
+func (r *Remote) Push(ctx context.Context, pkgLayout *PackageLayout, concurrency int) (err error) {
+	logger.From(ctx).Info("pushing package to registry",
+		"destination", r.Repo().Reference.String(),
+		"architecture", pkgLayout.Pkg.Build.Architecture)
+
+	src, err := file.New("")
+	if err != nil {
+		return err
+	}
+	defer func(src *file.Store) {
+		err2 := src.Close()
+		err = errors.Join(err, err2)
+	}(src)
+
+	descs := []ocispec.Descriptor{}
+	files, err := pkgLayout.Files()
+	if err != nil {
+		return err
+	}
+	for path, name := range files {
+		desc, err := src.Add(ctx, name, ZarfLayerMediaTypeBlob, path)
+		if err != nil {
+			return err
+		}
+		descs = append(descs, desc)
+	}
+
+	// Sort by Digest string
+	sort.Slice(descs, func(i, j int) bool {
+		return descs[i].Digest < descs[j].Digest
+	})
+
+	annotations := annotationsFromMetadata(pkgLayout.Pkg.Metadata)
+
+	// Perform the conversion of the string timestamp to the appropriate format in order to maintain backwards compatibility
+
+	t, err := time.Parse(CreateTimestampFormat, pkgLayout.Pkg.Build.Timestamp)
+	if err != nil {
+		// if we change the format of the timestamp, we need to update the conversion here
+		// and also account for an error state for mismatch with older formats
+		return fmt.Errorf("unable to parse timestamp: %w", err)
+	}
+	annotations[ocispec.AnnotationCreated] = t.Format(OCITimestampFormat)
+
+	manifestConfigDesc, err := r.CreateAndPushManifestConfig(ctx, annotations, ZarfConfigMediaType)
+	if err != nil {
+		return err
+	}
+	// here is where the manifest is created and written to the filesystem given the file.store Push() functionality
+	root, err := r.PackAndTagManifest(ctx, src, descs, manifestConfigDesc, annotations)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// remove the dangling manifest file created by the PackAndTagManifest
+		// should this behavior change, we should expect this to begin producing an error
+		err2 := os.Remove(pkgLayout.Pkg.Metadata.Name)
+		err = errors.Join(err, err2)
+	}()
+
+	copyOpts := r.GetDefaultCopyOpts()
+	copyOpts.Concurrency = concurrency
+	publishedDesc, err := oras.Copy(ctx, src, root.Digest.String(), r.Repo(), "", copyOpts)
+	if err != nil {
+		return err
+	}
+
+	err = r.UpdateIndex(ctx, r.Repo().Reference.Reference, publishedDesc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CopyPackage copies a zarf package from one OCI registry to another
+func CopyPackage(ctx context.Context, src *Remote, dst *Remote, concurrency int) (err error) {
+	l := logger.From(ctx)
+	if concurrency <= 0 {
+		concurrency = DefaultConcurrency
+	}
+
+	srcManifest, err := src.FetchRoot(ctx)
+	if err != nil {
+		return err
+	}
+	l.Info("copying package",
+		"src", src.Repo().Reference.String(),
+		"dst", dst.Repo().Reference.String())
+	if err := oci.Copy(ctx, src.OrasRemote, dst.OrasRemote, nil, concurrency, nil); err != nil {
+		return err
+	}
+
+	srcRoot, err := src.ResolveRoot(ctx)
+	if err != nil {
+		return err
+	}
+
+	b, err := srcManifest.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	expected := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, b)
+
+	if err := dst.Repo().Manifests().PushReference(ctx, expected, bytes.NewReader(b), srcRoot.Digest.String()); err != nil {
+		return err
+	}
+
+	tag := src.Repo().Reference.Reference
+	if err := dst.UpdateIndex(ctx, tag, expected); err != nil {
+		return err
+	}
+
+	src.Log().Info(fmt.Sprintf("Published %s to %s", src.Repo().Reference, dst.Repo().Reference))
+	return nil
+}

--- a/src/internal/packager2/layout/testdata/pull/basic/pod.yaml
+++ b/src/internal/packager2/layout/testdata/pull/basic/pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: test-pod
+  name: test-pod
+spec:
+  containers:
+  - image: ghcr.io/zarf-dev/images/alpine:3.21.3
+    name: test-pod
+    command: ["sleep", "3600"]
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Always
+status: {}

--- a/src/internal/packager2/layout/testdata/pull/basic/zarf.yaml
+++ b/src/internal/packager2/layout/testdata/pull/basic/zarf.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/zarf-dev/zarf/v0.54.0/zarf.schema.json
+kind: ZarfPackageConfig
+
+metadata:
+  name: basic-pod
+  version: 0.0.1
+  architecture: amd64
+
+components:
+  - name: alpine
+    required: true
+    manifests:
+      - name: alpine
+        namespace: test
+        files:
+          - pod.yaml
+    images:
+      - ghcr.io/zarf-dev/images/alpine:3.21.3

--- a/src/internal/packager2/load.go
+++ b/src/internal/packager2/load.go
@@ -24,7 +24,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/types"
 )
 
@@ -36,7 +35,7 @@ type LoadOptions struct {
 	PublicKeyPath           string
 	SkipSignatureValidation bool
 	Filter                  filters.ComponentFilterStrategy
-	LayersSelector          zoci.LayersSelector
+	LayersSelector          layout.LayersSelector
 	Output                  string
 }
 
@@ -47,7 +46,7 @@ func LoadPackage(ctx context.Context, opt LoadOptions) (_ *layout.PackageLayout,
 	}
 
 	if opt.LayersSelector == "" {
-		opt.LayersSelector = zoci.AllLayers
+		opt.LayersSelector = layout.AllLayers
 	}
 
 	srcType, err := identifySource(opt.Source)
@@ -240,7 +239,7 @@ func assembleSplitTar(src, dest string) (err error) {
 }
 
 // GetPackageFromSourceOrCluster retrieves a Zarf package from a source or cluster.
-func GetPackageFromSourceOrCluster(ctx context.Context, cluster *cluster.Cluster, src string, skipSignatureValidation bool, publicKeyPath string, layerSelector zoci.LayersSelector) (v1alpha1.ZarfPackage, error) {
+func GetPackageFromSourceOrCluster(ctx context.Context, cluster *cluster.Cluster, src string, skipSignatureValidation bool, publicKeyPath string, layerSelector layout.LayersSelector) (v1alpha1.ZarfPackage, error) {
 	srcType, err := identifySource(src)
 	if err != nil {
 		return v1alpha1.ZarfPackage{}, err

--- a/src/internal/packager2/load_test.go
+++ b/src/internal/packager2/load_test.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
+	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -199,11 +199,11 @@ func TestPackageFromSourceOrCluster(t *testing.T) {
 
 	ctx := testutil.TestContext(t)
 
-	_, err := GetPackageFromSourceOrCluster(ctx, nil, "test", false, "", zoci.AllLayers)
+	_, err := GetPackageFromSourceOrCluster(ctx, nil, "test", false, "", layout.AllLayers)
 	require.EqualError(t, err, "cannot get Zarf package from Kubernetes without configuration")
 
 	pkgPath := filepath.Join("testdata", "load-package", "compressed", "zarf-package-test-amd64-0.0.1.tar.zst")
-	pkg, err := GetPackageFromSourceOrCluster(ctx, nil, pkgPath, false, "", zoci.AllLayers)
+	pkg, err := GetPackageFromSourceOrCluster(ctx, nil, pkgPath, false, "", layout.AllLayers)
 	require.NoError(t, err)
 	require.Equal(t, "test", pkg.Metadata.Name)
 
@@ -212,7 +212,7 @@ func TestPackageFromSourceOrCluster(t *testing.T) {
 	}
 	_, err = c.RecordPackageDeployment(ctx, pkg, nil, 1)
 	require.NoError(t, err)
-	pkg, err = GetPackageFromSourceOrCluster(ctx, c, "test", false, "", zoci.AllLayers)
+	pkg, err = GetPackageFromSourceOrCluster(ctx, c, "test", false, "", layout.AllLayers)
 	require.NoError(t, err)
 	require.Equal(t, "test", pkg.Metadata.Name)
 }

--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
+	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 )
@@ -92,7 +93,7 @@ type PullOCIOptions struct {
 	Shasum                  string
 	Architecture            string
 	PublicKeyPath           string
-	LayersSelector          zoci.LayersSelector
+	LayersSelector          layout.LayersSelector
 	SkipSignatureValidation bool
 	Filter                  filters.ComponentFilterStrategy
 	Modifiers               []oci.Modifier
@@ -110,7 +111,7 @@ func pullOCI(ctx context.Context, opts PullOCIOptions) (_ bool, _ string, err er
 		opts.Source = fmt.Sprintf("%s@sha256:%s", opts.Source, opts.Shasum)
 	}
 	platform := oci.PlatformForArch(opts.Architecture)
-	remote, err := zoci.NewRemote(ctx, opts.Source, platform, opts.Modifiers...)
+	remote, err := layout.NewRemote(ctx, opts.Source, platform, opts.Modifiers...)
 	if err != nil {
 		return false, "", err
 	}

--- a/src/internal/packager2/pull.go
+++ b/src/internal/packager2/pull.go
@@ -26,7 +26,6 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
 	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 )
 
 // PullOptions declares optional configuration for a Pull operation.
@@ -258,7 +257,7 @@ func isSkeleton(platform *ocispec.Platform) bool {
 	if platform == nil {
 		return false
 	}
-	skeletonPlatform := zoci.PlatformForSkeleton()
+	skeletonPlatform := layout.PlatformForSkeleton()
 	if platform.Architecture == skeletonPlatform.Architecture && platform.OS == skeletonPlatform.OS {
 		return true
 	}

--- a/src/internal/packager2/pull_test.go
+++ b/src/internal/packager2/pull_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
+	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -125,7 +125,7 @@ func TestSupportsFiltering(t *testing.T) {
 		},
 		{
 			name:     "skeleton platform",
-			platform: &ocispec.Platform{OS: oci.MultiOS, Architecture: zoci.SkeletonArch},
+			platform: &ocispec.Platform{OS: oci.MultiOS, Architecture: layout.SkeletonArch},
 			expected: false,
 		},
 		{

--- a/src/internal/packager2/remove.go
+++ b/src/internal/packager2/remove.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/zoci"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
@@ -21,6 +20,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager2/actions"
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
+	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/types"
 )
@@ -38,7 +38,7 @@ type RemoveOptions struct {
 func Remove(ctx context.Context, opt RemoveOptions) error {
 	l := logger.From(ctx)
 
-	pkg, err := GetPackageFromSourceOrCluster(ctx, opt.Cluster, opt.Source, opt.SkipSignatureValidation, opt.PublicKeyPath, zoci.AllLayers)
+	pkg, err := GetPackageFromSourceOrCluster(ctx, opt.Cluster, opt.Source, opt.SkipSignatureValidation, opt.PublicKeyPath, layout.AllLayers)
 	if err != nil {
 		return fmt.Errorf("unable to load the package: %w", err)
 	}


### PR DESCRIPTION
## Description
This executes on an alternative mentioned in #3872.

Goal is to break the dependency cycle with between src/internal/packager2/layout and src/pkg/zoci

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
