### PR TITLE
feat(sdk): intuitive default path when using `./zarf` actions

### DIFF
--- a/examples/composable-packages/zarf.yaml
+++ b/examples/composable-packages/zarf.yaml
@@ -36,9 +36,9 @@ components:
       name: baseline
     # Un'name'd Zarf primitives will be appended to the end of the primitive's list for that component.
     actions:
-      onDeploy:
+      onCreate:
         before:
-          - cmd: ./zarf tools kubectl get -n dos-games deployment -o jsonpath={.items[0].metadata.creationTimestamp}
+          - cmd: ./zarf version
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI
 # The `x-mdx` key is used to render the markdown content for https://docs.zarf.dev/ref/examples

--- a/examples/composable-packages/zarf.yaml
+++ b/examples/composable-packages/zarf.yaml
@@ -36,9 +36,9 @@ components:
       name: baseline
     # Un'name'd Zarf primitives will be appended to the end of the primitive's list for that component.
     actions:
-      onCreate:
+      onDeploy:
         before:
-          - cmd: ./zarf version
+          - cmd: ./zarf tools kubectl get -n dos-games deployment -o jsonpath={.items[0].metadata.creationTimestamp}
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI
 # The `x-mdx` key is used to render the markdown content for https://docs.zarf.dev/ref/examples

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 var zarfSchema embed.FS
 
 func main() {
+	// This ensures `./zarf` actions call the current Zarf binary over the system Zarf binary
 	config.ActionsUseSystemZarf = false
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/zarf-dev/zarf/src/cmd"
+	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 )
 
@@ -19,6 +20,7 @@ import (
 var zarfSchema embed.FS
 
 func main() {
+	config.ActionsUseSystemZarf = false
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	signalCh := make(chan os.Signal, 1)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -42,7 +42,7 @@ var (
 	CLIVersion = UnsetCLIVersion
 
 	// ActionsUseSystemZarf sets whether to use Zarf from the system path if Zarf is being used as a library
-	ActionsUseSystemZarf = false
+	ActionsUseSystemZarf = true
 
 	// ActionsCommandZarfPrefix sets a sub command prefix that Zarf commands are under in the current binary if Zarf is being used as a library (and use system Zarf is not specified)
 	ActionsCommandZarfPrefix = ""

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -49,19 +49,20 @@ func GetFinalExecutablePath() (string, error) {
 // GetFinalExecutableCommand returns the final path to the Zarf executable including and library prefixes and overrides.
 func GetFinalExecutableCommand() (string, error) {
 	// In case the binary is symlinked somewhere else, get the final destination
-	zarfCommand, err := GetFinalExecutablePath()
+	executable, err := GetFinalExecutablePath()
 	if err != nil {
 		return "", err
 	}
 
+	// If ActionCommandZarfPrefix is set it takes priority
 	if config.ActionsCommandZarfPrefix != "" {
-		zarfCommand = fmt.Sprintf("%s %s", zarfCommand, config.ActionsCommandZarfPrefix)
+		return fmt.Sprintf("%s %s", executable, config.ActionsCommandZarfPrefix), nil
 	}
 
-	// If a library user has chosen to override config to use system Zarf instead, reset the binary path.
+	// If a library user is calling Zarf we default to using system Zarf otherwise main sets this to false for CLI users
 	if config.ActionsUseSystemZarf {
-		zarfCommand = "zarf"
+		return "zarf", nil
 	}
 
-	return zarfCommand, nil
+	return executable, nil
 }

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -49,14 +49,14 @@ func GetFinalExecutablePath() (string, error) {
 // GetFinalExecutableCommand returns the final path to the Zarf executable including and library prefixes and overrides.
 func GetFinalExecutableCommand() (string, error) {
 	// In case the binary is symlinked somewhere else, get the final destination
-	executable, err := GetFinalExecutablePath()
+	executablePath, err := GetFinalExecutablePath()
 	if err != nil {
 		return "", err
 	}
 
 	// If ActionCommandZarfPrefix is set it takes priority
 	if config.ActionsCommandZarfPrefix != "" {
-		return fmt.Sprintf("%s %s", executable, config.ActionsCommandZarfPrefix), nil
+		return fmt.Sprintf("%s %s", executablePath, config.ActionsCommandZarfPrefix), nil
 	}
 
 	// If a library user is calling Zarf we default to using system Zarf otherwise main sets this to false for CLI users
@@ -64,5 +64,5 @@ func GetFinalExecutableCommand() (string, error) {
 		return "zarf", nil
 	}
 
-	return executable, nil
+	return executablePath, nil
 }

--- a/src/pkg/utils/io_test.go
+++ b/src/pkg/utils/io_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package utils provides generic helper functions.
+package utils
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/config"
+)
+
+// GetFinalExecutableCommand returns the final path to the Zarf executable including and library prefixes and overrides.
+func TestGetFinalExecutableCommand(t *testing.T) {
+	t.Parallel()
+	binaryPath, err := os.Executable()
+	require.NoError(t, err)
+	tests := []struct {
+		name                    string
+		actionCommandZarfPrefix string
+		actionUsesSystemZarf    bool
+		expected                string
+	}{
+		{
+			name:     "using current binary",
+			expected: binaryPath,
+		},
+		{
+			name:                    "using prefix takes priority over actionUsesSystemZarf",
+			actionCommandZarfPrefix: "my-program",
+			expected:                fmt.Sprintf("%s %s", binaryPath, "my-program"),
+			actionUsesSystemZarf:    true,
+		},
+		{
+			name:                 "using actionUsesSystemZarf",
+			actionUsesSystemZarf: true,
+			expected:             "zarf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
+			config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
+			cmd, err := GetFinalExecutableCommand()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, cmd)
+		})
+	}
+}

--- a/src/pkg/utils/io_test.go
+++ b/src/pkg/utils/io_test.go
@@ -41,14 +41,12 @@ func TestGetFinalExecutableCommand(t *testing.T) {
 		},
 	}
 
+	// These test can't run in their own t.Run function, otherwise the binary path changes on windows
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
-			config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
-			cmd, err := GetFinalExecutableCommand()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, cmd)
-		})
+		config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
+		config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
+		cmd, err := GetFinalExecutableCommand()
+		require.NoError(t, err)
+		require.Equal(t, tt.expected, cmd)
 	}
 }

