### PR TITLE
chore: wrap mutex around appending to failed repository updates

### DIFF
--- a/src/cmd/helm/repo_update.go
+++ b/src/cmd/helm/repo_update.go
@@ -123,13 +123,16 @@ func updateCharts(repos []*repo.ChartRepository, out io.Writer, failOnRepoUpdate
 	fmt.Fprintln(out, "Hang tight while we grab the latest from your chart repositories...")
 	var wg sync.WaitGroup
 	var repoFailList []string
+	var repoFailLock sync.Mutex
 	for _, re := range repos {
 		wg.Add(1)
 		go func(re *repo.ChartRepository) {
 			defer wg.Done()
 			if _, err := re.DownloadIndexFile(); err != nil {
 				fmt.Fprintf(out, "...Unable to get an update from the %q chart repository (%s):\n\t%s\n", re.Config.Name, re.Config.URL, err)
+				repoFailLock.Lock()
 				repoFailList = append(repoFailList, re.Config.URL)
+				repoFailLock.Unlock()
 			} else {
 				fmt.Fprintf(out, "...Successfully got an update from the %q chart repository\n", re.Config.Name)
 			}


### PR DESCRIPTION
## Description

Appending to `repoFailList` from multiple goroutines is not concurrency safe, so let's wrap a `sync.Mutex` around the append.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
