### PR TITLE
chore(docs): update tutorial with images example

### DIFF
--- a/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
+++ b/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
@@ -106,10 +106,10 @@ From here you can copy the `images` key and array of images into the `wordpress`
 
 ```yaml
 components:
-  - name: wordpress  # specifies the name of our component and should be unique and unchanging through updates
-    description: |   # (optional) a human-readable description of the component you are defining
+  - name: wordpress
+    description: |
       Deploys the Bitnami-packaged WordPress chart into the cluster
-    required: true   # (optional) sets the component as 'required' so that it is always deployed
+    required: true
     charts:
       - name: wordpress
         url: oci://registry-1.docker.io/bitnamicharts/wordpress

--- a/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
+++ b/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
@@ -102,7 +102,26 @@ Once you have the above defined we can now work on setting the images that we wi
 
 <iframe src="/tutorials/prepare_find_images.html" height="220px" width="100%"></iframe>
 
-From here you can copy the `images` key and array of images into the `wordpress` component we defined in our `zarf.yaml`
+From here you can copy the `images` key and array of images into the `wordpress` component we defined in our `zarf.yaml`. The `wordpress` component should now be as follows:
+
+```yaml
+components:
+  - name: wordpress  # specifies the name of our component and should be unique and unchanging through updates
+    description: |   # (optional) a human-readable description of the component you are defining
+      Deploys the Bitnami-packaged WordPress chart into the cluster
+    required: true   # (optional) sets the component as 'required' so that it is always deployed
+    charts:
+      - name: wordpress
+        url: oci://registry-1.docker.io/bitnamicharts/wordpress
+        version: 16.0.4
+        namespace: wordpress
+        valuesFiles:
+          - wordpress-values.yaml
+    images:
+      - docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2
+      - docker.io/bitnami/mariadb:10.11.2-debian-11-r21
+      - docker.io/bitnami/wordpress:6.2.0-debian-11-r18
+```
 
 :::note
 


### PR DESCRIPTION
## Description

Updates the wordpress tutorial to have a reference to the images after running `zarf dev find-images` and adding the contents to the package manifest. 

## Related Issue

Relates to #4037

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
