### PR TITLE
fix!: allow creation of differential package from OCI source

### DIFF
--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
 
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
@@ -51,15 +52,31 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		return "", err
 	}
 
+	var differntialPkg v1alpha1.ZarfPackage
+	if opts.DifferentialPackagePath != "" {
+		pkgLayout, err := LoadPackage(ctx, opts.DifferentialPackagePath, LoadOptions{
+			Architecture:            pkg.Metadata.Architecture,
+			RemoteOptions:           opts.RemoteOptions,
+			LayersSelector:          zoci.MetadataLayers,
+			OCIConcurrency:          opts.OCIConcurrency,
+			CachePath:               opts.CachePath,
+			SkipSignatureValidation: true,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to load differential package: %w", err)
+		}
+		differntialPkg = pkgLayout.Pkg
+	}
+
 	assembleOpt := layout.AssembleOptions{
-		SkipSBOM:                opts.SkipSBOM,
-		OCIConcurrency:          opts.OCIConcurrency,
-		DifferentialPackagePath: opts.DifferentialPackagePath,
-		Flavor:                  opts.Flavor,
-		RegistryOverrides:       opts.RegistryOverrides,
-		SigningKeyPath:          opts.SigningKeyPath,
-		SigningKeyPassword:      opts.SigningKeyPassword,
-		CachePath:               opts.CachePath,
+		SkipSBOM:            opts.SkipSBOM,
+		OCIConcurrency:      opts.OCIConcurrency,
+		DifferentialPackage: differntialPkg,
+		Flavor:              opts.Flavor,
+		RegistryOverrides:   opts.RegistryOverrides,
+		SigningKeyPath:      opts.SigningKeyPath,
+		SigningKeyPassword:  opts.SigningKeyPassword,
+		CachePath:           opts.CachePath,
 	}
 	pkgLayout, err := layout.AssemblePackage(ctx, pkg, packagePath, assembleOpt)
 	if err != nil {

--- a/src/pkg/packager/create_test.go
+++ b/src/pkg/packager/create_test.go
@@ -20,12 +20,10 @@ func TestPackageCreatePublishArch(t *testing.T) {
 		name         string
 		path         string
 		expectedArch string
-		packageName  string
 	}{
 		{
 			name:         "should use pkg.metadata.architecture when global arch not set",
 			path:         filepath.Join("testdata", "create", "create-publish-arch"),
-			packageName:  "create-arch",
 			expectedArch: "amd64",
 		},
 	}
@@ -47,28 +45,32 @@ func TestPackageCreateDifferentialOCIPackage(t *testing.T) {
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
 	tests := []struct {
-		name         string
-		path         string
-		expectedArch string
-		packageName  string
+		name           string
+		newPackagePath string
+		oldPackagePath string
 	}{
 		{
-			name:         "differential OCI package",
-			path:         filepath.Join("testdata", "create", "create-publish-arch"),
-			packageName:  "create-arch",
-			expectedArch: "amd64",
+			name:           "differential package builds from OCI source",
+			oldPackagePath: filepath.Join("testdata", "create", "differential", "older-version"),
+			newPackagePath: filepath.Join("testdata", "create", "differential"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := createRegistry(ctx, t)
-			packageSource, err := Create(ctx, tt.path, fmt.Sprintf("oci://%s", reg.String()), CreateOptions{
+			packageSource, err := Create(ctx, tt.oldPackagePath, fmt.Sprintf("oci://%s", reg.String()), CreateOptions{
 				RemoteOptions: defaultTestRemoteOptions(),
 			})
 			require.NoError(t, err)
-			layout := pullFromRemote(ctx, t, packageSource, tt.expectedArch, "", t.TempDir())
-			require.Equal(t, tt.expectedArch, layout.Pkg.Metadata.Architecture)
+			tmpdir := t.TempDir()
+			newPackageSource, err := Create(ctx, tt.newPackagePath, tmpdir, CreateOptions{
+				DifferentialPackagePath: fmt.Sprintf("oci://%s", packageSource),
+				RemoteOptions:           defaultTestRemoteOptions(),
+				CachePath:               t.TempDir(),
+			})
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(tmpdir, "zarf-package-differential-test-amd64-0.0.1-differential-0.0.2.tar.zst"), newPackageSource)
 		})
 	}
 }

--- a/src/pkg/packager/create_test.go
+++ b/src/pkg/packager/create_test.go
@@ -42,3 +42,33 @@ func TestPackageCreatePublishArch(t *testing.T) {
 		})
 	}
 }