--- a/src/pkg/utils/io_test.go
+++ b/src/pkg/utils/io_test.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ import (
 // GetFinalExecutableCommand returns the final path to the Zarf executable including and library prefixes and overrides.
 func TestGetFinalExecutableCommand(t *testing.T) {
 	t.Parallel()
-	binaryPath, err := os.Executable()
+	executablePath, err := GetFinalExecutablePath()
 	require.NoError(t, err)
 	tests := []struct {
 		name                    string
@@ -26,12 +25,12 @@ func TestGetFinalExecutableCommand(t *testing.T) {
 	}{
 		{
 			name:     "using current binary",
-			expected: binaryPath,
+			expected: executablePath,
 		},
 		{
 			name:                    "using prefix takes priority over actionUsesSystemZarf",
 			actionCommandZarfPrefix: "my-program",
-			expected:                fmt.Sprintf("%s %s", binaryPath, "my-program"),
+			expected:                fmt.Sprintf("%s %s", executablePath, "my-program"),
 			actionUsesSystemZarf:    true,
 		},
 		{
@@ -41,12 +40,14 @@ func TestGetFinalExecutableCommand(t *testing.T) {
 		},
 	}
 
-	// These test can't run in their own t.Run function, otherwise the binary path changes on windows
 	for _, tt := range tests {
-		config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
-		config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
-		cmd, err := GetFinalExecutableCommand()
-		require.NoError(t, err)
-		require.Equal(t, tt.expected, cmd)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
+			config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
+			cmd, err := GetFinalExecutableCommand()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, cmd)
+		})
 	}
 }

--- a/src/pkg/utils/network_test.go
+++ b/src/pkg/utils/network_test.go
@@ -136,7 +136,6 @@ func TestDownloadToFile(t *testing.T) {
 			if tt.shasum != "" {
 				src = strings.Join([]string{src, tt.shasum}, "@")
 			}
-			fmt.Println(src)
 			dst := filepath.Join(t.TempDir(), tt.fileName)
 			err := DownloadToFile(testutil.TestContext(t), src, dst, "")
 			if tt.expectedErr != "" {


### PR DESCRIPTION
## Description

Currently if a library user calls `packager.Create` on a package with an action calling `./zarf` like this
```go
    actions:
      onCreate:
        before:
          - cmd: ./zarf version
```

The command will re run the go program calling the Zarf SDK. This is because actions will call `GetFinalExecutableCommand` to replace `./zarf`, and instead of replacing it with the zarfCLI it will replace it with whatever the go program running the Zarf SDK is. 

There is already an override for this with the `config.ActionsUseSystemZarf` global, but it is set to false by defualt. This PR updates it to be set to true by default, but set to false main() that way by default it will be true for library users and false for CLI users. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
