### PR TITLE
fix(tools): update-creds handle registry subpaths

### DIFF
--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -7,6 +7,7 @@ package helm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/state"
@@ -80,6 +81,15 @@ func UpdateZarfAgentValues(ctx context.Context, opts InstallUpgradeOptions) erro
 	agentImage, err := transform.ParseImageRef(deployment.Spec.Template.Spec.Containers[0].Image)
 	if err != nil {
 		return err
+	}
+
+	// In the event the registry is external and includes subpaths
+	// we will remove the subpath from the agent path
+	registry := opts.State.RegistryInfo.Address
+	parts := strings.Split(registry, "/")
+	subPath := strings.Join(parts[1:], "/")
+	if subPath != "" {
+		agentImage.Path = strings.TrimPrefix(agentImage.Path, fmt.Sprintf("%s/", subPath))
 	}
 
 	actionConfig, err := createActionConfig(ctx, state.ZarfNamespaceName)

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -44,7 +44,7 @@ var outClusterCredentialArgs = []string{
 	"--git-url=http://" + giteaHost + ":3000",
 	"--registry-push-username=" + registryUser,
 	"--registry-push-password=" + commonPassword,
-	"--registry-url=k3d-" + registryHost + "/test:5000"}
+	"--registry-url=k3d-" + registryHost + ":5000/test"}
 
 type ExtOutClusterTestSuite struct {
 	suite.Suite
@@ -116,7 +116,7 @@ func (suite *ExtOutClusterTestSuite) Test_0_Mirror() {
 	suite.NoError(err, "unable to mirror the package with zarf")
 
 	// Check that the registry contains the images we want
-	regCatalogURL := fmt.Sprintf("http://%s:%s@k3d-%s/test:5000/v2/_catalog", registryUser, commonPassword, registryHost)
+	regCatalogURL := fmt.Sprintf("http://%s:%s@k3d-%s:5000/v2/_catalog", registryUser, commonPassword, registryHost)
 	respReg, err := http.Get(regCatalogURL)
 	suite.NoError(err)
 	regBody, err := io.ReadAll(respReg.Body)

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -44,7 +44,7 @@ var outClusterCredentialArgs = []string{
 	"--git-url=http://" + giteaHost + ":3000",
 	"--registry-push-username=" + registryUser,
 	"--registry-push-password=" + commonPassword,
-	"--registry-url=k3d-" + registryHost + ":5000"}
+	"--registry-url=k3d-" + registryHost + "/test:5000"}
 
 type ExtOutClusterTestSuite struct {
 	suite.Suite
@@ -116,7 +116,7 @@ func (suite *ExtOutClusterTestSuite) Test_0_Mirror() {
 	suite.NoError(err, "unable to mirror the package with zarf")
 
 	// Check that the registry contains the images we want
-	regCatalogURL := fmt.Sprintf("http://%s:%s@k3d-%s:5000/v2/_catalog", registryUser, commonPassword, registryHost)
+	regCatalogURL := fmt.Sprintf("http://%s:%s@k3d-%s/test:5000/v2/_catalog", registryUser, commonPassword, registryHost)
 	respReg, err := http.Get(regCatalogURL)
 	suite.NoError(err)
 	regBody, err := io.ReadAll(respReg.Body)
@@ -198,6 +198,13 @@ func (suite *ExtOutClusterTestSuite) Test_3_AuthToPrivateHelmChart() {
 	packageCreateArgs := []string{"package", "create", packagePath, fmt.Sprintf("--output=%s", tempDir), "--confirm"}
 	err = exec.CmdWithPrint(zarfBinPath, packageCreateArgs...)
 	suite.NoError(err, "Unable to create package, helm auth likely failed")
+}
+
+func (suite *ExtOutClusterTestSuite) Test_4_SubpathAgentTlsUpdate() {
+	updateCredsArgs := []string{"tools", "update-creds", "agent", "--confirm"}
+
+	err := exec.CmdWithPrint(zarfBinPath, updateCredsArgs...)
+	suite.NoError(err, "Unable to find images, helm auth likely failed")
 }
 
 func (suite *ExtOutClusterTestSuite) createHelmChartInGitea(baseURL string, username string, password string) {


### PR DESCRIPTION
## Description

Fix support for subpaths in the use of external registries during `zarf tools update-creds agent`. 

Most managed external registries will not have the root registry available to push images. Rather a organization with nested projects may be defined - such as `registry.example.com/organization`. 

Zarf init for the agent - which is pre-mutation - is set as `registry.example.com/organization/zarf-dev/zarf/agent:<tag>`

In this scenario - the current logic for updating the agent tls certificate was identifying:
registry = `registry.example.com`
path = `organization/zarf-dev/zarf/agent`

and assigning the full path - `organization/zarf-dev/zarf/agent` - to the image - which when the registry is appended now equals `registry.example.com/organization/organization/zarf-dev/zarf/agent:<tag>`.

This fixes the behavior by trimming subpaths when present  - as the `registry-url` should indeed declare subpaths if utilized. 

## Related Issue

Fixes #4024

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
