### PR TITLE
fix(mirror): separate artifact upload by component

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -346,7 +346,9 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 
 	if hasImages {
 		imagePushOpts := ImagePushOptions{
-			Cluster:         d.c,
+			Cluster: d.c,
+			// we only want to push the images for this single component
+			Components:      []v1alpha1.ZarfComponent{component},
 			NoImageChecksum: noImgChecksum,
 			OCIConcurrency:  opts.OCIConcurrency,
 			Retries:         opts.Retries,
@@ -361,7 +363,9 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	if hasRepos {
 		repoPushOptions := RepoPushOptions{
 			Cluster: d.c,
-			Retries: opts.Retries,
+			// we only want to push the images for this single component
+			Components: []v1alpha1.ZarfComponent{component},
+			Retries:    opts.Retries,
 		}
 		if err := PushReposToRepository(ctx, pkgLayout, d.s.GitServer, repoPushOptions); err != nil {
 			return nil, fmt.Errorf("unable to push the repos to the repository: %w", err)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -363,7 +363,7 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	if hasRepos {
 		repoPushOptions := RepoPushOptions{
 			Cluster: d.c,
-			// we only want to push the images for this single component
+			// we only want to push the repositories for this single component
 			Components: []v1alpha1.ZarfComponent{component},
 			Retries:    opts.Retries,
 		}

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -87,15 +87,15 @@ func PushImagesToRegistry(ctx context.Context, pkgLayout *layout.PackageLayout, 
 	return nil
 }
 
-// RepoPushOptions are optional parameters to push images in a zarf package to a registry
+// RepoPushOptions are optional parameters to push repos in a zarf package to a Git server
 type RepoPushOptions struct {
 	Cluster *cluster.Cluster
-	// Components is a list of components to push images for
+	// Components is a list of components to push repos
 	Components []v1alpha1.ZarfComponent
 	Retries    int
 }
 
-// PushReposToRepository pushes Git repositories in the package layout to the registry
+// PushReposToRepository pushes Git repositories in the package layout to the Git server
 func PushReposToRepository(ctx context.Context, pkgLayout *layout.PackageLayout, gitInfo state.GitServerInfo, opts RepoPushOptions) (err error) {
 	if pkgLayout == nil {
 		return fmt.Errorf("package layout is required")


### PR DESCRIPTION
## Description

Adds an option to `ImagePushOptions` and `RepoPushOptions` to specify a slice of components to include. Library users can then coordinate their preferred behavior. Default (not-specified) is to include all components - which aligns with current use in the `mirror-resources` command. Otherwise deploy now specifies a single component to perform the desired behavior. 

## Related Issue

Fixes #3964

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
