### PR TITLE
fix: exempt packages from revive var-naming linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -55,6 +55,10 @@ linters:
         - name: if-return
         - name: increment-decrement
         - name: var-naming
+          arguments:
+            - [] # allowlist
+            - [] # blocklist
+            - [{skipPackageNameChecks: true}] # options map
         - name: var-declaration
         - name: package-comments
         - name: range


### PR DESCRIPTION
## Description
This PR is intended to address a new linter rule that popped up in latest golangci-lint, v2.2.1. "meaningless" package names like util, types, etc. are now flagged as a code smell / linter rule error. As much as I'd agree with this, it's an intentional and managed decision in the Zarf codebase at the moment. This PR adds an ignore rule for package names, with the intent to remove it in the future when we're done breaking types and utils out into packages with more meaningful names.

I did try specific allowlist rules for `types` and `utils` but the linter error kept flagging so maybe the allowlist doesn't work for packages? Either way, `skipPackageNameChecks: true` solves the issue locally.

## Related Issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
