### PR TITLE
feat(sdk): return final package ref after publish

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1237,7 +1237,8 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 			RemoteOptions:      defaultRemoteOptions(),
 			CachePath:          cachePath,
 		}
-		return packager.PublishSkeleton(ctx, packageSource, dstRef, skeletonOpts)
+		_, err = packager.PublishSkeleton(ctx, packageSource, dstRef, skeletonOpts)
+		return err
 	}
 
 	if helpers.IsOCIURL(packageSource) && pkgConfig.PublishOpts.SigningKeyPath == "" {
@@ -1313,7 +1314,8 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 		RemoteOptions:      defaultRemoteOptions(),
 	}
 
-	return packager.PublishPackage(ctx, pkgLayout, dstRef, publishPackageOpts)
+	_, err = packager.PublishPackage(ctx, pkgLayout, dstRef, publishPackageOpts)
+	return err
 }
 
 type packagePullOptions struct{}

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -75,7 +75,7 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		if err != nil {
 			return "", err
 		}
-		remote, err := zoci.NewRemote(ctx, ref, oci.PlatformForArch(pkgLayout.Pkg.Build.Architecture),
+		remote, err := zoci.NewRemote(ctx, ref.String(), oci.PlatformForArch(pkgLayout.Pkg.Build.Architecture),
 			oci.WithPlainHTTP(opts.PlainHTTP), oci.WithInsecureSkipVerify(opts.InsecureSkipTLSVerify))
 		if err != nil {
 			return "", err
@@ -84,7 +84,7 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		if err != nil {
 			return "", err
 		}
-		packageLocation = ref
+		packageLocation = ref.String()
 	} else {
 		packageLocation, err = pkgLayout.Archive(ctx, output, opts.MaxPackageSizeMB)
 		if err != nil {

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -185,10 +185,11 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 			},
 		})
 	}
-	err = utils.ColorPrintYAML(ex, nil, true)
+	err = utils.ColorPrintYAML(ex, nil, false)
 	if err != nil {
 		return registry.Reference{}, err
 	}
+	l.Info("find more info on skeleton packages at https://docs.zarf.dev/faq/#what-is-a-skeleton-zarf-package")
 	return pkgRef, nil
 }
 

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -30,6 +30,7 @@ type PublishFromOCIOptions struct {
 }
 
 // PublishFromOCI takes a source and destination registry reference and a PublishFromOCIOpts and copies the package from the source to the destination.
