### PR TITLE
fix: allow access token to be used with `zarf package mirror-resources`

### DIFF
--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -74,7 +74,9 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			Cache:  auth.NewCache(),
 			Credential: auth.StaticCredential(registryURL, auth.Credential{
 				Username: cfg.RegistryInfo.PushUsername,
-				Password: cfg.RegistryInfo.PushPassword,
+				// Set both the password and access token and let oras decide which is correct to use
+				Password:    cfg.RegistryInfo.PushPassword,
+				AccessToken: cfg.RegistryInfo.PushPassword,
 			}),
 		}
 


### PR DESCRIPTION
## Description

I believe oras will automatically determine the correct password to use. I'm not 100% sure though, and I need a way to test that access tokens work.

## Related Issue

Fixes #3915 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
