### PR TITLE
fix(release): correct GitHub environment variable syntax for GoReleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}
-          GORELEASER_CURRENT_TAG: $GITHUB_REF_NAME
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Report disk space on failure
         if: failure()


### PR DESCRIPTION
## Description

The release workflow has incorrect actions syntax for setting an env variable

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
