### PR TITLE
fix: properly create push auth credentials when registry address includes a repo path 

### DIFF
--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -57,7 +57,7 @@ func Push(ctx context.Context, cfg PushConfig) error {
 		// reset concurrency to user-provided value on each component retry
 		ociConcurrency := cfg.OCIConcurrency
 		var registryRef registry.Reference
-		// Include tunnel connection in case the port forward breaks, for example, a registry pod could spin down / restart
+		// Include tunnel connection in retry loop in case the port forward breaks, for example, a registry pod could spin down / restart
 		var tunnel *cluster.Tunnel
 		if cfg.Cluster != nil {
 			var err error

--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -54,14 +54,9 @@ func Push(ctx context.Context, cfg PushConfig) error {
 	}
 
 	err = retry.Do(func() error {
-		var registryRef registry.Reference
 		// reset concurrency to user-provided value on each component retry
 		ociConcurrency := cfg.OCIConcurrency
-		registryRef, err := parseRegistryReference(cfg.RegistryInfo.Address)
-		if err != nil {
-			return fmt.Errorf("failed to get reference from registry address: %w", err)
-		}
-
+		var registryRef registry.Reference
 		// Include tunnel connection in case the port forward breaks, for example, a registry pod could spin down / restart
 		var tunnel *cluster.Tunnel
 		if cfg.Cluster != nil {
@@ -77,6 +72,11 @@ func Push(ctx context.Context, cfg PushConfig) error {
 			}
 			if tunnel != nil {
 				defer tunnel.Close()
+			}
+		} else {
+			registryRef, err = parseRegistryReference(cfg.RegistryInfo.Address)
+			if err != nil {
+				return fmt.Errorf("failed to get reference from registry address: %w", err)
 			}
 		}
 

--- a/src/internal/packager/images/push_test.go
+++ b/src/internal/packager/images/push_test.go
@@ -5,6 +5,8 @@
 package images
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -12,6 +14,9 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/test/testutil"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry"
+	orasRemote "oras.land/oras-go/v2/registry/remote"
 )
 
 func TestPush(t *testing.T) {
@@ -21,6 +26,7 @@ func TestPush(t *testing.T) {
 		SourceDirectory string
 		imageNames      []string
 		expectErr       bool
+		namespace       string
 	}{
 		{
 			name: "push local images oras",
@@ -48,13 +54,19 @@ func TestPush(t *testing.T) {
 				"hello-world@sha256:03b62250a3cb1abd125271d393fc08bf0cc713391eda6b57c02d1ef85efcc25c",
 			},
 		},
+		{
+			name:            "push image to namespace",
+			SourceDirectory: "testdata/oras-oci-layout/images",
+			imageNames: []string{
+				"local-test:1.0.0",
+			},
+			namespace: "my-namespace",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// Push overwrites the index, this code sets it back directory
+			// Push overwrites the index, this code sets it back, this means we can't run these tests in parallel
 			idx, err := getIndexFromOCILayout(tc.SourceDirectory)
 			require.NoError(t, err)
 			defer func() {
@@ -65,6 +77,9 @@ func TestPush(t *testing.T) {
 			port, err := helpers.GetAvailablePort()
 			require.NoError(t, err)
 			address := testutil.SetupInMemoryRegistry(ctx, t, port)
+			if tc.namespace != "" {
+				address = fmt.Sprintf("%s/%s", address, tc.namespace)
+			}
 			imageList := []transform.Image{}
 			regInfo := state.RegistryInfo{
 				Address: address,
@@ -92,6 +107,26 @@ func TestPush(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+
+			// Verify all images are in the repo
+			for _, image := range tc.imageNames {
+				checksumRef, err := transform.ImageTransformHost(address, image)
+				require.NoError(t, err)
+				verifyImageExists(ctx, t, checksumRef)
+				ref, err := transform.ImageTransformHostWithoutChecksum(address, image)
+				require.NoError(t, err)
+				verifyImageExists(ctx, t, ref)
+			}
 		})
 	}
+}
+
+func verifyImageExists(ctx context.Context, t *testing.T, ref string) {
+	repo := &orasRemote.Repository{}
+	var err error
+	repo.Reference, err = registry.ParseReference(ref)
+	require.NoError(t, err)
+	repo.PlainHTTP = true
+	_, err = oras.Resolve(ctx, repo, ref, oras.DefaultResolveOptions)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

We were allowing users to give a path to oras auth that looks like `registry.com/my-namespace`, but when you give anything more than the host to the oras auth client it breaks. 

## Related Issue

Fixes #3915 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
