### PR TITLE
feat(site): add Word List back into style-guide.mdx

### DIFF
--- a/site/src/content/docs/contribute/style-guide.mdx
+++ b/site/src/content/docs/contribute/style-guide.mdx
@@ -213,3 +213,18 @@ If you're going to use jargon, consider the following questions:
 - **Can you write around the term?** If you don't need the term for search engine optimization (SEO), try writing around it. For example, instead of writing Hold a post-mortem, write When the project is finished, review what processes worked or didn't work. Instead of writing Create a back-of-the-envelope design, write Use an informal design process.
 - **Are you using the term only once in your document?** If so, describe the term in plain language and refer to it in parentheses, or link to a trusted definition.
 - **Are you using the term throughout your document?** If so, briefly describe the term in parentheses on first reference, or link to a trusted definition.
+
+### Word List
+In order to remain consistently apply, capitalize, and abbreviate industry and domain terms we have a word list below.
+Zarf documentation and materials must adhere to the word list below to avoid ambiguities. Words noted with "proper noun"
+must be capitalized.
+
+- Zarf (proper noun, always capitalize)
+- Zarf Package
+- Open-source
+- Airgap/Airgapped
+- K8s
+- K9s
+- K3d
+- K3s
+- High side/Low side


### PR DESCRIPTION
## Description
This PR adds the Word List back into the style guide and adds clarity around proper nouns. Usage of capitalization is a bit ambiguous otherwise, because each bullet entry is treated like the beginning of a sentence. On first read, "Zarf" is the only proper noun in the list, but open to feedback on if we should mark other terms as proper nouns.

## Related Issue
Fixes #3991 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
