### PR TITLE
fix: avoid injector and registry randomly landing on same nodeport

### DIFF
--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -197,7 +197,7 @@ func TestInit(t *testing.T) {
 				}
 			}()
 
-			err := c.InitState(ctx, tt.initOpts)
+			_, err := c.InitState(ctx, tt.initOpts)
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 				return

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -396,7 +396,6 @@ func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum s
 // createInjectorNodeportService creates the injector service on an available port different than the registryNodePort service
 func (c *Cluster) createInjectorNodeportService(ctx context.Context, registryNodePort int) (*corev1.Service, error) {
 	l := logger.From(ctx)
-
 	for {
 		svcAc := v1ac.Service("zarf-injector", state.ZarfNamespaceName).
 			WithSpec(v1ac.ServiceSpec().
@@ -415,17 +414,14 @@ func (c *Cluster) createInjectorNodeportService(ctx context.Context, registryNod
 		assignedNodePort := int(svc.Spec.Ports[0].NodePort)
 		if assignedNodePort == registryNodePort {
 			l.Info("injector service NodePort conflicts with registry NodePort, recreating service", "conflictingPort", assignedNodePort)
-
 			err = c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
 			if err != nil {
 				return nil, err
 			}
 
 			time.Sleep(500 * time.Millisecond)
-
 			continue
 		}
-
 		return svc, nil
 	}
 }

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -396,7 +396,7 @@ func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum s
 // createInjectorNodeportService creates the injector service on an available port different than the registryNodePort service
 func (c *Cluster) createInjectorNodeportService(ctx context.Context, registryNodePort int) (*corev1.Service, error) {
 	l := logger.From(ctx)
-	for {
+	for i := 0; i < 10; i++ {
 		svcAc := v1ac.Service("zarf-injector", state.ZarfNamespaceName).
 			WithSpec(v1ac.ServiceSpec().
 				WithType(corev1.ServiceTypeNodePort).
@@ -424,4 +424,5 @@ func (c *Cluster) createInjectorNodeportService(ctx context.Context, registryNod
 		}
 		return svc, nil
 	}
+	return nil, fmt.Errorf("failed to create the injector nodeport service")
 }

--- a/src/pkg/cluster/injector_test.go
+++ b/src/pkg/cluster/injector_test.go
@@ -107,7 +107,7 @@ func TestInjector(t *testing.T) {
 		_, err = layout.Write(filepath.Join(tmpDir, "seed-images"), idx)
 		require.NoError(t, err)
 
-		err = c.StartInjection(ctx, tmpDir, t.TempDir(), nil)
+		err = c.StartInjection(ctx, tmpDir, t.TempDir(), nil, 0)
 		require.NoError(t, err)
 
 		podList, err := cs.CoreV1().Pods(state.ZarfNamespaceName).List(ctx, metav1.ListOptions{})

--- a/src/pkg/cluster/injector_test.go
+++ b/src/pkg/cluster/injector_test.go
@@ -107,7 +107,7 @@ func TestInjector(t *testing.T) {
 		_, err = layout.Write(filepath.Join(tmpDir, "seed-images"), idx)
 		require.NoError(t, err)
 
-		err = c.StartInjection(ctx, tmpDir, t.TempDir(), nil, 0)
+		err = c.StartInjection(ctx, tmpDir, t.TempDir(), nil, 31999)
 		require.NoError(t, err)
 
 		podList, err := cs.CoreV1().Pods(state.ZarfNamespaceName).List(ctx, metav1.ListOptions{})

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -265,7 +265,8 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 				applianceMode = true
 			}
 		}
-		err := d.c.InitState(ctx, cluster.InitStateOptions{
+		var err error
+		d.s, err = d.c.InitState(ctx, cluster.InitStateOptions{
 			GitServer:      opts.GitServer,
 			RegistryInfo:   opts.RegistryInfo,
 			ArtifactServer: opts.ArtifactServer,
@@ -289,7 +290,7 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 
 	// Before deploying the seed registry, start the injector
 	if isSeedRegistry {
-		err := d.c.StartInjection(ctx, pkgLayout.DirPath(), pkgLayout.GetImageDirPath(), component.Images)
+		err := d.c.StartInjection(ctx, pkgLayout.DirPath(), pkgLayout.GetImageDirPath(), component.Images, d.s.RegistryInfo.NodePort)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Fixes #2357 using option 2 in my most recent comment. 

I tested this with k3d by making only two ports available:
```bash
k3d cluster create --k3s-arg "--service-node-port-range=31998-31999@server:0" --k3s-arg="--disable=traefik@server:0"
```

After a try or two you'll something like
```bash
2025-07-18 10:58:59 INF adding archived binary configmaps of registry image to the cluster
2025-07-18 10:59:06 INF injector service NodePort conflicts with registry NodePort, recreating service conflictingPort=31999
2025-07-18 10:59:07 INF injector service NodePort conflicts with registry NodePort, recreating service conflictingPort=31999
2025-07-18 10:59:09 INF deploying component name=zarf-seed-registry
2025-07-18 10:59:09 INF processing Helm chart name=docker-registry version=1.0.0 source=Zarf-generated
```
and it continue successfully. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
