### PR TITLE
feat: add logic to add image to possible list when auth is needed

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -683,8 +683,10 @@ func (o *devFindImagesOptions) run(cmd *cobra.Command, args []string) error {
 
 	componentDefinition := "\ncomponents:\n"
 	for _, finding := range imagesScans {
-		if len(finding.Matches) > 0 {
+		if len(finding.Matches)+len(finding.PotentialMatches)+len(finding.CosignArtifacts) > 0 {
 			componentDefinition += fmt.Sprintf("  - name: %s\n    images:\n", finding.ComponentName)
+		}
+		if len(finding.Matches) > 0 {
 			for _, image := range finding.Matches {
 				componentDefinition += fmt.Sprintf("      - %s\n", image)
 			}

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -37,10 +37,11 @@ import (
 )
 
 var (
-	imageCheck      = regexp.MustCompile(`(?mi)"image":"((([a-z0-9._-]+)/)?([a-z0-9._-]+)(:([a-z0-9._-]+))?)"`)
-	imageFuzzyCheck = regexp.MustCompile(`(?mi)["|=]([a-z0-9\-.\/:]+:[\w.\-]*[a-z\.\-][\w.\-]*)"`)
-	shaCheck        = regexp.MustCompile(`(?mi)sha256:[a-fA-F0-9]{64}`)
-	statusCheck     = regexp.MustCompile(`(?mi)status code 40[0-9]`)
+	imageCheck       = regexp.MustCompile(`(?mi)"image":"((([a-z0-9._-]+)/)?([a-z0-9._-]+)(:([a-z0-9._-]+))?)"`)
+	imageFuzzyCheck  = regexp.MustCompile(`(?mi)["|=]([a-z0-9\-.\/:]+:[\w.\-]*[a-z\.\-][\w.\-]*)"`)
+	shaCheck         = regexp.MustCompile(`(?mi)sha256:[a-fA-F0-9]{64}`)
+	statusCheck      = regexp.MustCompile(`(?mi)status code 40[0-9]`)
+	connRefusedCheck = regexp.MustCompile(`(?mi)connect: connection refused`)
 )
 
 // FindImagesOptions declares the parameters to find images.
@@ -244,7 +245,7 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 					l.Debug("suspected image does not appear to be valid", "error", err)
 					// statusCheck is find if the error has an 40x error code
 					// shaCheck is remove false positives of sha256:aaaaa....
-					if statusCheck.FindString(err.Error()) != "" && shaCheck.FindString(image) == "" {
+					if (statusCheck.FindString(err.Error()) != "" || connRefusedCheck.FindString(err.Error()) != "") && shaCheck.FindString(image) == "" {
 						l.Debug("adding image even though registry check failed")
 						validMaybeImages = append(validMaybeImages, image)
 					}

--- a/src/pkg/packager/find_images_test.go
+++ b/src/pkg/packager/find_images_test.go
@@ -4,6 +4,7 @@
 package packager
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,8 @@ func TestFindImages(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.TestContext(t)
+
+	address := testutil.SetupInMemoryRegistryWithAuth(ctx, t, 65000, "axol", "otl")
 
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
 
@@ -151,6 +154,49 @@ func TestFindImages(t *testing.T) {
 					Matches: []string{
 						"ghcr.io/stefanprodan/manifests/podinfo:6.4.1",
 						"ghcr.io/stefanprodan/manifests/podinfo@sha256:fc60d367cc05bedae04d6030e270daa89c3d82fa18b1a155314102b2fca39652",
+					},
+				},
+			},
+		},
+		{
+			name:        "fuzzy-upstream",
+			packagePath: "./testdata/find-images/fuzzy-upstream",
+			opts: FindImagesOptions{
+				SkipCosign: true,
+			},
+			expectedImages: []ComponentImageScan{
+				{
+					ComponentName: "baseline",
+					Matches:       []string{},
+					PotentialMatches: []string{
+						"quay.io/cephcsi/cephcsi:v3.14.1",
+						"quay.io/csiaddons/k8s-sidecar:v0.12.0",
+						"registry.k8s.io/sig-storage/csi-attacher:v4.8.1",
+						"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0",
+						"registry.k8s.io/sig-storage/csi-provisioner:v5.2.0",
+						"registry.k8s.io/sig-storage/csi-resizer:v1.13.2",
+						"registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1",
+					},
+				},
+			},
+		},
+		{
+			name:        "fuzzy-registry-auth",
+			packagePath: "./testdata/find-images/fuzzy-registry-auth",
+			opts: FindImagesOptions{
+				SkipCosign: true,
+			},
+			expectedImages: []ComponentImageScan{
+				{
+					ComponentName: "baseline",
+					PotentialMatches: []string{
+						"registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:v1.12.0",
+						"registry1.dso.mil/ironbank/opensource/ceph/ceph-csi:v3.14.1",
+						"registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-attacher:v4.8.1",
+						"registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-provisioner:v5.2.0",
+						fmt.Sprintf("%s/sig-storage/csi-snapshotter:v8.2.1", address),
+						fmt.Sprintf("%s/sig-storage/csi-resizer:v1.13.2", address),
+						fmt.Sprintf("%s/sig-storage/csi-node-driver-registrar:v2.13.0", address),
 					},
 				},
 			},

--- a/src/pkg/packager/find_images_test.go
+++ b/src/pkg/packager/find_images_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/zarf-dev/zarf/src/pkg/lint"
+	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -19,7 +20,10 @@ func TestFindImages(t *testing.T) {
 
 	ctx := testutil.TestContext(t)
 
-	address := testutil.SetupInMemoryRegistryWithAuth(ctx, t, 65000)
+	htp, err := utils.GetHtpasswdString("axol", "otl")
+	require.NoError(t, err)
+
+	address := testutil.SetupInMemoryRegistryWithAuth(ctx, t, 65000, htp)
 
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
 

--- a/src/pkg/packager/find_images_test.go
+++ b/src/pkg/packager/find_images_test.go
@@ -19,7 +19,7 @@ func TestFindImages(t *testing.T) {
 
 	ctx := testutil.TestContext(t)
 
-	address := testutil.SetupInMemoryRegistryWithAuth(ctx, t, 65000, "axol", "otl")
+	address := testutil.SetupInMemoryRegistryWithAuth(ctx, t, 65000)
 
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../zarf.schema.json")
 

--- a/src/pkg/packager/testdata/find-images/fuzzy-registry-auth/configmap.yml
+++ b/src/pkg/packager/testdata/find-images/fuzzy-registry-auth/configmap.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-operator-config
+  namespace: rook-ceph
+data:
+  A_IMAGE: registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:v1.12.0
+  B_IMAGE: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-attacher:v4.8.1
+  C_IMAGE: registry1.dso.mil/ironbank/opensource/ceph/ceph-csi:v3.14.1
+  D_IMAGE: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/sig-storage/csi-provisioner:v5.2.0
+  E_IMAGE: localhost:65000/sig-storage/csi-node-driver-registrar:v2.13.0
+  F_IMAGE: localhost:65000/sig-storage/csi-resizer:v1.13.2
+  G_IMAGE: localhost:65000/sig-storage/csi-snapshotter:v8.2.1

--- a/src/pkg/packager/testdata/find-images/fuzzy-registry-auth/zarf.yaml
+++ b/src/pkg/packager/testdata/find-images/fuzzy-registry-auth/zarf.yaml
@@ -1,0 +1,12 @@
+kind: ZarfPackageConfig
+metadata:
+  name: fuzzy-registry1
+  version: 1.0.0
+components:
+  - name: baseline
+    required: true
+    manifests:
+      - name: fuzzy-registry1
+        namespace: default
+        files:
+          - configmap.yml

--- a/src/pkg/packager/testdata/find-images/fuzzy-upstream/configmap.yml
+++ b/src/pkg/packager/testdata/find-images/fuzzy-upstream/configmap.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-operator-config
+  namespace: rook-ceph
+data:
+  ROOK_CSIADDONS_IMAGE: quay.io/csiaddons/k8s-sidecar:v0.12.0
+  ROOK_CSI_ATTACHER_IMAGE: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+  ROOK_CSI_CEPH_IMAGE: quay.io/cephcsi/cephcsi:v3.14.1
+  ROOK_CSI_PROVISIONER_IMAGE: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+  ROOK_CSI_REGISTRAR_IMAGE: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  ROOK_CSI_RESIZER_IMAGE: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+  ROOK_CSI_SNAPSHOTTER_IMAGE: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1

--- a/src/pkg/packager/testdata/find-images/fuzzy-upstream/kustomization.yaml
+++ b/src/pkg/packager/testdata/find-images/fuzzy-upstream/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- configmap.yml

--- a/src/pkg/packager/testdata/find-images/fuzzy-upstream/zarf.yaml
+++ b/src/pkg/packager/testdata/find-images/fuzzy-upstream/zarf.yaml
@@ -1,0 +1,12 @@
+kind: ZarfPackageConfig
+metadata:
+  name: fuzzy-upstream
+  version: 1.0.0
+components:
+  - name: baseline
+    required: true
+    manifests:
+      - name: fuzzy-upstream
+        namespace: default
+        kustomizations:
+          - ./.

--- a/src/test/testutil/registry.go
+++ b/src/test/testutil/registry.go
@@ -19,23 +19,12 @@ import (
 
 // SetupInMemoryRegistry sets up an in-memory registry on localhost and returns the address.
 func SetupInMemoryRegistry(ctx context.Context, t *testing.T, port int) string {
-	t.Helper()
-	config := &configuration.Configuration{}
-	config.HTTP.Addr = fmt.Sprintf(":%d", port)
-	config.Log.AccessLog.Disabled = true
-	config.Log.Level = "error"
-	logrus.SetOutput(io.Discard)
-	config.HTTP.DrainTimeout = 10 * time.Second
-	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
-	ref, err := registry.NewRegistry(ctx, config)
-	require.NoError(t, err)
-	//nolint:errcheck // ignore
-	go ref.ListenAndServe()
-	return fmt.Sprintf("localhost:%d", port)
+	return SetupInMemoryRegistryWithAuth(ctx, t, port, "")
 }
 
-// SetupInMemoryRegistryWithAuth sets up an in-memory registry on localhost and returns the address. Has an auth of user: `axol`, pass `otl`
-func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int) string {
+// SetupInMemoryRegistryWithAuth sets up an in-memory registry on localhost and returns the address.
+// If the parameter `htpassword` is not empty, the registry will use that as the auth for accessing it.
+func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int, htpassword string) string {
 	t.Helper()
 	config := &configuration.Configuration{}
 	config.HTTP.Addr = fmt.Sprintf(":%d", port)
@@ -43,11 +32,9 @@ func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int) 
 	config.Log.Level = "error"
 	logrus.SetOutput(io.Discard)
 	config.HTTP.DrainTimeout = 10 * time.Second
-	// This is a hard-coded HTTP Auth secret, largely to avoid an import cycle issues with using:
-	// utils.GetHtpasswdString(username, password)
-	// user: axol
-	// pass: otl
-	config.HTTP.Secret = "axol:$2a$10$NY2qOGl71AFVAeNqC951UOc3e8o16HIzFBAqg/QNT1jQJ/RkAP9lS"
+	if htpassword != "" {
+		config.HTTP.Secret = htpassword
+	}
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	ref, err := registry.NewRegistry(ctx, config)
 	require.NoError(t, err)

--- a/src/test/testutil/registry.go
+++ b/src/test/testutil/registry.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory" // used for docker test registry
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
 // SetupInMemoryRegistry sets up an in-memory registry on localhost and returns the address.
@@ -26,6 +27,26 @@ func SetupInMemoryRegistry(ctx context.Context, t *testing.T, port int) string {
 	config.Log.Level = "error"
 	logrus.SetOutput(io.Discard)
 	config.HTTP.DrainTimeout = 10 * time.Second
+	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
+	ref, err := registry.NewRegistry(ctx, config)
+	require.NoError(t, err)
+	//nolint:errcheck // ignore
+	go ref.ListenAndServe()
+	return fmt.Sprintf("localhost:%d", port)
+}
+
+// SetupInMemoryRegistry sets up an in-memory registry on localhost and returns the address.
+func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int, username string, password string) string {
+	t.Helper()
+	config := &configuration.Configuration{}
+	config.HTTP.Addr = fmt.Sprintf(":%d", port)
+	config.Log.AccessLog.Disabled = true
+	config.Log.Level = "error"
+	logrus.SetOutput(io.Discard)
+	config.HTTP.DrainTimeout = 10 * time.Second
+	htp, err := utils.GetHtpasswdString(username, password)
+	require.NoError(t, err)
+	config.HTTP.Secret = htp
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	ref, err := registry.NewRegistry(ctx, config)
 	require.NoError(t, err)

--- a/src/test/testutil/registry.go
+++ b/src/test/testutil/registry.go
@@ -15,7 +15,6 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory" // used for docker test registry
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
 // SetupInMemoryRegistry sets up an in-memory registry on localhost and returns the address.
@@ -35,8 +34,8 @@ func SetupInMemoryRegistry(ctx context.Context, t *testing.T, port int) string {
 	return fmt.Sprintf("localhost:%d", port)
 }
 
-// SetupInMemoryRegistry sets up an in-memory registry on localhost and returns the address.
-func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int, username string, password string) string {
+// SetupInMemoryRegistryWithAuth sets up an in-memory registry on localhost and returns the address. Has an auth of user: `axol`, pass `otl`
+func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int) string {
 	t.Helper()
 	config := &configuration.Configuration{}
 	config.HTTP.Addr = fmt.Sprintf(":%d", port)
@@ -44,9 +43,11 @@ func SetupInMemoryRegistryWithAuth(ctx context.Context, t *testing.T, port int, 
 	config.Log.Level = "error"
 	logrus.SetOutput(io.Discard)
 	config.HTTP.DrainTimeout = 10 * time.Second
-	htp, err := utils.GetHtpasswdString(username, password)
-	require.NoError(t, err)
-	config.HTTP.Secret = htp
+	// This is a hard-coded HTTP Auth secret, largely to avoid an import cycle issues with using:
+	// utils.GetHtpasswdString(username, password)
+	// user: axol
+	// pass: otl
+	config.HTTP.Secret = "axol:$2a$10$NY2qOGl71AFVAeNqC951UOc3e8o16HIzFBAqg/QNT1jQJ/RkAP9lS"
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	ref, err := registry.NewRegistry(ctx, config)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Updates logic that when trying to use `zarf dev find-images` a package, it will silently fail if the registry, in this case registry1.dso.mil, needs auth to check it.

## Related Issue

Fixes #4007

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
