### PR TITLE
chore(docs): update open-source to open source and clean up style-guide.mdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Zarf eliminates the [complexity of airgap software delivery](https://www.itopsti
 
 ## Why Use Zarf
 
-- 💸 **Free and Open-Source.** Zarf will always be free to use and maintained by the open-source community.
+- 💸 **Free and Open Source.** Zarf will always be free to use and maintained by the open source community.
 - ⭐️ **Zero Dependencies.** As a statically compiled binary, the Zarf CLI has zero dependencies to run on any machine.
 - 🔓 **No Vendor Lock.** There is no proprietary software that locks you into using Zarf. If you want to remove it, you can still use your Helm charts to deploy your software manually.
 - 💻 **OS Agnostic.** Zarf supports numerous operating systems. A full matrix of supported OSes, architectures, and feature sets is coming soon.

--- a/site/src/content/docs/contribute/style-guide.mdx
+++ b/site/src/content/docs/contribute/style-guide.mdx
@@ -4,7 +4,7 @@ title: Documentation Style Guide
 
 ### Introduction
 
-Welcome to the Defense Unicorns Project Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent Unicorn-related documentation. Writing is an essential aspect of open source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
+Welcome to the Zarf Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent Unicorn-related documentation. Writing is an essential aspect of open source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
 
 ### Writing Goals
 
@@ -16,9 +16,9 @@ With every piece of content or documentation we publish, we should aim to:
 
 ### Writing Tone
 
-Here at Defense Unicorns, we aim to publish project documentation that is informative and approachable. It should convey a sense of reliability and expertise while also being easy to understand to those who read our project documentation. The tone should be educative and welcoming, highlighting the benefits and features of our software in a clear and concise manor.
+We aim to publish project documentation that is informative and approachable. It should convey a sense of reliability and expertise while also being easy to understand to those who read our project documentation. The tone should be educative and welcoming, highlighting the benefits and features of our software in a clear and concise manor.
 
-Here are some key elements of writing in the Defense Unicorn tone:
+Here are some key elements of writing in the Zarf project tone:
 
 - Use [active voice](https://webapps.towson.edu/ows/activepass.htm), avoid using passive voice.
 - Write plainly, avoid using cliches, colloquiums, jargon, and unclear analogies.
@@ -28,9 +28,9 @@ Here are some key elements of writing in the Defense Unicorn tone:
 
 ### Capitalization
 
-Defense Unicorns style uses sentence-style capitalization. That means everything is lowercase except the first word and proper nouns, which include the names of brands, products, and services.
+Zarf documentation and content uses sentence-style capitalization. That means everything is lowercase except the first word and proper nouns, which include the names of brands, products, and services.
 
-Follow these guidelines for creating Defense Unicorns content:
+Follow these guidelines:
 
 #### Body Style Capitalization
 
@@ -67,7 +67,7 @@ Many developers copy example code from documentation into their own code or adap
 
 To create useful code examples, identify tasks and scenarios that are meaningful for your audience, and then create examples that illustrate those scenarios. Code examples that demonstrate product features are useful only when they address the problems that developers are trying to solve.
 
-Follow these guidelines for creating Defense Unicorns code examples:
+Follow these guidelines for code examples:
 
 - Create concise examples that exemplify key development tasks. Start with simple examples and build up the complexity after you cover common scenarios.
 - Create code examples that are easy to scan and understand. Reserve complicated examples for tutorials, where you can provide a step-by-step explanation of how the example works.
@@ -77,9 +77,9 @@ Follow these guidelines for creating Defense Unicorns code examples:
 
 ### Text Formatting
 
-The thoughtful use of fonts, text formatting, capitalization, alignment, and spacing creates a first impression, reinforces the Defense Unicorn brand, and improves readability. The consistent formatting of text elements, such as command names and URLs, reduces ambiguity and helps users find and interpret information easily.
+The thoughtful use of fonts, text formatting, capitalization, alignment, and spacing creates a first impression and improves readability. The consistent formatting of text elements, such as command names and URLs, reduces ambiguity and helps users find and interpret information easily.
 
-Follow these guidelines for creating proper Defense Unicorns text formatting:
+Follow these guidelines for text formatting:
 
 - Use headings to show hierarchy of information.
 - Project documentation and project websites use Roboto for the body text, unless explicitly stated in otherwise in the project brand guide.
@@ -92,7 +92,7 @@ Follow these guidelines for creating proper Defense Unicorns text formatting:
 
 It is important to ensure that our communication is clear, concise, and useful. Many portions of our documentation consists of examples and tutorials for users to deploy our software. Creating consistent formatting helps users locate and interpret steps and procedures efficiently.
 
-Follow these guidelines for creating Defense Unicorn instructions and procedures:
+Follow these guidelines for procedures and instructions:
 
 - Format procedures consistently so customers can find them easily by scanning.
 - Consider using a heading to help users find instructions quickly.
@@ -218,7 +218,6 @@ If you're going to use jargon, consider the following questions:
 In order to consistently name, capitalize, and abbreviate industry and domain terms we have a word list below.
 Zarf documentation and materials must adhere to the word list below to avoid ambiguities. Words noted with "proper noun"
 must be capitalized.
-
 
 - Zarf (Proper noun)
 - Zarf Package

--- a/site/src/content/docs/contribute/style-guide.mdx
+++ b/site/src/content/docs/contribute/style-guide.mdx
@@ -4,7 +4,7 @@ title: Documentation Style Guide
 
 ### Introduction
 
-Welcome to the Defense Unicorns Project Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent Unicorn-related documentation. Writing is an essential aspect of open-source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
+Welcome to the Defense Unicorns Project Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent Unicorn-related documentation. Writing is an essential aspect of open source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
 
 ### Writing Goals
 

--- a/site/src/content/docs/contribute/style-guide.mdx
+++ b/site/src/content/docs/contribute/style-guide.mdx
@@ -4,7 +4,7 @@ title: Documentation Style Guide
 
 ### Introduction
 
-Welcome to the Zarf Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent Unicorn-related documentation. Writing is an essential aspect of open source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
+Welcome to the Zarf Documentation Style Guide, your guide to writing style and terminology for all project communication. This style guide provides editorial guidelines for writing clear and consistent documentation. Writing is an essential aspect of open source software development, including documentation, user guides, and communication with the community. Consistency and clarity are critical in conveying our information effectively.
 
 ### Writing Goals
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -10,11 +10,11 @@ Defense Unicorns' mission is to advance freedom and independence globally throug
 
 ## What license is Zarf under?
 
-Zarf is under the [Apache License 2.0](https://github.com/zarf-dev/zarf/blob/main/LICENSE). This is one of the most commonly used licenses for open-source software.
+Zarf is under the [Apache License 2.0](https://github.com/zarf-dev/zarf/blob/main/LICENSE). This is one of the most commonly used licenses for open source software.
 
 ## Is Zarf free to use?
 
-Yes! Zarf is Free and Open-Source Software (FOSS). And will remain free forever. We believe Free and Open Source software changes the world and promotes freedom and security. Anyone who sees the value in our tool should be free to use it without fear of vendor locking or licensing fees.
+Yes! Zarf is Free and Open Source Software (FOSS). And will remain free forever. We believe Free and Open Source software changes the world and promotes freedom and security. Anyone who sees the value in our tool should be free to use it without fear of vendor locking or licensing fees.
 
 ## Do I have to use Homebrew to install Zarf?
 

--- a/site/src/content/docs/getting-started/understanding.mdx
+++ b/site/src/content/docs/getting-started/understanding.mdx
@@ -16,7 +16,7 @@ For Zarf-specific concepts, see the following pages:
 
 ## Target Use Cases
 
-- Make the delivery of software "across the airgap" an open-source "solved problem".
+- Make the delivery of software "across the airgap" an open source "solved problem".
 - Make it trivial to deploy and run Kubernetes apps "at the Edge".
 - Make it easy to support GitOps-based K8s cluster updates in isolated environments.
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is Zarf?
-description: Zarf is a free and open-source tool that enables declarative creation & distribution of software into air-gapped/constrained/standalone environments.
+description: Zarf is a free and open source tool that enables declarative creation & distribution of software into air-gapped/constrained/standalone environments.
 tableOfContents: false
 ---
 
@@ -9,7 +9,7 @@ import Community from "../../../../COMMUNITY.md";
 
 ![Zarf Underwater](../../assets/zarf-underwater-behind-rock.svg)
 
-Zarf is a free and open-source tool that enables _**declarative creation & distribution of software into air-gapped/constrained/standalone environments**_.
+Zarf is a free and open source tool that enables _**declarative creation & distribution of software into air-gapped/constrained/standalone environments**_.
 
 Zarf provides a way to package and deploy software in a way that is **repeatable**, **secure**, and **reliable**.
 
@@ -21,7 +21,7 @@ Zarf provides a way to package and deploy software in a way that is **repeatable
 
 ## Why Use Zarf?
 
-- 💸 **Free and Open-Source.** Zarf will always be free to use and maintained by the open-source community.
+- 💸 **Free and Open Source.** Zarf will always be free to use and maintained by the open source community.
 - ⭐️ **Zero Dependencies.** As a statically compiled binary, the Zarf CLI has zero dependencies to run on any machine.
 - 🔓 **No Vendor Lock.** There is no proprietary software that locks you into using Zarf. If you want to remove it, you still can use your helm charts to deploy your software manually.
 - 💻 **OS Agnostic.** Zarf supports numerous operating systems. A full matrix of supported OSes, architectures and featuresets is coming soon.


### PR DESCRIPTION
## Description
This PR is a follow up to #3991 matching the change in "open-source" to "open source" in Zarf's documentation. ADRs are not in scope for this change.

This PR also updates references to Zarf's original creator company to just point to Zarf.

## Related Issue
Relates to #3991 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
