### PR TITLE
feat!(deploy): support return of package VariableConfig

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -322,7 +322,7 @@ func deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts packager.
 		return nil, err
 	}
 
-	deployedComponents, err := packager.Deploy(ctx, pkgLayout, opts)
+	deployedComponents, _, err := packager.Deploy(ctx, pkgLayout, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy package: %w", err)
 	}

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -322,12 +322,12 @@ func deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts packager.
 		return nil, err
 	}
 
-	deployedComponents, _, err := packager.Deploy(ctx, pkgLayout, opts)
+	result, err := packager.Deploy(ctx, pkgLayout, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy package: %w", err)
 	}
 
-	return deployedComponents, nil
+	return result.DeployedComponents, nil
 }
 
 func confirmDeploy(ctx context.Context, pkgLayout *layout.PackageLayout, setVariables map[string]string) (err error) {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -70,14 +70,20 @@ type deployer struct {
 	hpaModified bool
 }
 
+// DeployResult is the result of a successful deploy
+type DeployResult struct {
+	DeployedComponents []state.DeployedComponent
+	VariableConfig     *variables.VariableConfig
+}
+
 // Deploy takes a reference to a `layout.PackageLayout` and deploys the package. If successful, returns a list of components that were successfully deployed and the associated variable config.
-func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOptions) ([]state.DeployedComponent, *variables.VariableConfig, error) {
+func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOptions) (DeployResult, error) {
 	l := logger.From(ctx)
 	l.Info("starting deploy", "package", pkgLayout.Pkg.Metadata.Name)
 	start := time.Now()
 	if opts.NamespaceOverride != "" {
 		if err := OverridePackageNamespace(pkgLayout.Pkg, opts.NamespaceOverride); err != nil {
-			return nil, nil, err
+			return DeployResult{}, err
 		}
 	}
 
@@ -90,7 +96,7 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 
 	variableConfig, err := getPopulatedVariableConfig(ctx, pkgLayout.Pkg, opts.SetVariables)
 	if err != nil {
-		return nil, nil, err
+		return DeployResult{}, err
 	}
 
 	d := deployer{
@@ -103,13 +109,19 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 
 	deployedComponents, err := d.deployComponents(ctx, pkgLayout, opts)
 	if err != nil {
-		return nil, nil, err
+		return DeployResult{}, err
 	}
 	if len(deployedComponents) == 0 {
 		l.Warn("no components were selected for deployment. Inspect the package to view the available components and select components interactively or by name with \"--components\"")
 	}
 	l.Debug("deployment complete", "duration", time.Since(start))
-	return deployedComponents, d.vc, nil
+
+	// assemble the result
+	deployResult := DeployResult{
+		DeployedComponents: deployedComponents,
+		VariableConfig:     d.vc,
+	}
+	return deployResult, nil
 }
 
 func (d *deployer) resetRegistryHPA(ctx context.Context) {


### PR DESCRIPTION
## Description

This change modifies the signature of `packager.Deploy()` to return the `VariableConfig` of the package deployed. 

## Related Issue

Fixes #3975


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
