### PR TITLE
release: fix RC release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,6 @@ jobs:
 
       - name: Setup release ENV vars
         run: |
-          echo TAG=$GITHUB_REF_NAME >> $GITHUB_ENV
-
           K8S_MODULES_VER=$(go list -f '{{.Version}}' -m k8s.io/client-go | sed 's/v//; s/\./ /g')
           echo K8S_MODULES_MAJOR_VER=$(expr $(echo "$K8S_MODULES_VER" | cut -d " " -f 1) + 1) >> $GITHUB_ENV
           echo K8S_MODULES_MINOR_VER=$(echo "$K8S_MODULES_VER" | cut -d " " -f 2) >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ release-init-package:
 ## Build the Zarf CLI for all platforms aligned with the release process
 ## skipping validation here to allow for building with a dirty git state (IE development)
 goreleaser-build:
-	TAG="$(CLI_VERSION)" \
+	GORELEASER_CURRENT_TAG="$(CLI_VERSION)" \
 	K8S_MODULES_VER="$(K8S_MODULES_VER)" \
 	K8S_MODULES_MAJOR_VER="$(K8S_MODULES_MAJOR_VER)" \
 	K8S_MODULES_MINOR_VER="$(K8S_MODULES_MINOR_VER)" \


### PR DESCRIPTION
## Description
Currently there is a problem when executing an RC release. The config.CLIVersion will be set to the RC even when the release process is running on the newer release tag. This likely has something to do with an interaction between `git describe --tag` and the default git configuration in GitHub actions. To avoid this problem, we are setting the tag explicitly using the built in GitHub variable `$GITHUB_REF_NAME` for both make commands and goreleaser.

I cannot do a direct test on a fork, as I have to comment some things out, but I have tried out these changes in my fork, and I was able to run an [RC release](https://github.com/AustinAbro321/zarf/releases/tag/v0.56.9-rc1), then a [regular release](https://github.com/AustinAbro321/zarf/releases/tag/v0.56.9) with what is currently on main in that fork.

I verified locally using that {{ .Version }} is the exact same as {{ .Tag }} minus the v. It's also implied on this page https://goreleaser.com/customization/templates/

Fixes #3726

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
