### PR TITLE
chore(docs): add community meeting documentation to project/website

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,16 @@
+# Community
+
+Come say hello! We're on the OpenSSF Slack workspace and hold a community
+meeting on the **every other Tuesday at 2:30 PM ET**.
+
+| Reference                     | Link                                                                                                                                                                                                    |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Website                       | [zarf.dev](https://zarf.dev)                                                                                                                                                                            |
+| Docs Website                  | [docs.zarf.dev](https://docs.zarf.dev)                                                                                                                                                                  |
+| OpenSSF Slack Invite          | [slack.openssf.org](http://slack.openssf.org/)                                                                                                                                                          |
+| OpenSSF Slack Channel         | [#zarf](https://openssf.slack.com/archives/C07AKUMBDMJ)                                                                                                                                                 |
+| Kubernetes Slack Invite       | [kubernetes.slack.com/](https://kubernetes.slack.com/)                                                                                                                                                  |
+| Kubernetes Slack Channel      | [#zarf](https://kubernetes.slack.com/archives/C03B6BJAUJ3)                                                                                                                                              |
+| Mailing List                  | Zarf@lists.openssf.org ([lists](https://lists.openssf.org/g/zarf))                                                                                                                                      |
+| Community Meeting Invite      | [Invite](https://zoom-lfx.platform.linuxfoundation.org/meeting/97461829237?password=add48ad5-fc07-4951-96d2-531b72d2a5dc&invite=true)                                                                   |
+| Community Meeting Notes       | [2025](https://docs.google.com/document/d/1GOjDGYqgQ5EJQmsAxE24MT720w4pum0lYiq8Od5BFrM/edit), [2024](https://docs.google.com/document/d/1Ww5XOICluxIY_bAsyVieLe9GU9FpXJ3LwSCZxqOSLaM/edit?usp=sharing)  |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Using Zarf in GitHub workflows? Check out the [setup-zarf](https://github.com/de
 
 ## 🫶 Our Community
 
-Join us on the [Kubernetes Slack](https://kubernetes.slack.com/) in the [_#zarf_](https://kubernetes.slack.com/archives/C03B6BJAUJ3) channel or the [_#zarf-dev_](https://kubernetes.slack.com/archives/C03BP9Z3CMA) channel! Our active community of developers, users, and contributors are available to answer questions, share examples, and find new ways use Zarf together!
+Join us in our [Community](./COMMUNITY.md) spaces! Our active community of developers, users, and contributors are available to answer questions, share examples, and find new ways use Zarf together!
 
 We are so grateful to our Zarf community for contributing bug fixes and collaborating on new features:
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -5,6 +5,7 @@ tableOfContents: false
 ---
 
 import { LinkCard } from "@astrojs/starlight/components";
+import Community from "../../../../COMMUNITY.md";
 
 ![Zarf Underwater](../../assets/zarf-underwater-behind-rock.svg)
 
@@ -60,3 +61,7 @@ Zarf provides a way to package and deploy software in a way that is **repeatable
 To quickly try out Zarf for yourself see the [Zarf Quick Start](/getting-started)!
 
 :::
+
+<StripH1>
+<Community />
+</StripH1>


### PR DESCRIPTION
## Description

Adding documentation to support where the community artifacts and information can be found - per OpenSSF request. 

Using a separate `COMMUNITY.md` file to support importing it into the website for utility. 

## Related Issue

Fixes #3883

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