+
+func TestPackageCreateDifferentialOCIPackage(t *testing.T) {
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
+	ctx := testutil.TestContext(t)
+	tests := []struct {
+		name         string
+		path         string
+		expectedArch string
+		packageName  string
+	}{
+		{
+			name:         "differential OCI package",
+			path:         filepath.Join("testdata", "create", "create-publish-arch"),
+			packageName:  "create-arch",
+			expectedArch: "amd64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := createRegistry(ctx, t)
+			packageSource, err := Create(ctx, tt.path, fmt.Sprintf("oci://%s", reg.String()), CreateOptions{
+				RemoteOptions: defaultTestRemoteOptions(),
+			})
+			require.NoError(t, err)
+			layout := pullFromRemote(ctx, t, packageSource, tt.expectedArch, "", t.TempDir())
+			require.Equal(t, tt.expectedArch, layout.Pkg.Metadata.Architecture)
+		})
+	}
+}

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -49,9 +49,9 @@ type AssembleOptions struct {
 	SigningKeyPath     string
 	SigningKeyPassword string
 	SkipSBOM           bool
-	// DifferentialPackagePath causes a differential package to be created that only contains images and repos not included in the package at the given path
-	DifferentialPackagePath string
-	OCIConcurrency          int
+	// When DifferentialPackage is set the zarf package created only includes images and repos not in the differential package
+	DifferentialPackage v1alpha1.ZarfPackage
+	OCIConcurrency      int
 	// CachePath is the path to the Zarf cache, used to cache images
 	CachePath string
 }
@@ -61,18 +61,11 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 	l := logger.From(ctx)
 	l.Info("assembling package", "path", packagePath)
 
-	if opts.DifferentialPackagePath != "" {
-		l.Debug("creating differential package", "differential", opts.DifferentialPackagePath)
-		layoutOpts := PackageLayoutOptions{
-			SkipSignatureValidation: true,
-		}
-		diffPkgLayout, err := LoadFromTar(ctx, opts.DifferentialPackagePath, layoutOpts)
-		if err != nil {
-			return nil, err
-		}
+	if opts.DifferentialPackage.Metadata.Name != "" {
+		l.Debug("creating differential package", "differential", opts.DifferentialPackage)
 		allIncludedImagesMap := map[string]bool{}
 		allIncludedReposMap := map[string]bool{}
-		for _, component := range diffPkgLayout.Pkg.Components {
+		for _, component := range opts.DifferentialPackage.Components {
 			for _, image := range component.Images {
 				allIncludedImagesMap[image] = true
 			}
@@ -82,17 +75,18 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		}
 
 		pkg.Build.Differential = true
-		pkg.Build.DifferentialPackageVersion = diffPkgLayout.Pkg.Metadata.Version
+		pkg.Build.DifferentialPackageVersion = opts.DifferentialPackage.Metadata.Version
 
-		versionsMatch := diffPkgLayout.Pkg.Metadata.Version == pkg.Metadata.Version
+		versionsMatch := opts.DifferentialPackage.Metadata.Version == pkg.Metadata.Version
 		if versionsMatch {
 			return nil, errors.New(lang.PkgCreateErrDifferentialSameVersion)
 		}
-		noVersionSet := diffPkgLayout.Pkg.Metadata.Version == "" || pkg.Metadata.Version == ""
+		noVersionSet := opts.DifferentialPackage.Metadata.Version == "" || pkg.Metadata.Version == ""
 		if noVersionSet {
 			return nil, errors.New(lang.PkgCreateErrDifferentialNoVersion)
 		}
 		filter := filters.ByDifferentialData(allIncludedImagesMap, allIncludedReposMap)
+		var err error
 		pkg.Components, err = filter.Apply(pkg)
 		if err != nil {
 			return nil, err

--- a/src/pkg/packager/testdata/create/differential/older-version/zarf.yaml
+++ b/src/pkg/packager/testdata/create/differential/older-version/zarf.yaml
@@ -1,0 +1,8 @@
+kind: ZarfPackageConfig
+metadata:
+  name: differential-test
+  architecture: amd64
+  version: 0.0.1
+
+components:
+  - name: simple-component

--- a/src/pkg/packager/testdata/create/differential/zarf.yaml
+++ b/src/pkg/packager/testdata/create/differential/zarf.yaml
@@ -1,0 +1,8 @@
+kind: ZarfPackageConfig
+metadata:
+  name: differential-test
+  architecture: amd64
+  version: 0.0.2
+
+components:
+  - name: simple-component


### PR DESCRIPTION
## Description

There is a regression which blocks users from making a differential package from an OCI source. 

This does include a breaking change in the SDK for `layout.assemblePackage`. It's possible to keep this backwards compatible, but IMO it makes sense to change the field here given that:
- Callers are much more likely to call `packager2.create` which still accepts a source, than the more granular `layout.assemblePackage`
- It's simple to get the package definition before `layout.assemblePackage` with `packager2.LoadPackage`

## Related Issue

Fixes #3960

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
