### PR TITLE
refactor: move split file logic to it's own package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,9 +50,6 @@ linters:
         - name: error-strings
         - name: error-naming
         - name: exported
-          severity: warning
-          disabled: false
-          exclude: [""]
           arguments:
             - "disableStutteringCheck"
         - name: if-return

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,11 @@ linters:
         - name: error-strings
         - name: error-naming
         - name: exported
+          severity: warning
+          disabled: false
+          exclude: [""]
+          arguments:
+            - "disableStutteringCheck"
         - name: if-return
         - name: increment-decrement
         - name: var-naming

--- a/src/internal/packager2/layout/assemble.go
+++ b/src/internal/packager2/layout/assemble.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +38,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 // AssembleOptions are the options for creating a package from a package object
@@ -839,115 +837,4 @@ func createReproducibleTarballFromDir(dirPath, dirPrefix, tarballPath string, ov
 
 		return nil
 	})
-}
-
-func splitFile(ctx context.Context, srcPath string, chunkSize int) (err error) {
-	// Remove any existing split files
-	existingChunks, err := filepath.Glob(srcPath + ".part*")
-	if err != nil {
-		return err
-	}
-	for _, chunk := range existingChunks {
-		err := os.Remove(chunk)
-		if err != nil {
-			return err
-		}
-	}
-	srcFile, err := os.Open(srcPath)
-	if err != nil {
-		return err
-	}
-	// Ensure we close our sourcefile, even if we error out.
-	defer func() {
-		err2 := srcFile.Close()
-		// Ignore if file is already closed
-		if !errors.Is(err2, os.ErrClosed) {
-			err = errors.Join(err, err2)
-		}
-	}()
-
-	fi, err := srcFile.Stat()
-	if err != nil {
-		return err
-	}
-
-	hash := sha256.New()
-	fileCount := 0
-	// TODO(mkcp): The inside of this loop should be wrapped in a closure so we can close the destination file each
-	//   iteration as soon as we're done writing.
-	for {
-		path := fmt.Sprintf("%s.part%03d", srcPath, fileCount+1)
-		dstFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
-		if err != nil {
-			return err
-		}
-		defer func(dstFile *os.File) {
-			err2 := dstFile.Close()
-			// Ignore if file is already closed
-			if !errors.Is(err2, os.ErrClosed) {
-				err = errors.Join(err, err2)
-			}
-		}(dstFile)
-
-		written, copyErr := io.CopyN(dstFile, srcFile, int64(chunkSize))
-		if copyErr != nil && !errors.Is(copyErr, io.EOF) {
-			return err
-		}
-
-		_, err = dstFile.Seek(0, io.SeekStart)
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(hash, dstFile)
-		if err != nil {
-			return err
-		}
-
-		// EOF error could be returned on 0 bytes written.
-		if written == 0 {
-			// NOTE(mkcp): We have to close the file before removing it or windows will break with a file-in-use err.
-			err = dstFile.Close()
-			if err != nil {
-				return err
-			}
-			err = os.Remove(path)
-			if err != nil {
-				return err
-			}
-			break
-		}
-
-		fileCount++
-		if errors.Is(copyErr, io.EOF) {
-			break
-		}
-	}
-
-	// Remove original file
-	// NOTE(mkcp): We have to close the file before removing or windows can break with a file-in-use err.
-	err = srcFile.Close()
-	if err != nil {
-		return err
-	}
-	err = os.Remove(srcPath)
-	if err != nil {
-		return err
-	}
-
-	// Write header file
-	data := types.ZarfSplitPackageData{
-		Count:     fileCount,
-		Bytes:     fi.Size(),
-		Sha256Sum: fmt.Sprintf("%x", hash.Sum(nil)),
-	}
-	b, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("unable to marshal the split package data: %w", err)
-	}
-	path := fmt.Sprintf("%s.part000", srcPath)
-	if err := os.WriteFile(path, b, 0644); err != nil {
-		return fmt.Errorf("unable to write the file %s: %w", path, err)
-	}
-	logger.From(ctx).Info("package split across files", "count", fileCount+1)
-	return nil
 }