+// src and dst are references to the full package ref, E.G. my-registry.com/my-namespace/my-package:0.0.1
 func PublishFromOCI(ctx context.Context, src registry.Reference, dst registry.Reference, opts PublishFromOCIOptions) (err error) {
 	l := logger.From(ctx)
 	start := time.Now()
@@ -86,7 +87,8 @@ type PublishPackageOptions struct {
 	RemoteOptions
 }
 
-// PublishPackage takes a package layout and pushes the package to the given registry. It returns the ref to the pushed package
+// PublishPackage takes a package layout and pushes the package to the given registry.
+// dst is the path to the registry namespace, E.G. my-registry.com/my-namespace. The full package ref is created using the package name and returned
 func PublishPackage(ctx context.Context, pkgLayout *layout.PackageLayout, dst registry.Reference, opts PublishPackageOptions) (string, error) {
 	l := logger.From(ctx)
 
@@ -129,7 +131,8 @@ type PublishSkeletonOptions struct {
 	RemoteOptions
 }
 
-// PublishSkeleton takes a Path to the package definition and uploads a skeleton package to the given a registry. It returns a ref to the skeleton package.
+// PublishSkeleton takes a Path to the package definition and uploads a skeleton package to the given a registry.
+// dst is the path to the registry namespace, E.G. my-registry.com/my-namespace. The full package ref is created using the package name and returned
 func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, opts PublishSkeletonOptions) (string, error) {
 	l := logger.From(ctx)
 

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -33,7 +33,7 @@ type PublishFromOCIOptions struct {
 }
 
 // PublishFromOCI takes a source and destination registry reference and a PublishFromOCIOpts and copies the package from the source to the destination.
-// src and dst are references to the full package ref, E.G. my-registry.com/my-namespace/my-package:0.0.1
+// src and dst are references to the full package ref, e.g. my-registry.com/my-namespace/my-package:0.0.1
 func PublishFromOCI(ctx context.Context, src registry.Reference, dst registry.Reference, opts PublishFromOCIOptions) (err error) {
 	l := logger.From(ctx)
 	start := time.Now()
@@ -91,7 +91,7 @@ type PublishPackageOptions struct {
 }
 
 // PublishPackage takes a package layout and pushes the package to the given registry.
-// dst is the path to the registry namespace, E.G. my-registry.com/my-namespace. The full package ref is created using the package name and returned
+// dst is the path to the registry namespace, e.g. my-registry.com/my-namespace. The full package ref is created using the package name and returned
 func PublishPackage(ctx context.Context, pkgLayout *layout.PackageLayout, dst registry.Reference, opts PublishPackageOptions) (registry.Reference, error) {
 	l := logger.From(ctx)
 
@@ -135,7 +135,7 @@ type PublishSkeletonOptions struct {
 }
 
 // PublishSkeleton takes a Path to the package definition and uploads a skeleton package to the given a registry.
-// dst is the path to the registry namespace, E.G. my-registry.com/my-namespace. The full package ref is created using the package name and returned
+// dst is the path to the registry namespace, e.g. my-registry.com/my-namespace. The full package ref is created using the package name and returned
 func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, opts PublishSkeletonOptions) (registry.Reference, error) {
 	l := logger.From(ctx)
 

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -258,10 +258,10 @@ func TestPublishPackage(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			ref, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			packageRef, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
-			layoutActual := pullFromRemote(ctx, t, ref, "amd64", tc.publicKeyPath, t.TempDir())
+			layoutActual := pullFromRemote(ctx, t, packageRef, "amd64", tc.publicKeyPath, t.TempDir())
 			require.Equal(t, layoutExpected.Pkg, layoutActual.Pkg, "Uploaded package is not identical to downloaded package")
 			if tc.opts.SigningKeyPath != "" {
 				require.FileExists(t, filepath.Join(layoutActual.DirPath(), layout.Signature))
@@ -295,12 +295,12 @@ func TestPublishPackageDeterministic(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			ref, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			packageRef, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			// Attempt to get the digest
 			platform := oci.PlatformForArch(layoutExpected.Pkg.Build.Architecture)
-			remote, err := zoci.NewRemote(ctx, ref, platform, oci.WithPlainHTTP(tc.opts.PlainHTTP))
+			remote, err := zoci.NewRemote(ctx, packageRef, platform, oci.WithPlainHTTP(tc.opts.PlainHTTP))
 			require.NoError(t, err)
 			desc, err := remote.ResolveRoot(ctx)
 			require.NoError(t, err)

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -104,7 +104,7 @@ func TestPublishError(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			err := PublishPackage(context.Background(), tc.packageLayout, tc.ref, tc.opts)
+			_, err := PublishPackage(context.Background(), tc.packageLayout, tc.ref, tc.opts)
 			require.ErrorContains(t, err, tc.expectErr.Error())
 		})
 	}
@@ -191,7 +191,7 @@ func TestPublishSkeleton(t *testing.T) {
 			registryRef := createRegistry(ctx, t)
 
 			// Publish test package
-			err := PublishSkeleton(ctx, tc.path, registryRef, tc.opts)
+			ref, err := PublishSkeleton(ctx, tc.path, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			// Read and unmarshall expected
@@ -203,9 +203,6 @@ func TestPublishSkeleton(t *testing.T) {
 			// This verifies that publish deletes the manifest that is auto created by oras
 			require.NoFileExists(t, expectedPkg.Metadata.Name)
 
-			// Format url and instantiate remote
-			ref, err := zoci.ReferenceFromMetadata(registryRef.String(), expectedPkg)
-			require.NoError(t, err)
 			rmt, err := zoci.NewRemote(ctx, ref, zoci.PlatformForSkeleton(), oci.WithPlainHTTP(true))
 			require.NoError(t, err)
 
@@ -261,14 +258,10 @@ func TestPublishPackage(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			ref, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
-			// Format url and instantiate remote
-			packageRef, err := zoci.ReferenceFromMetadata(registryRef.String(), layoutExpected.Pkg)
-			require.NoError(t, err)
-
-			layoutActual := pullFromRemote(ctx, t, packageRef, "amd64", tc.publicKeyPath, t.TempDir())
+			layoutActual := pullFromRemote(ctx, t, ref, "amd64", tc.publicKeyPath, t.TempDir())
 			require.Equal(t, layoutExpected.Pkg, layoutActual.Pkg, "Uploaded package is not identical to downloaded package")
 			if tc.opts.SigningKeyPath != "" {
 				require.FileExists(t, filepath.Join(layoutActual.DirPath(), layout.Signature))
@@ -302,23 +295,19 @@ func TestPublishPackageDeterministic(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
-			require.NoError(t, err)
-
-			// Format url and instantiate remote
-			packageRef, err := zoci.ReferenceFromMetadata(registryRef.String(), layoutExpected.Pkg)
+			ref, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			// Attempt to get the digest
 			platform := oci.PlatformForArch(layoutExpected.Pkg.Build.Architecture)
-			remote, err := zoci.NewRemote(ctx, packageRef, platform, oci.WithPlainHTTP(tc.opts.PlainHTTP))
+			remote, err := zoci.NewRemote(ctx, ref, platform, oci.WithPlainHTTP(tc.opts.PlainHTTP))
 			require.NoError(t, err)
 			desc, err := remote.ResolveRoot(ctx)
 			require.NoError(t, err)
 			expectedDigest := desc.Digest.String()
 
 			// Re-publish the package to ensure the digest does not change
-			err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			_, err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 			// Publish creates a local oci manifest file using the package name, which gets deleted
 			require.NoFileExists(t, layoutExpected.Pkg.Metadata.Name)
@@ -357,7 +346,7 @@ func TestPublishCopySHA(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			srcRef, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			// Setup destination registry
@@ -365,13 +354,12 @@ func TestPublishCopySHA(t *testing.T) {
 
 			// This gets the test package digest from the first package publish
 			localRepo := &remote.Repository{PlainHTTP: true}
-			ociSrc := fmt.Sprintf("%s/%s", registryRef.String(), "test:0.0.1")
-			localRepo.Reference, err = registry.ParseReference(ociSrc)
+			localRepo.Reference, err = registry.ParseReference(srcRef)
 			require.NoError(t, err)
-			indexDesc, err := oras.Resolve(ctx, localRepo, ociSrc, oras.ResolveOptions{})
+			indexDesc, err := oras.Resolve(ctx, localRepo, srcRef, oras.ResolveOptions{})
 			require.NoError(t, err)
 			src := fmt.Sprintf("%s/%s@%s", registryRef.String(), "test:0.0.1", indexDesc.Digest)
-			srcRef, err := registry.ParseReference(src)
+			srcRefWithDigest, err := registry.ParseReference(src)
 			require.NoError(t, err)
 
 			dst := fmt.Sprintf("%s/%s", dstRegistryRef.String(), "test:0.0.1")
@@ -385,7 +373,7 @@ func TestPublishCopySHA(t *testing.T) {
 			}
 
 			// Publish test package to the destination registry
-			err = PublishFromOCI(ctx, srcRef, dstRef, opts)
+			err = PublishFromOCI(ctx, srcRefWithDigest, dstRef, opts)
 			require.NoError(t, err)
 
 			// This verifies that publish deletes the manifest that is auto created by oras
@@ -427,8 +415,8 @@ func TestPublishCopyTag(t *testing.T) {
 			layoutExpected, err := layout.LoadFromTar(ctx, tc.packageToPublish, layout.PackageLayoutOptions{})
 			require.NoError(t, err)
 
-			// Publish test package
-			err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			// Publish test package FIXME potentially
+			_, err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			dstRegistryRef := createRegistry(ctx, t)

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -358,7 +358,7 @@ func TestPublishCopySHA(t *testing.T) {
 			require.NoError(t, err)
 			indexDesc, err := oras.Resolve(ctx, localRepo, srcRef, oras.ResolveOptions{})
 			require.NoError(t, err)
-			src := fmt.Sprintf("%s/%s@%s", registryRef.String(), "test:0.0.1", indexDesc.Digest)
+			src := fmt.Sprintf("%s@%s", srcRef, indexDesc.Digest)
 			srcRefWithDigest, err := registry.ParseReference(src)
 			require.NoError(t, err)
 
@@ -382,9 +382,9 @@ func TestPublishCopySHA(t *testing.T) {
 			packageRef, err := zoci.ReferenceFromMetadata(dstRegistryRef.String(), layoutExpected.Pkg)
 			require.NoError(t, err)
 
-			pkgRefsha := fmt.Sprintf("%s@%s", packageRef, indexDesc.Digest)
+			pkgRefSha := fmt.Sprintf("%s@%s", packageRef, indexDesc.Digest)
 
-			layoutActual := pullFromRemote(ctx, t, pkgRefsha, layoutExpected.Pkg.Build.Architecture, "", t.TempDir())
+			layoutActual := pullFromRemote(ctx, t, pkgRefSha, layoutExpected.Pkg.Build.Architecture, "", t.TempDir())
 			require.Equal(t, layoutExpected.Pkg, layoutActual.Pkg, "Uploaded package is not identical to downloaded package")
 		})
 	}
@@ -415,14 +415,13 @@ func TestPublishCopyTag(t *testing.T) {
 			layoutExpected, err := layout.LoadFromTar(ctx, tc.packageToPublish, layout.PackageLayoutOptions{})
 			require.NoError(t, err)
 
-			// Publish test package FIXME potentially
-			_, err = PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			// Publish test package
+			srcRef, err := PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			dstRegistryRef := createRegistry(ctx, t)
 
-			src := fmt.Sprintf("%s/%s", registryRef.String(), "test:0.0.1")
-			srcRegistry, err := registry.ParseReference(src)
+			srcRegistry, err := registry.ParseReference(srcRef)
 			require.NoError(t, err)
 			dst := fmt.Sprintf("%s/%s", dstRegistryRef.String(), "test:0.0.1")
 			dstRegistry, err := registry.ParseReference(dst)

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -378,11 +378,8 @@ func TestPublishCopySHA(t *testing.T) {
 
 			// This verifies that publish deletes the manifest that is auto created by oras
 			require.NoFileExists(t, layoutExpected.Pkg.Metadata.Name)
-			// Format url and instantiate remote
-			packageRef, err := zoci.ReferenceFromMetadata(dstRegistryRef.String(), layoutExpected.Pkg)
-			require.NoError(t, err)
 
-			pkgRefSha := fmt.Sprintf("%s@%s", packageRef, indexDesc.Digest)
+			pkgRefSha := fmt.Sprintf("%s@%s", dstRef.String(), indexDesc.Digest)
 
 			layoutActual := pullFromRemote(ctx, t, pkgRefSha, layoutExpected.Pkg.Build.Architecture, "", t.TempDir())
 			require.Equal(t, layoutExpected.Pkg, layoutActual.Pkg, "Uploaded package is not identical to downloaded package")
@@ -439,11 +436,8 @@ func TestPublishCopyTag(t *testing.T) {
 
 			// This verifies that publish deletes the manifest that is auto created by oras
 			require.NoFileExists(t, layoutExpected.Pkg.Metadata.Name)
-			// Format url and instantiate remote
-			packageRef, err := zoci.ReferenceFromMetadata(dstRegistryRef.String(), layoutExpected.Pkg)
-			require.NoError(t, err)
 
-			layoutActual := pullFromRemote(ctx, t, packageRef, layoutExpected.Pkg.Build.Architecture, "", t.TempDir())
+			layoutActual := pullFromRemote(ctx, t, dstRegistry.String(), layoutExpected.Pkg.Build.Architecture, "", t.TempDir())
 
 			require.Equal(t, layoutExpected.Pkg, layoutActual.Pkg, "Uploaded package is not identical to downloaded package")
 		})

--- a/src/pkg/utils/io_test.go
+++ b/src/pkg/utils/io_test.go
@@ -41,8 +41,8 @@ func TestGetFinalExecutableCommand(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		// Tests can't run in parallel since global state is being changed
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			config.ActionsCommandZarfPrefix = tt.actionCommandZarfPrefix
 			config.ActionsUseSystemZarf = tt.actionUsesSystemZarf
 			cmd, err := GetFinalExecutableCommand()

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -12,7 +12,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	ociDirectory "oras.land/oras-go/v2/content/oci"
 )
 
@@ -47,13 +46,10 @@ type Remote struct {
 
 // NewRemote returns an oras remote repository client and context for the given url
 // with zarf opination embedded
-func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
-	l := logger.From(ctx)
-
+func NewRemote(_ context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
 	modifiers := append([]oci.Modifier{
 		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
 		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),
-		oci.WithLogger(l),
 		oci.WithUserAgent("zarf/" + config.CLIVersion),
 	}, mods...)
 	remote, err := oci.NewOrasRemote(url, platform, modifiers...)

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -25,7 +25,7 @@ const (
 	// ZarfLayerMediaTypeBlob is the media type for all Zarf layers due to the range of possible content
 	ZarfLayerMediaTypeBlob = "application/vnd.zarf.layer.v1.blob"
 	// DefaultConcurrency is the default concurrency used for operations
-	DefaultConcurrency = 3
+	DefaultConcurrency = 6
 	// ImageCacheDirectory is the directory within the Zarf cache containing an OCI store
 	ImageCacheDirectory = "images"
 	// AllLayers is the default selector for all layers

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -12,6 +12,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	ociDirectory "oras.land/oras-go/v2/content/oci"
 )
 
@@ -24,7 +25,7 @@ const (
 	// ZarfLayerMediaTypeBlob is the media type for all Zarf layers due to the range of possible content
 	ZarfLayerMediaTypeBlob = "application/vnd.zarf.layer.v1.blob"
 	// DefaultConcurrency is the default concurrency used for operations
-	DefaultConcurrency = 6
+	DefaultConcurrency = 3
 	// ImageCacheDirectory is the directory within the Zarf cache containing an OCI store
 	ImageCacheDirectory = "images"
 	// AllLayers is the default selector for all layers
@@ -46,10 +47,13 @@ type Remote struct {
 
 // NewRemote returns an oras remote repository client and context for the given url
 // with zarf opination embedded
-func NewRemote(_ context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
+func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
+	l := logger.From(ctx)
+
 	modifiers := append([]oci.Modifier{
 		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
 		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),
+		oci.WithLogger(l),
 		oci.WithUserAgent("zarf/" + config.CLIVersion),
 	}, mods...)
 	remote, err := oci.NewOrasRemote(url, platform, modifiers...)

--- a/src/pkg/zoci/copier.go
+++ b/src/pkg/zoci/copier.go
@@ -7,7 +7,6 @@ package zoci
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -53,6 +52,6 @@ func CopyPackage(ctx context.Context, src *Remote, dst *Remote, concurrency int)
 		return err
 	}
 
-	src.Log().Info(fmt.Sprintf("Published %s to %s", src.Repo().Reference, dst.Repo().Reference))
+	l.Info("package copied successfully", "source", src.Repo().Reference, "destination", dst.Repo().Reference)
 	return nil
 }

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -38,7 +38,7 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	}
 
 	layerSize := oci.SumDescsSize(layersToPull)
-	logger.From(ctx).Info("Pulling package", "name", r.Repo().Reference, "size", utils.ByteFormat(float64(layerSize), 2))
+	logger.From(ctx).Info("pulling package", "name", r.Repo().Reference, "size", utils.ByteFormat(float64(layerSize), 2))
 
 	dst, err := file.New(destinationDir)
 	if err != nil {

--- a/src/pkg/zoci/pull.go
+++ b/src/pkg/zoci/pull.go
@@ -14,6 +14,7 @@ import (
 	"github.com/defenseunicorns/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -33,8 +34,7 @@ func (r *Remote) PullPackage(ctx context.Context, destinationDir string, concurr
 	}
 
 	layerSize := oci.SumDescsSize(layersToPull)
-	// TODO (@austinabro321) change this and other r.Log() calls to the proper slog format
-	r.Log().Info(fmt.Sprintf("Pulling %s, size: %s", r.Repo().Reference, utils.ByteFormat(float64(layerSize), 2)))
+	logger.From(ctx).Info("Pulling package", "name", r.Repo().Reference, "size", utils.ByteFormat(float64(layerSize), 2))
 
 	dst, err := file.New(destinationDir)
 	if err != nil {

--- a/src/pkg/zoci/pull_test.go
+++ b/src/pkg/zoci/pull_test.go
@@ -82,7 +82,7 @@ func TestAssembleLayers(t *testing.T) {
 			require.NoError(t, err)
 
 			platform := oci.PlatformForArch(layoutExpected.Pkg.Build.Architecture)
-			remote, err := zoci.NewRemote(ctx, packageRef, platform, oci.WithPlainHTTP(tc.opts.PlainHTTP), cacheModifier)
+			remote, err := zoci.NewRemote(ctx, packageRef.String(), platform, oci.WithPlainHTTP(tc.opts.PlainHTTP), cacheModifier)
 			require.NoError(t, err)
 
 			// get all layers

--- a/src/pkg/zoci/pull_test.go
+++ b/src/pkg/zoci/pull_test.go
@@ -75,14 +75,11 @@ func TestAssembleLayers(t *testing.T) {
 			require.NoError(t, err)
 
 			// Publish test package
-			err = packager.PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
+			packageRef, err := packager.PublishPackage(ctx, layoutExpected, registryRef, tc.opts)
 			require.NoError(t, err)
 
 			// Publish creates a local oci manifest file using the package name, delete this to clean up test name
 			defer os.Remove(layoutExpected.Pkg.Metadata.Name) //nolint:errcheck
-			// Format url and instantiate remote
-			packageRef, err := zoci.ReferenceFromMetadata(registryRef.String(), layoutExpected.Pkg)
-			require.NoError(t, err)
 
 			cacheModifier, err := zoci.GetOCICacheModifier(ctx, tmpdir)
 			require.NoError(t, err)

--- a/src/pkg/zoci/utils.go
+++ b/src/pkg/zoci/utils.go
@@ -15,9 +15,9 @@ import (
 )
 
 // ReferenceFromMetadata returns a reference for the given metadata.
-func ReferenceFromMetadata(registryLocation string, pkg v1alpha1.ZarfPackage) (string, error) {
+func ReferenceFromMetadata(registryLocation string, pkg v1alpha1.ZarfPackage) (registry.Reference, error) {
 	if len(pkg.Metadata.Version) == 0 {
-		return "", errors.New("version is required for publishing")
+		return registry.Reference{}, errors.New("version is required for publishing")
 	}
 	if !strings.HasSuffix(registryLocation, "/") {
 		registryLocation = registryLocation + "/"
@@ -31,9 +31,9 @@ func ReferenceFromMetadata(registryLocation string, pkg v1alpha1.ZarfPackage) (s
 
 	ref, err := registry.ParseReference(raw)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse %s: %w", raw, err)
+		return registry.Reference{}, fmt.Errorf("failed to parse %s: %w", raw, err)
 	}
-	return ref.String(), nil
+	return ref, nil
 }
 
 // GetInitPackageURL returns the URL for the init package for the given version.


### PR DESCRIPTION
## Description

Returns the final path after publish. This makes for a more intuitive experience on the SDK side, where you can publish your package, then use the new reference directly.

It bodes well for this PR that the tests consistently get simplified. Most of the time, in test, after we call this function we put together the ref to do more with it anyway. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
