### PR TITLE
fix: identify file type using filename instead of mholt/archives auto detection

### DIFF
--- a/src/pkg/archive/archive.go
+++ b/src/pkg/archive/archive.go
@@ -193,7 +193,7 @@ func withArchive(ctx context.Context, path string, fn func(ex archives.Extractor
 	}
 	defer func() { err = errors.Join(err, f.Close()) }()
 
-	format, input, err := archives.Identify(ctx, filepath.Base(path), f)
+	format, _, err := archives.Identify(ctx, filepath.Base(path), nil)
 	if err != nil {
 		return fmt.Errorf("identifying %q: %w", path, err)
 	}
@@ -201,7 +201,7 @@ func withArchive(ctx context.Context, path string, fn func(ex archives.Extractor
 	if !ok {
 		return fmt.Errorf("format %T cannot extract", format)
 	}
-	return fn(ex, input)
+	return fn(ex, f)
 }
 
 // unarchive extracts all entries from src into dst using the defaultHandler.

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mholt/archives"
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -288,6 +289,7 @@ func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, pac
 	decompressOpts := archive.DecompressOpts{
 		OverwriteExisting: true,
 		StripComponents:   1,
+		Extractor:         archives.Tar{},
 	}
 	err = archive.Decompress(ctx, tarball, dir, decompressOpts)
 	if err != nil {


### PR DESCRIPTION
## Description

mholt/archives auto detection has been unreliable. Changing the code to instead detect the format using the filename

Fixes #3917

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
