### PR TITLE
feat(deploy): actions setVariables to deployed component

### DIFF
--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -268,7 +268,8 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 	}
 
 	onCreate := component.Actions.OnCreate
-	if err := actions2.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil); err != nil {
+	_, err = actions2.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil)
+	if err != nil {
 		return fmt.Errorf("unable to run component before action: %w", err)
 	}
 
@@ -443,7 +444,8 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 		}
 	}
 
-	if err := actions2.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil); err != nil {
+	_, err = actions2.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil)
+	if err != nil {
 		return fmt.Errorf("unable to run component after action: %w", err)
 	}
 

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -79,7 +79,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 		}
 
 		err := func() error {
-			err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil)
+			_, err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil)
 			if err != nil {
 				return fmt.Errorf("unable to run the before action: %w", err)
 			}
@@ -120,11 +120,11 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 				}
 			}
 
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil)
+			_, err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil)
 			if err != nil {
 				return fmt.Errorf("unable to run the after action: %w", err)
 			}
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil)
+			_, err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil)
 			if err != nil {
 				return fmt.Errorf("unable to run the success action: %w", err)
 			}
@@ -141,7 +141,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 			return nil
 		}()
 		if err != nil {
-			removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil)
+			_, removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil)
 			if removeErr != nil {
 				return errors.Join(fmt.Errorf("unable to run the failure action: %w", err), removeErr)
 			}

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -410,6 +410,8 @@ type DeployedComponent struct {
 	InstalledCharts    []InstalledChart `json:"installedCharts"`
 	Status             ComponentStatus  `json:"status"`
 	ObservedGeneration int              `json:"observedGeneration"`
+	// [ALPHA] optional map containing variables set during component deployment
+	SetVariablesMap map[string]*v1alpha1.SetVariable
 }
 
 // InstalledChart contains information about a Helm Chart that has been deployed to a cluster.


### PR DESCRIPTION
## Description

Separate implementation of including variables set during component actions. 

`packager.Deploy()` returns a slice of `DeployedComponents`. If we were to add additional information to the deployment process for each component - then we could include that natively in the return. 

This modifies the signature of the `actions` package functions to support returning variables set such that they can be used on a component-by-component basis or aggregated for a whole package after deployment. 
## Related Issue

Fixes #3975 
## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
