### PR TITLE
docs: update Zarfs tagline

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,7 +88,7 @@ brews:
 
     commit_msg_template: "build(release): upgrade {{ .ProjectName }} to {{ .Tag }}"
     homepage: "https://zarf.dev/"
-    description: "DevSecOps for Airgap"
+    description: "The Airgap Native Packager Manager for Kubernetes"
 
   # NOTE: We are using .Version instead of .Tag because homebrew has weird semver parsing rules and won't be able to
   #       install versioned releases that has a `v` character before the version number.
@@ -106,4 +106,4 @@ brews:
           name: homebrew-tap
     commit_msg_template: "build(release): {{ .ProjectName }}@{{ .Tag }}"
     homepage: "https://zarf.dev/"
-    description: "DevSecOps for Airgap"
+    description: "The Airgap Native Packager Manager for Kubernetes"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Latest Release](https://img.shields.io/github/v/release/zarf-dev/zarf)](https://github.com/zarf-dev/zarf/releases)
 [![Go version](https://img.shields.io/github/go-mod/go-version/zarf-dev/zarf?filename=go.mod)](https://go.dev/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/zarf-dev/zarf/release.yml)](https://github.com/zarf-dev/zarf/actions/workflows/release.yml)
-[![OpenSSF Project](https://img.shields.io/badge/OpenSSF-Project-orange)](https://openssf.org/)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/zarf-dev/zarf/badge)](https://securityscorecards.dev/viewer/?uri=github.com/zarf-dev/zarf)
 
 <img align="right" alt="zarf logo" src="site/src/assets/zarf-logo.png"  height="256" />

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Zarf - DevSecOps for Airgap
+# Zarf - The Airgap Native Packager Manager for Kubernetes
 
 [![Latest Release](https://img.shields.io/github/v/release/zarf-dev/zarf)](https://github.com/zarf-dev/zarf/releases)
 [![Go version](https://img.shields.io/github/go-mod/go-version/zarf-dev/zarf?filename=go.mod)](https://go.dev/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/zarf-dev/zarf/release.yml)](https://github.com/zarf-dev/zarf/actions/workflows/release.yml)
+[![OpenSSF Project](https://img.shields.io/badge/OpenSSF-Project-orange)](https://openssf.org/)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/zarf-dev/zarf/badge)](https://securityscorecards.dev/viewer/?uri=github.com/zarf-dev/zarf)
 
 <img align="right" alt="zarf logo" src="site/src/assets/zarf-logo.png"  height="256" />

--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -8,7 +8,7 @@ tableOfContents: false
 
 ## zarf
 
-DevSecOps for Airgap
+The Airgap Native Packager Manager for Kubernetes
 
 ### Synopsis
 

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -37,7 +37,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 * [zarf completion bash](/commands/zarf_completion_bash/)	 - Generate the autocompletion script for bash
 * [zarf completion fish](/commands/zarf_completion_fish/)	 - Generate the autocompletion script for fish
 * [zarf completion powershell](/commands/zarf_completion_powershell/)	 - Generate the autocompletion script for powershell

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -51,6 +51,6 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 * [zarf connect list](/commands/zarf_connect_list/)	 - Lists all available connection shortcuts
 

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -47,5 +47,5 @@ zarf destroy --confirm [flags]
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -31,7 +31,7 @@ Commands useful for developing packages
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 * [zarf dev deploy](/commands/zarf_dev_deploy/)	 - [beta] Creates and deploys a Zarf package from a given directory
 * [zarf dev find-images](/commands/zarf_dev_find-images/)	 - Evaluates components in a Zarf file to identify images specified in their helm charts and manifests
 * [zarf dev generate](/commands/zarf_dev_generate/)	 - [alpha] Creates a zarf.yaml automatically from a given remote (git) Helm chart

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -97,5 +97,5 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -33,7 +33,7 @@ Zarf package commands for creating, deploying, and inspecting packages
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 * [zarf package create](/commands/zarf_package_create/)	 - Creates a Zarf package from a given directory or the current directory
 * [zarf package deploy](/commands/zarf_package_deploy/)	 - Deploys a Zarf package from a local file or URL (runs offline)
 * [zarf package inspect](/commands/zarf_package_inspect/)	 - Displays the definition of a Zarf package (runs offline)

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -39,5 +39,5 @@ zarf say [flags]
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -31,7 +31,7 @@ Collection of additional tools to make airgap easier
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 * [zarf tools archiver](/commands/zarf_tools_archiver/)	 - Compresses/Decompresses generic archives, including Zarf packages
 * [zarf tools clear-cache](/commands/zarf_tools_clear-cache/)	 - Clears the configured git and image cache directory
 * [zarf tools download-init](/commands/zarf_tools_download-init/)	 - Downloads the init package for the current Zarf version into the specified directory

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -40,5 +40,5 @@ zarf version [flags]
 
 ### SEE ALSO
 
-* [zarf](/commands/zarf/)	 - DevSecOps for Airgap
+* [zarf](/commands/zarf/)	 - The Airgap Native Packager Manager for Kubernetes
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -26,7 +26,7 @@ Zarf is statically compiled and written in [Go](https://golang.org/) and [Rust](
 
 ## Should Zarf only be used in the airgap?
 
-No, Zarf is used outside of the airgap as well. Some users leverage Zarf to declaratively define their clusters or deployments, while others want their resources cached in the event of a lost connection.
+No, Zarf is used outside of the airgap as well. Some users leverage Zarf for a declarative deployment mechanism, while others want their resources cached in the event of a lost connection.
 
 ## Should Zarf only be used with Kubernetes
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -30,7 +30,7 @@ No, Zarf is used outside of the airgap as well. Some users leverage Zarf to decl
 
 ## Should Zarf only be used with Kubernetes
 
-No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions)
+No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
 
 ## How can I improve the speed of loading large images from Docker on `zarf package create`?
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -26,11 +26,11 @@ Zarf is statically compiled and written in [Go](https://golang.org/) and [Rust](
 
 ## Should Zarf only be used in the airgap?
 
-No, Zarf is used outside of the airgap as well. Some users leverage Zarf for a declarative deployment mechanism, while others want their resources cached in the event of a lost connection.
+No, Zarf is used in connected environments as well. Some users value making their deployment mechanism declarative, while others want their resources cached in the event of a lost connection.
 
 ## Should Zarf only be used with Kubernetes
 
-No, while improving the airgap Kubernetes UX is often the highest priority for the project, many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
+No, while improving the airgapped Kubernetes UX is often the top priority for the project, many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
 
 ## How can I improve the speed of loading large images from Docker on `zarf package create`?
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -28,7 +28,7 @@ Zarf is statically compiled and written in [Go](https://golang.org/) and [Rust](
 
 No, Zarf is used in connected environments as well. Some users value making their deployment mechanism declarative, while others want their resources cached in the event of a lost connection.
 
-## Should Zarf only be used with Kubernetes
+## Should Zarf only be used with Kubernetes?
 
 No, while improving the airgapped Kubernetes UX is often the top priority for the project, many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -30,7 +30,7 @@ No, Zarf is used outside of the airgap as well. Some users leverage Zarf for a d
 
 ## Should Zarf only be used with Kubernetes
 
-No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
+No, while improving the airgap Kubernetes UX is often the highest priority for the project, many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions).
 
 ## How can I improve the speed of loading large images from Docker on `zarf package create`?
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -26,7 +26,7 @@ Zarf is statically compiled and written in [Go](https://golang.org/) and [Rust](
 
 ## Should Zarf only be used in the airgap?
 
-No, Zarf is used outside of the airgap as well. Some users leverage Zarf to declaratively define their clusters or deployments, while others want their resources cached the event of a lost connection.
+No, Zarf is used outside of the airgap as well. Some users leverage Zarf to declaratively define their clusters or deployments, while others want their resources cached in the event of a lost connection.
 
 ## Should Zarf only be used with Kubernetes
 

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -4,9 +4,9 @@ title: FAQ
 
 ## Who is behind this project?
 
-Zarf was built by the developers at [Defense Unicorns](https://www.defenseunicorns.com/) and an amazing community of contributors.
+Zarf is an [Open Source Security Foundation (OpenSSF)](https://openssf.org/) project, and has a vibrant community maintaining it.
 
-Defense Unicorns' mission is to advance freedom and independence globally through Free and Open Source software.
+Zarf was originally built by the developers at [Defense Unicorns](https://www.defenseunicorns.com/).
 
 ## What license is Zarf under?
 
@@ -24,6 +24,14 @@ No, the Zarf binary and init package can be downloaded from the [Releases Page](
 
 Zarf is statically compiled and written in [Go](https://golang.org/) and [Rust](https://www.rust-lang.org/), so it has no external dependencies. For Linux, Zarf can bring a Kubernetes cluster using [K3s](https://k3s.io/). For Mac and Windows, Zarf can leverage any available local or remote cluster the user has access to. Currently, the K3s installation Zarf performs does require a [Systemd](https://en.wikipedia.org/wiki/Systemd) based system and `root` (not just `sudo`) access.
 
+## Should Zarf only be used in the airgap?
+
+No, Zarf is used outside of the airgap as well. Some users leverage Zarf to declaratively define their clusters or deployments, while others want their resources cached the event of a lost connection.
+
+## Should Zarf only be used with Kubernetes
+
+No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources.md) across environments and using [Zarf actions](ref/actions.mdx)
+
 ## How can I improve the speed of loading large images from Docker on `zarf package create`?
 
 Due to some limitations with how Docker provides access to local image layers, `zarf package create` has to rely on `docker save` under the hood which is [very slow overall](https://github.com/zarf-dev/zarf/issues/1214) and also takes a long time to report progress. We experimented with many ways to improve this, but for now recommend leveraging a local docker registry to speed up the process.
@@ -32,7 +40,7 @@ This can be done by running a local registry and pushing the images to it before
 
 ```sh
 # Create a local registry
-docker run -d -p 5000:5000 --restart=always --name registry registry:2
+docker run -d -p 5000:5000 --restart=always --name registry registry:3
 
 # Run the package create with a tag variable
 zarf package create --registry-override registry.enterprise.corp=localhost:5000 --set IMG=my-giant-image:v2

--- a/site/src/content/docs/faq.mdx
+++ b/site/src/content/docs/faq.mdx
@@ -30,7 +30,7 @@ No, Zarf is used outside of the airgap as well. Some users leverage Zarf to decl
 
 ## Should Zarf only be used with Kubernetes
 
-No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources.md) across environments and using [Zarf actions](ref/actions.mdx)
+No, improving the airgap Kubernetes UX is often the highest priority for the project, however many users find value in [mirroring resources](commands/zarf_package_mirror-resources) across environments and using [Zarf actions](ref/actions)
 
 ## How can I improve the speed of loading large images from Docker on `zarf package create`?
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -37,7 +37,7 @@ const (
 // Zarf CLI commands.
 const (
 	// root zarf command
-	RootCmdShort = "DevSecOps for Airgap"
+	RootCmdShort = "The Airgap Native Packager Manager for Kubernetes"
 	RootCmdLong  = "Zarf eliminates the complexity of airgap software delivery for Kubernetes clusters and cloud native workloads\n" +
 		"using a declarative packaging strategy to support DevSecOps in offline and semi-connected environments."
 


### PR DESCRIPTION
## Description

This updates Zarf tagline to "The Airgap Native Package Manager for Kubernetes" instead of "DevSecOps for Airgap". This help should help highlight our main use case, and make it easier to search for Zarf.

Also adds to the FAQ that Zarf is not only used for airgap and Kubernetes, but it is often the highest priority.

Upon merge of this PR I will update the about section in GitHub to use this tagline as well.

## Related Issue

Fixes #3478

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
