### PR TITLE
fix(monitor): mimic k9s init to silence klog errors

### DIFF
--- a/src/cmd/k9s.go
+++ b/src/cmd/k9s.go
@@ -5,11 +5,13 @@
 package cmd
 
 import (
+	"flag"
 	"os"
 
 	k9s "github.com/derailed/k9s/cmd"
 	"github.com/spf13/cobra"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"k8s.io/klog/v2"
 
 	// This allows for go linkname to be used in this file.  Go linkname is used so that we can pull the CLI flags from k9s and generate proper docs for the vendored tool.
 	_ "unsafe"
@@ -23,10 +25,28 @@ func newK9sCommand() *cobra.Command {
 		Use:     "monitor",
 		Aliases: []string{"m", "k9s"},
 		Short:   lang.CmdToolsMonitorShort,
-		Run: func(_ *cobra.Command, _ []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// Hack to make k9s think it's all alone
 			os.Args = []string{os.Args[0]}
+
+			// Mimic k9s/main.go:init()
+			klog.InitFlags(nil)
+			if err := flag.Set("logtostderr", "false"); err != nil {
+				return err
+			}
+			if err := flag.Set("alsologtostderr", "false"); err != nil {
+				return err
+			}
+			if err := flag.Set("stderrthreshold", "fatal"); err != nil {
+				return err
+			}
+			if err := flag.Set("v", "0"); err != nil {
+				return err
+			}
+
 			k9s.Execute()
+
+			return nil
 		},
 	}
 


### PR DESCRIPTION
## Description

This resolves the issue below by reproducing the silence of klog as k9s does in [main.go](https://github.com/derailed/k9s/blob/master/main.go). 

## Related Issue

Fixes #2549 

## Manual Evidence
After: 
![Screenshot 2025-06-10 at 1 00 25 PM](https://github.com/user-attachments/assets/d0888ab7-b7f6-43f8-b25c-b000b8d26668)
Before:
![Screenshot 2025-06-10 at 1 00 50 PM](https://github.com/user-attachments/assets/58ea5274-83bb-4e53-b004-1fbe81db3069)


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