--- a/src/internal/packager2/layout/assemble_test.go
+++ b/src/internal/packager2/layout/assemble_test.go
@@ -4,16 +4,12 @@
 package layout
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestGetChecksum(t *testing.T) {
@@ -81,110 +77,4 @@ func TestCreateReproducibleTarballFromDir(t *testing.T) {
 	shaSum, err := helpers.GetSHA256OfFile(tarPath)
 	require.NoError(t, err)
 	require.Equal(t, "c09d17f612f241cdf549e5fb97c9e063a8ad18ae7a9f3af066332ed6b38556ad", shaSum)
-}
-
-func TestSplitFile(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name                 string
-		fileSize             int
-		chunkSize            int
-		expectedFileSize     int64
-		expectedLastFileSize int64
-		expectedFileCount    int
-		expectedSha256Sum    string
-	}{
-		{
-			name:                 "split evenly",
-			fileSize:             2048,
-			chunkSize:            16,
-			expectedFileSize:     16,
-			expectedLastFileSize: 16,
-			expectedFileCount:    128,
-			expectedSha256Sum:    "93ecad679eff0df493aaf5d7d615211b0f1d7a919016efb15c98f0b8efb1ba43",
-		},
-		{
-			name:                 "split with remainder",
-			fileSize:             2048,
-			chunkSize:            10,
-			expectedFileSize:     10,
-			expectedLastFileSize: 8,
-			expectedFileCount:    205,
-			expectedSha256Sum:    "fe8460f4d53d3578aa37191acf55b3db7bbcb706056f4b6b02a0c70f24b0d95a",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			dir := t.TempDir()
-			name := "random"
-			p := filepath.Join(dir, name)
-			f, err := os.Create(p)
-			require.NoError(t, err)
-			b := make([]byte, tt.fileSize)
-			for i := range tt.fileSize {
-				b[i] = byte(tt.chunkSize)
-			}
-			require.NoError(t, err)
-			_, err = f.Write(b)
-			require.NoError(t, err)
-			err = f.Close()
-			require.NoError(t, err)
-
-			err = splitFile(context.Background(), p, tt.chunkSize)
-			require.NoError(t, err)
-
-			_, err = os.Stat(p)
-			require.ErrorIs(t, err, os.ErrNotExist)
-			entries, err := os.ReadDir(dir)
-			require.NoError(t, err)
-			require.Len(t, entries, tt.expectedFileCount+1)
-			for i, entry := range entries[1:] {
-				require.Equal(t, fmt.Sprintf("%s.part%03d", name, i+1), entry.Name())
-
-				fi, err := entry.Info()
-				require.NoError(t, err)
-				if i == len(entries)-2 {
-					require.Equal(t, tt.expectedLastFileSize, fi.Size())
-				} else {
-					require.Equal(t, tt.expectedFileSize, fi.Size())
-				}
-			}
-
-			b, err = os.ReadFile(filepath.Join(dir, fmt.Sprintf("%s.part000", name)))
-			require.NoError(t, err)
-			var data types.ZarfSplitPackageData
-			err = json.Unmarshal(b, &data)
-			require.NoError(t, err)
-			require.Equal(t, tt.expectedFileCount, data.Count)
-			require.Equal(t, int64(tt.fileSize), data.Bytes)
-			require.Equal(t, tt.expectedSha256Sum, data.Sha256Sum)
-		})
-	}
-}
-
-func TestSplitDeleteExistingFiles(t *testing.T) {
-	t.Parallel()
-	tempDir := t.TempDir()
-	inputFilename := filepath.Join(tempDir, "testfile.txt")
-	data := make([]byte, 50)
-	err := os.WriteFile(inputFilename, data, 0644)
-	require.NoError(t, err)
-	// Create many fake split files
-	for i := range 15 {
-		f, err := os.Create(fmt.Sprintf("%s.part%03d", inputFilename, i))
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-	}
-
-	chunkSize := 20
-	err = splitFile(context.Background(), inputFilename, chunkSize)
-	require.NoError(t, err)
-
-	entries, err := os.ReadDir(tempDir)
-	require.NoError(t, err)
-	// Verify only header file + 3 data files remain, and not the 15 test split files
-	require.Len(t, entries, 4)
 }

