### PR TITLE
4031 init package naming

### DIFF
--- a/packages/zarf-agent/chart/Chart.yaml
+++ b/packages/zarf-agent/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Zarf agent
 name: zarf-agent
-version: 0.1.1
+version: 0.1.0
 
 maintainers:
   - name: The Zarf Authors

--- a/packages/zarf-agent/chart/Chart.yaml
+++ b/packages/zarf-agent/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Zarf agent
-name: raw-init-zarf-agent-zarf-agent
-version: 0.1.0
+name: zarf-agent
+version: 0.1.1
 
 maintainers:
   - name: The Zarf Authors

--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -108,8 +108,9 @@ func UpdateZarfAgentValues(ctx context.Context, opts InstallUpgradeOptions) erro
 	found := false
 	for _, release := range releases {
 		// Update the Zarf Agent release with the new values
-		// Maintaining the "raw-init" release name for backwards compatibility
-		if release.Chart.Name() == "raw-init-zarf-agent-zarf-agent" {
+		// note: this should never work for custom named init packages - this should be made more generic
+		// Assumes there will only be one release in the zarf namespace with "zarf-agent" in the name
+		if strings.Contains(release.Chart.Name(), "zarf-agent") {
 			found = true
 			chart := v1alpha1.ZarfChart{
 				Namespace:   "zarf",

--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -108,7 +108,6 @@ func UpdateZarfAgentValues(ctx context.Context, opts InstallUpgradeOptions) erro
 	found := false
 	for _, release := range releases {
 		// Update the Zarf Agent release with the new values
-		// note: this should never work for custom named init packages - this should be made more generic
 		// Assumes there will only be one release in the zarf namespace with "zarf-agent" in the name
 		if strings.Contains(release.Chart.Name(), "zarf-agent") {
 			found = true


### PR DESCRIPTION
## Description

Discovered that `zarf tools update-creds agent` does not work for any init packages where `metadata.name` does not equal `init` (IE all custom-named init packages). 

This was inadvertently fixed in #3678 for all releases >=v0.59.0. This change merely allows the ability to run this logic on clusters that are already initialized with a custom-named init package but may not have upgraded. 

Given the historical data on clusters that run into certificate update issues - this may be something we reference for some time and can point users to the next release as a version that resolves the ability to update certificates on all <= v0.58.0 zarf agents.  

## Related Issue

Relates to #4031

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