--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
+	"github.com/zarf-dev/zarf/src/internal/split"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -223,7 +224,7 @@ func (p *PackageLayout) Archive(ctx context.Context, dirPath string, maxPackageS
 		if fi.Size()/int64(chunkSize) > 999 {
 			return fmt.Errorf("unable to split the package archive into multiple files: must be less than 1,000 files")
 		}
-		err := splitFile(ctx, tarballPath, chunkSize)
+		err := split.File(ctx, tarballPath, chunkSize)
 		if err != nil {
 			return fmt.Errorf("unable to split the package archive into multiple files: %w", err)
 		}

--- a/src/internal/packager2/layout/package.go
+++ b/src/internal/packager2/layout/package.go
@@ -224,7 +224,7 @@ func (p *PackageLayout) Archive(ctx context.Context, dirPath string, maxPackageS
 		if fi.Size()/int64(chunkSize) > 999 {
 			return fmt.Errorf("unable to split the package archive into multiple files: must be less than 1,000 files")
 		}
-		err := split.File(ctx, tarballPath, chunkSize)
+		err := split.SplitFile(ctx, tarballPath, chunkSize)
 		if err != nil {
 			return fmt.Errorf("unable to split the package archive into multiple files: %w", err)
 		}

--- a/src/internal/packager2/load.go
+++ b/src/internal/packager2/load.go
@@ -98,7 +98,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 		if opts.Output == "" {
 			opts.Output = filepath.Dir(source)
 		}
-		err := split.ReAssembleFile(source, tmpPath)
+		err := split.ReassembleFile(source, tmpPath)
 		if err != nil {
 			return nil, err
 		}

--- a/src/internal/packager2/load.go
+++ b/src/internal/packager2/load.go
@@ -5,14 +5,12 @@ package packager2
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -21,11 +19,11 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager2/filters"
 	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
+	"github.com/zarf-dev/zarf/src/internal/split"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 // LoadOptions are the options for LoadPackage.
@@ -100,7 +98,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 		if opts.Output == "" {
 			opts.Output = filepath.Dir(source)
 		}
-		err := assembleSplitTar(source, tmpPath)
+		err := split.ReAssembleFile(source, tmpPath)
 		if err != nil {
 			return nil, err
 		}
@@ -179,73 +177,6 @@ func identifySource(src string) (string, error) {
 		return "cluster", nil
 	}
 	return "", fmt.Errorf("unknown source %s", src)
-}
-
-// assembleSplitTar reconstructs a split tarball into a single archive.
-func assembleSplitTar(src, dest string) (err error) {
-	pattern := strings.Replace(src, ".part000", ".part*", 1)
-	splitFiles, err := filepath.Glob(pattern)
-	if err != nil {
-		return fmt.Errorf("unable to find split tarball files: %w", err)
-	}
-	if len(splitFiles) == 0 {
-		return fmt.Errorf("no split files with pattern %s found", pattern)
-	}
-	slices.Sort(splitFiles)
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, out.Close())
-	}()
-
-	for i, part := range splitFiles {
-		if i == 0 {
-			// validate metadata
-			data, err := os.ReadFile(part)
-			if err != nil {
-				return err
-			}
-			var meta types.ZarfSplitPackageData
-			err = json.Unmarshal(data, &meta)
-			if err != nil {
-				return err
-			}
-			expected := len(splitFiles) - 1
-			if meta.Count != expected {
-				return fmt.Errorf("split parts mismatch: expected %d, got %d", expected, meta.Count)
-			}
-			continue
-		}
-
-		// Create a new scope for the file so the defer close happens during each loop rather than once the function completes
-		err := func() (err error) {
-			f, err := os.Open(part)
-			if err != nil {
-				return err
-			}
-			defer func() {
-				err = errors.Join(err, f.Close())
-			}()
-
-			_, err = io.Copy(out, f)
-			return err
-		}()
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, file := range splitFiles {
-		err := os.Remove(file)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // GetPackageFromSourceOrCluster retrieves a Zarf package from a source or cluster.

--- a/src/internal/split/split.go
+++ b/src/internal/split/split.go
@@ -142,8 +142,8 @@ func File(ctx context.Context, srcPath string, chunkSize int) (err error) {
 	return nil
 }
 
-// ReAssembleFile reconstructs many split files into a single file then deletes the split files
-func ReAssembleFile(src, dest string) (err error) {
+// ReassembleFile takes a directory containing split files, reassembles those files into the destination, then the split files.
+func ReassembleFile(src, dest string) (err error) {
 	pattern := strings.Replace(src, ".part000", ".part*", 1)
 	splitFiles, err := filepath.Glob(pattern)
 	if err != nil {

--- a/src/internal/split/split.go
+++ b/src/internal/split/split.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package split splits and re-assembles files
+package split
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+)
+
+// FileData contains info about a split file.
+type FileData struct {
+	// The sha256sum of the file
+	Sha256Sum string
+	// The size of the file in bytes
+	Bytes int64
+	// The number of parts the file is split into
+	Count int
+}
+
+// File splits a file into several parts. part000 always holds the split.FileData.
+// The remaining parts hold a chunkSize number of bytes of the original file.
+func File(ctx context.Context, srcPath string, chunkSize int) (err error) {
+	// Remove any existing split files
+	existingChunks, err := filepath.Glob(srcPath + ".part*")
+	if err != nil {
+		return err
+	}
+	for _, chunk := range existingChunks {
+		err := os.Remove(chunk)
+		if err != nil {
+			return err
+		}
+	}
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	// Ensure we close our sourcefile, even if we error out.
+	defer func() {
+		err2 := srcFile.Close()
+		// Ignore if file is already closed
+		if !errors.Is(err2, os.ErrClosed) {
+			err = errors.Join(err, err2)
+		}
+	}()
+
+	fi, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	hash := sha256.New()
+	fileCount := 0
+	// TODO(mkcp): The inside of this loop should be wrapped in a closure so we can close the destination file each
+	//   iteration as soon as we're done writing.
+	for {
+		path := fmt.Sprintf("%s.part%03d", srcPath, fileCount+1)
+		dstFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer func(dstFile *os.File) {
+			err2 := dstFile.Close()
+			// Ignore if file is already closed
+			if !errors.Is(err2, os.ErrClosed) {
+				err = errors.Join(err, err2)
+			}
+		}(dstFile)
+
+		written, copyErr := io.CopyN(dstFile, srcFile, int64(chunkSize))
+		if copyErr != nil && !errors.Is(copyErr, io.EOF) {
+			return err
+		}
+
+		_, err = dstFile.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(hash, dstFile)
+		if err != nil {
+			return err
+		}
+
+		// EOF error could be returned on 0 bytes written.
+		if written == 0 {
+			// NOTE(mkcp): We have to close the file before removing it or windows will break with a file-in-use err.
+			err = dstFile.Close()
+			if err != nil {
+				return err
+			}
+			err = os.Remove(path)
+			if err != nil {
+				return err
+			}
+			break
+		}
+
+		fileCount++
+		if errors.Is(copyErr, io.EOF) {
+			break
+		}
+	}
+
+	// Remove original file
+	// NOTE(mkcp): We have to close the file before removing or windows can break with a file-in-use err.
+	err = srcFile.Close()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(srcPath)
+	if err != nil {
+		return err
+	}
+
+	// Write header file
+	data := FileData{
+		Count:     fileCount,
+		Bytes:     fi.Size(),
+		Sha256Sum: fmt.Sprintf("%x", hash.Sum(nil)),
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("unable to marshal the split package data: %w", err)
+	}
+	path := fmt.Sprintf("%s.part000", srcPath)
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		return fmt.Errorf("unable to write the file %s: %w", path, err)
+	}
+	logger.From(ctx).Info("package split across files", "count", fileCount+1)
+	return nil
+}
+
+// ReAssembleFile reconstructs many split files into a single file then deletes the split files
+func ReAssembleFile(src, dest string) (err error) {
+	pattern := strings.Replace(src, ".part000", ".part*", 1)
+	splitFiles, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("unable to find split tarball files: %w", err)
+	}
+	if len(splitFiles) == 0 {
+		return fmt.Errorf("no split files with pattern %s found", pattern)
+	}
+	slices.Sort(splitFiles)
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, out.Close())
+	}()
+
+	for i, part := range splitFiles {
+		if i == 0 {
+			// validate metadata
+			data, err := os.ReadFile(part)
+			if err != nil {
+				return err
+			}
+			var meta FileData
+			err = json.Unmarshal(data, &meta)
+			if err != nil {
+				return err
+			}
+			expected := len(splitFiles) - 1
+			if meta.Count != expected {
+				return fmt.Errorf("split parts mismatch: expected %d, got %d", expected, meta.Count)
+			}
+			continue
+		}
+
+		// Create a new scope for the file so the defer close happens during each loop rather than once the function completes
+		err := func() (err error) {
+			f, err := os.Open(part)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				err = errors.Join(err, f.Close())
+			}()
+
+			_, err = io.Copy(out, f)
+			return err
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, file := range splitFiles {
+		err := os.Remove(file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/internal/split/split.go
+++ b/src/internal/split/split.go
@@ -19,8 +19,8 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 )
 
-// FileData contains info about a split file.
-type FileData struct {
+// SplitFileMetadata contains info about a split file.
+type SplitFileMetadata struct {
 	// The sha256sum of the file
 	Sha256Sum string
 	// The size of the file in bytes
@@ -29,9 +29,9 @@ type FileData struct {
 	Count int
 }
 
-// File splits a file into several parts. part000 always holds the split.FileData.
+// SplitFile splits a file into several parts. part000 always holds the split.FileData.
 // The remaining parts hold a chunkSize number of bytes of the original file.
-func File(ctx context.Context, srcPath string, chunkSize int) (err error) {
+func SplitFile(ctx context.Context, srcPath string, chunkSize int) (err error) {
 	// Remove any existing split files
 	existingChunks, err := filepath.Glob(srcPath + ".part*")
 	if err != nil {
@@ -125,7 +125,7 @@ func File(ctx context.Context, srcPath string, chunkSize int) (err error) {
 	}
 
 	// Write header file
-	data := FileData{
+	data := SplitFileMetadata{
 		Count:     fileCount,
 		Bytes:     fi.Size(),
 		Sha256Sum: fmt.Sprintf("%x", hash.Sum(nil)),
@@ -169,7 +169,7 @@ func ReassembleFile(src, dest string) (err error) {
 			if err != nil {
 				return err
 			}
-			var meta FileData
+			var meta SplitFileMetadata
 			err = json.Unmarshal(data, &meta)
 			if err != nil {
 				return err

--- a/src/internal/split/split_test.go
+++ b/src/internal/split/split_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+package split
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		fileSize             int
+		chunkSize            int
+		expectedFileSize     int64
+		expectedLastFileSize int64
+		expectedFileCount    int
+		expectedSha256Sum    string
+	}{
+		{
+			name:                 "split evenly",
+			fileSize:             2048,
+			chunkSize:            16,
+			expectedFileSize:     16,
+			expectedLastFileSize: 16,
+			expectedFileCount:    128,
+			expectedSha256Sum:    "93ecad679eff0df493aaf5d7d615211b0f1d7a919016efb15c98f0b8efb1ba43",
+		},
+		{
+			name:                 "split with remainder",
+			fileSize:             2048,
+			chunkSize:            10,
+			expectedFileSize:     10,
+			expectedLastFileSize: 8,
+			expectedFileCount:    205,
+			expectedSha256Sum:    "fe8460f4d53d3578aa37191acf55b3db7bbcb706056f4b6b02a0c70f24b0d95a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			name := "random"
+			p := filepath.Join(dir, name)
+			f, err := os.Create(p)
+			require.NoError(t, err)
+			b := make([]byte, tt.fileSize)
+			for i := range tt.fileSize {
+				b[i] = byte(tt.chunkSize)
+			}
+			require.NoError(t, err)
+			_, err = f.Write(b)
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
+
+			err = File(context.Background(), p, tt.chunkSize)
+			require.NoError(t, err)
+
+			_, err = os.Stat(p)
+			require.ErrorIs(t, err, os.ErrNotExist)
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Len(t, entries, tt.expectedFileCount+1)
+			for i, entry := range entries[1:] {
+				require.Equal(t, fmt.Sprintf("%s.part%03d", name, i+1), entry.Name())
+
+				fi, err := entry.Info()
+				require.NoError(t, err)
+				if i == len(entries)-2 {
+					require.Equal(t, tt.expectedLastFileSize, fi.Size())
+				} else {
+					require.Equal(t, tt.expectedFileSize, fi.Size())
+				}
+			}
+
+			b, err = os.ReadFile(filepath.Join(dir, fmt.Sprintf("%s.part000", name)))
+			require.NoError(t, err)
+			var data FileData
+			err = json.Unmarshal(b, &data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedFileCount, data.Count)
+			require.Equal(t, int64(tt.fileSize), data.Bytes)
+			require.Equal(t, tt.expectedSha256Sum, data.Sha256Sum)
+		})
+	}
+}
+
+func TestSplitDeleteExistingFiles(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	inputFilename := filepath.Join(tempDir, "testfile.txt")
+	data := make([]byte, 50)
+	err := os.WriteFile(inputFilename, data, 0644)
+	require.NoError(t, err)
+	// Create many fake split files
+	for i := range 15 {
+		f, err := os.Create(fmt.Sprintf("%s.part%03d", inputFilename, i))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	chunkSize := 20
+	err = File(context.Background(), inputFilename, chunkSize)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	// Verify only header file + 3 data files remain, and not the 15 test split files
+	require.Len(t, entries, 4)
+}

--- a/src/internal/split/split_test.go
+++ b/src/internal/split/split_test.go
@@ -63,7 +63,7 @@ func TestSplitFile(t *testing.T) {
 			err = f.Close()
 			require.NoError(t, err)
 
-			err = File(context.Background(), p, tt.chunkSize)
+			err = SplitFile(context.Background(), p, tt.chunkSize)
 			require.NoError(t, err)
 
 			_, err = os.Stat(p)
@@ -85,7 +85,7 @@ func TestSplitFile(t *testing.T) {
 
 			b, err = os.ReadFile(filepath.Join(dir, fmt.Sprintf("%s.part000", name)))
 			require.NoError(t, err)
-			var data FileData
+			var data SplitFileMetadata
 			err = json.Unmarshal(b, &data)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedFileCount, data.Count)
@@ -110,7 +110,7 @@ func TestSplitDeleteExistingFiles(t *testing.T) {
 	}
 
 	chunkSize := 20
-	err = File(context.Background(), inputFilename, chunkSize)
+	err = SplitFile(context.Background(), inputFilename, chunkSize)
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(tempDir)

--- a/src/pkg/lint/findings.go
+++ b/src/pkg/lint/findings.go
@@ -9,8 +9,6 @@ import (
 )
 
 // LintError represents an error containing lint findings.
-//
-//nolint:revive // ignore name
 type LintError struct {
 	PackageName string
 	Findings    []PackageFinding

--- a/src/test/e2e/05_tarball_test.go
+++ b/src/test/e2e/05_tarball_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/packager2/layout"
+	"github.com/zarf-dev/zarf/src/internal/split"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestMultiPartPackage(t *testing.T) {
@@ -46,7 +46,7 @@ func TestMultiPartPackage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(20000000), part2FileInfo.Size())
 	// Check the package data is correct
-	pkgData := types.ZarfSplitPackageData{}
+	pkgData := split.FileData{}
 	part0File, err := os.ReadFile(parts[0])
 	require.NoError(t, err)
 	err = json.Unmarshal(part0File, &pkgData)

--- a/src/test/e2e/05_tarball_test.go
+++ b/src/test/e2e/05_tarball_test.go
@@ -46,7 +46,7 @@ func TestMultiPartPackage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(20000000), part2FileInfo.Size())
 	// Check the package data is correct
-	pkgData := split.FileData{}
+	pkgData := split.SplitFileMetadata{}
 	part0File, err := os.ReadFile(parts[0])
 	require.NoError(t, err)
 	err = json.Unmarshal(part0File, &pkgData)


### PR DESCRIPTION
## Description

This moves the split file logic into it's own package, and stops the reliance on the types.ZarfPackageSplitData

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
