### PR TITLE
fix: allow absolute paths in zarf.yaml

### DIFF
--- a/examples/component-actions/zarf.yaml
+++ b/examples/component-actions/zarf.yaml
@@ -2,7 +2,6 @@ kind: ZarfPackageConfig
 metadata:
   name: component-actions
   description: Component actions examples
-  version: 0.0.1
 
 variables:
   - name: DOG_SOUND

--- a/examples/component-actions/zarf.yaml
+++ b/examples/component-actions/zarf.yaml
@@ -2,6 +2,7 @@ kind: ZarfPackageConfig
 metadata:
   name: component-actions
   description: Component actions examples
+  version: 0.0.1
 
 variables:
   - name: DOG_SOUND

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -13,9 +13,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
-	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
@@ -259,70 +257,48 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 }
 
 func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig) ([]Resource, error) {
-	manifestPaths := []string{}
-	for idx, path := range manifest.Kustomizations {
-		kname := fmt.Sprintf("kustomization-%s-%d.yaml", manifest.Name, idx)
-		rel := filepath.Join(string(layout.ManifestsComponentDir), kname)
-		dst := filepath.Join(baseComponentDir, rel)
-		if !helpers.IsURL(path) {
-			path = filepath.Join(packagePath, path)
-		}
-		// Generate manifests from kustomizations and place in the package
-		if err := kustomize.Build(path, dst, manifest.KustomizeAllowAnyDirectory); err != nil {
-			return nil, fmt.Errorf("unable to build the kustomization for %s: %w", path, err)
-		}
-		manifestPaths = append(manifestPaths, dst)
+	if err := layout.PackageManifest(ctx, manifest, baseComponentDir, packagePath, ""); err != nil {
+		return nil, err
 	}
-	// Get all manifest files
-	for idx, f := range manifest.Files {
-		rel := filepath.Join(string(layout.ManifestsComponentDir), fmt.Sprintf("%s-%d.yaml", manifest.Name, idx))
-		dst := filepath.Join(baseComponentDir, rel)
-		if helpers.IsURL(f) {
-			if err := utils.DownloadToFile(ctx, f, dst, ""); err != nil {
-				return nil, fmt.Errorf(lang.ErrDownloading, f, err.Error())
-			}
-		} else {
-			if err := helpers.CreatePathAndCopy(filepath.Join(packagePath, f), dst); err != nil {
-				return nil, fmt.Errorf("unable to copy manifest %s: %w", f, err)
-			}
-		}
-		manifestPaths = append(manifestPaths, dst)
-	}
+
+	manifestPath := filepath.Join(baseComponentDir, string(layout.ManifestsComponentDir))
+
 	var resources []Resource
-	for _, manifest := range manifestPaths {
+	err := filepath.Walk(manifestPath, func(manifest string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
 		if err := variableConfig.ReplaceTextTemplate(manifest); err != nil {
-			return nil, fmt.Errorf("error templating the manifest: %w", err)
+			return fmt.Errorf("error templating the manifest: %w", err)
 		}
 		content, err := os.ReadFile(manifest)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		resources = append(resources, Resource{
 			Content:      string(content),
 			Name:         manifest,
 			ResourceType: ManifestResource,
 		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
+
 	return resources, nil
 }
 
 // getTemplatedChart returns a templated chart.yaml as a string after templating
 func getTemplatedChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig, kubeVersion string) (Resource, chartutil.Values, error) {
-	if zarfChart.LocalPath != "" {
-		zarfChart.LocalPath = filepath.Join(packagePath, zarfChart.LocalPath)
-	}
-	valuesFiles := []string{}
-	oldValuesFiles := zarfChart.ValuesFiles
-	for _, v := range zarfChart.ValuesFiles {
-		valuesFiles = append(valuesFiles, filepath.Join(packagePath, v))
-	}
-	zarfChart.ValuesFiles = valuesFiles
 	chartPath := filepath.Join(baseComponentDir, string(layout.ChartsComponentDir))
 	valuesFilePath := filepath.Join(baseComponentDir, string(layout.ValuesComponentDir))
-	if err := helm.PackageChart(ctx, zarfChart, chartPath, valuesFilePath); err != nil {
-		return Resource{}, chartutil.Values{}, fmt.Errorf("unable to package the chart %s: %w", zarfChart.Name, err)
+	if err := layout.PackageChart(ctx, zarfChart, packagePath, chartPath, valuesFilePath); err != nil {
+		return Resource{}, chartutil.Values{}, err
 	}
-	zarfChart.ValuesFiles = oldValuesFiles
 
 	chartOverrides := make(map[string]any)
 	for _, variable := range zarfChart.Variables {

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -525,7 +525,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			rel := filepath.Join(string(ChartsComponentDir), fmt.Sprintf("%s-%d", chart.Name, chartIdx))
 			dst := filepath.Join(compBuildPath, rel)
 
-			err := helpers.CreatePathAndCopy(filepath.Join(packagePath, chart.LocalPath), dst)
+			err := copyFile(packagePath, chart.LocalPath, dst)
 			if err != nil {
 				return err
 			}
@@ -573,7 +573,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 				}
 			}
 		} else {
-			if err := helpers.CreatePathAndCopy(filepath.Join(packagePath, file.Source), dst); err != nil {
+			if err := copyFile(packagePath, file.Source, dst); err != nil {
 				return fmt.Errorf("unable to copy file %s: %w", file.Source, err)
 			}
 		}
@@ -608,7 +608,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 		rel := filepath.Join(string(DataComponentDir), strconv.Itoa(dataIdx), filepath.Base(data.Target.Path))
 		dst := filepath.Join(compBuildPath, rel)
 
-		if err := helpers.CreatePathAndCopy(filepath.Join(packagePath, data.Source), dst); err != nil {
+		if err := copyFile(packagePath, data.Source, dst); err != nil {
 			return fmt.Errorf("unable to copy data injection %s: %s", data.Source, err.Error())
 		}
 
@@ -627,7 +627,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			dst := filepath.Join(compBuildPath, rel)
 
 			// Copy manifests without any processing.
-			if err := helpers.CreatePathAndCopy(filepath.Join(packagePath, path), dst); err != nil {
+			if err := copyFile(packagePath, path, dst); err != nil {
 				return fmt.Errorf("unable to copy manifest %s: %w", path, err)
 			}
 

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -435,14 +435,11 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 }
 
 func copyFile(packagePath, file, dst string) error {
-	if filepath.IsAbs(file) {
-		if err := helpers.CreatePathAndCopy(file, dst); err != nil {
-			return fmt.Errorf("unable to copy file %s: %w", file, err)
-		}
-	} else {
-		if err := helpers.CreatePathAndCopy(filepath.Join(packagePath, file), dst); err != nil {
-			return fmt.Errorf("unable to copy file %s: %w", file, err)
-		}
+	if !filepath.IsAbs(file) {
+		file = filepath.Join(packagePath, file)
+	}
+	if err := helpers.CreatePathAndCopy(file, dst); err != nil {
+		return fmt.Errorf("unable to copy file %s: %w", file, err)
 	}
 	return nil
 }

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -483,7 +483,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 
 // PackageChart takes a Zarf Chart definition and packs it into a package layout
 func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath string, chartPath string, valuesFilePath string) error {
-	if chart.LocalPath != "" {
+	if chart.LocalPath != "" && !filepath.IsAbs(chart.LocalPath) {
 		chart.LocalPath = filepath.Join(packagePath, chart.LocalPath)
 	}
 	oldValuesFiles := chart.ValuesFiles

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -116,6 +116,8 @@ func TestCreateAbsoluteSources(t *testing.T) {
 			absoluteFilePath := createFileToImport(t, tmpdir)
 			absoluteChartPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "chart"))
 			require.NoError(t, err)
+			absoluteKustomizePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "kustomize"))
+			require.NoError(t, err)
 			componentName := "absolute-files"
 			pkg := v1alpha1.ZarfPackage{
 				Kind: v1alpha1.ZarfPackageConfig,
@@ -136,6 +138,9 @@ func TestCreateAbsoluteSources(t *testing.T) {
 								Name: "test-manifest",
 								Files: []string{
 									absoluteFilePath,
+								},
+								Kustomizations: []string{
+									absoluteKustomizePath,
 								},
 							},
 						},
@@ -186,6 +191,7 @@ func TestCreateAbsoluteSources(t *testing.T) {
 			manifestComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.ManifestsComponentDir)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(manifestComponent, "test-manifest-0.yaml"))
+			require.FileExists(t, filepath.Join(manifestComponent, "kustomization-test-manifest-0.yaml"))
 
 			dataInjectionsDir, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.DataComponentDir)
 			require.NoError(t, err)

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -85,15 +85,6 @@ func TestGetSBOM(t *testing.T) {
 	require.ErrorAs(t, err, &noSBOMErr)
 }
 
-func createFileToImport(t *testing.T, dir string) string {
-	t.Helper()
-	absoluteFilePath, err := filepath.Abs(filepath.Join(dir, "file.txt"))
-	require.NoError(t, err)
-	_, err = os.Create(absoluteFilePath)
-	require.NoError(t, err)
-	return absoluteFilePath
-}
-
 func TestCreateAbsoluteSources(t *testing.T) {
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
@@ -113,7 +104,8 @@ func TestCreateAbsoluteSources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpdir := t.TempDir()
-			absoluteFilePath := createFileToImport(t, tmpdir)
+			absoluteFilePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "data.txt"))
+			require.NoError(t, err)
 			absoluteChartPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "chart"))
 			require.NoError(t, err)
 			absoluteKustomizePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "kustomize"))
@@ -205,7 +197,8 @@ func TestCreateAbsolutePathImports(t *testing.T) {
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
 	tmpdir := t.TempDir()
-	absoluteFilePath := createFileToImport(t, tmpdir)
+	absoluteFilePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "data.txt"))
+	require.NoError(t, err)
 	parentPkg := v1alpha1.ZarfPackage{
 		Kind: v1alpha1.ZarfPackageConfig,
 		Metadata: v1alpha1.ZarfMetadata{
@@ -241,7 +234,7 @@ func TestCreateAbsolutePathImports(t *testing.T) {
 	// Create zarf.yaml files in the tempdir
 	writePackageToDisk(t, parentPkg, tmpdir)
 	childDir := filepath.Join(tmpdir, "child")
-	err := os.Mkdir(childDir, 0700)
+	err = os.Mkdir(childDir, 0700)
 	require.NoError(t, err)
 	writePackageToDisk(t, childPkg, childDir)
 	pkg, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -117,6 +117,19 @@ func TestCreateAbsolutePathFileSource(t *testing.T) {
 							Target: "file.txt",
 						},
 					},
+					Manifests: []v1alpha1.ZarfManifest{
+						{
+							Name: "test manifest",
+							Files: []string{
+								absoluteFilePath,
+							},
+						},
+					},
+					DataInjections: []v1alpha1.ZarfDataInjection{
+						{
+							Source: absoluteFilePath,
+						},
+					},
 				},
 			},
 		}

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -103,6 +103,8 @@ func TestCreateAbsolutePathFileSource(t *testing.T) {
 		t.Parallel()
 		tmpdir := t.TempDir()
 		absoluteFilePath := createFileToImport(t, tmpdir)
+		absoluteChartPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "chart"))
+		require.NoError(t, err)
 		pkg := v1alpha1.ZarfPackage{
 			Kind: v1alpha1.ZarfPackageConfig,
 			Metadata: v1alpha1.ZarfMetadata{
@@ -130,13 +132,21 @@ func TestCreateAbsolutePathFileSource(t *testing.T) {
 							Source: absoluteFilePath,
 						},
 					},
+					Charts: []v1alpha1.ZarfChart{
+						{
+							Name:      "test-chart",
+							Namespace: "test",
+							Version:   "1.0.0",
+							LocalPath: absoluteChartPath,
+						},
+					},
 				},
 			},
 		}
 		// Create the zarf.yaml file in the tmpdir
 		writePackageToDisk(t, pkg, tmpdir)
 
-		pkg, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
+		pkg, err = load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
 		require.NoError(t, err)
 
 		pkgLayout, err := layout.AssemblePackage(ctx, pkg, tmpdir, layout.AssembleOptions{})

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -85,145 +85,167 @@ func TestGetSBOM(t *testing.T) {
 	require.ErrorAs(t, err, &noSBOMErr)
 }
 
-func TestCreateAbsolutePathFileSource(t *testing.T) {
-	t.Parallel()
+func createFileToImport(t *testing.T, dir string) string {
+	t.Helper()
+	absoluteFilePath, err := filepath.Abs(filepath.Join(dir, "file.txt"))
+	require.NoError(t, err)
+	_, err = os.Create(absoluteFilePath)
+	require.NoError(t, err)
+	return absoluteFilePath
+}
+
+func TestCreateAbsoluteSources(t *testing.T) {
 	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
-
-	createFileToImport := func(t *testing.T, dir string) string {
-		t.Helper()
-		absoluteFilePath, err := filepath.Abs(filepath.Join(dir, "file.txt"))
-		require.NoError(t, err)
-		_, err = os.Create(absoluteFilePath)
-		require.NoError(t, err)
-		return absoluteFilePath
+	tests := []struct {
+		name       string
+		isSkeleton bool
+	}{
+		{
+			name:       "regular package",
+			isSkeleton: false,
+		},
+		{
+			name:       "skeleton package",
+			isSkeleton: true,
+		},
 	}
-
-	t.Run("test a standard package can use absolute file paths", func(t *testing.T) {
-		t.Parallel()
-		tmpdir := t.TempDir()
-		absoluteFilePath := createFileToImport(t, tmpdir)
-		absoluteChartPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "chart"))
-		require.NoError(t, err)
-		componentName := "absolute-files"
-		pkg := v1alpha1.ZarfPackage{
-			Kind: v1alpha1.ZarfPackageConfig,
-			Metadata: v1alpha1.ZarfMetadata{
-				Name: "standard",
-			},
-			Components: []v1alpha1.ZarfComponent{
-				{
-					Name: componentName,
-					Files: []v1alpha1.ZarfFile{
-						{
-							Source: absoluteFilePath,
-							Target: "file.txt",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			absoluteFilePath := createFileToImport(t, tmpdir)
+			absoluteChartPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "chart"))
+			require.NoError(t, err)
+			componentName := "absolute-files"
+			pkg := v1alpha1.ZarfPackage{
+				Kind: v1alpha1.ZarfPackageConfig,
+				Metadata: v1alpha1.ZarfMetadata{
+					Name: "standard",
+				},
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: componentName,
+						Files: []v1alpha1.ZarfFile{
+							{
+								Source: absoluteFilePath,
+								Target: "file.txt",
+							},
 						},
-					},
-					Manifests: []v1alpha1.ZarfManifest{
-						{
-							Name: "test-manifest",
-							Files: []string{
-								absoluteFilePath,
+						Manifests: []v1alpha1.ZarfManifest{
+							{
+								Name: "test-manifest",
+								Files: []string{
+									absoluteFilePath,
+								},
+							},
+						},
+						DataInjections: []v1alpha1.ZarfDataInjection{
+							{
+								Source: absoluteFilePath,
+							},
+						},
+						Charts: []v1alpha1.ZarfChart{
+							{
+								Name:      "test-chart",
+								Namespace: "test",
+								Version:   "1.0.0",
+								LocalPath: absoluteChartPath,
 							},
 						},
 					},
-					DataInjections: []v1alpha1.ZarfDataInjection{
-						{
-							Source: absoluteFilePath,
-						},
-					},
-					Charts: []v1alpha1.ZarfChart{
-						{
-							Name:      "test-chart",
-							Namespace: "test",
-							Version:   "1.0.0",
-							LocalPath: absoluteChartPath,
-						},
-					},
 				},
-			},
-		}
-		// Create the zarf.yaml file in the tmpdir
-		writePackageToDisk(t, pkg, tmpdir)
+			}
+			// Create the zarf.yaml file in the tmpdir
+			writePackageToDisk(t, pkg, tmpdir)
 
-		pkg, err = load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
-		require.NoError(t, err)
+			pkg, err = load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
+			require.NoError(t, err)
 
-		pkgLayout, err := layout.AssemblePackage(ctx, pkg, tmpdir, layout.AssembleOptions{
-			SkipSBOM: true,
+			var pkgLayout *layout.PackageLayout
+			if tt.isSkeleton {
+				pkgLayout, err = layout.AssembleSkeleton(ctx, pkg, tmpdir, layout.AssembleSkeletonOptions{})
+				require.NoError(t, err)
+			} else {
+				pkgLayout, err = layout.AssemblePackage(ctx, pkg, tmpdir, layout.AssembleOptions{SkipSBOM: true})
+				require.NoError(t, err)
+			}
+
+			// Ensure the component has the correct files
+			fileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.FilesComponentDir)
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(fileComponent, "0", "file.txt"))
+
+			chartComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.ChartsComponentDir)
+			require.NoError(t, err)
+			if tt.isSkeleton {
+				require.DirExists(t, filepath.Join(chartComponent, "test-chart-0"))
+			} else {
+				require.FileExists(t, filepath.Join(chartComponent, "test-chart-1.0.0.tgz"))
+			}
+
+			manifestComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.ManifestsComponentDir)
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(manifestComponent, "test-manifest-0.yaml"))
+
+			dataInjectionsDir, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.DataComponentDir)
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(dataInjectionsDir, "0"))
 		})
-		require.NoError(t, err)
+	}
+}
 
-		// Ensure the component has the correct files
-		fileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.FilesComponentDir)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(fileComponent, "0", "file.txt"))
-
-		chartComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.ChartsComponentDir)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(chartComponent, "test-chart-1.0.0.tgz"))
-
-		manifestComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.ManifestsComponentDir)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(manifestComponent, "test-manifest-0.yaml"))
-
-		dataInjectionsDir, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.DataComponentDir)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(dataInjectionsDir, "0"))
-	})
-
-	t.Run("test that imports handle absolute paths properly", func(t *testing.T) {
-		t.Parallel()
-		tmpdir := t.TempDir()
-		absoluteFilePath := createFileToImport(t, tmpdir)
-		parentPkg := v1alpha1.ZarfPackage{
-			Kind: v1alpha1.ZarfPackageConfig,
-			Metadata: v1alpha1.ZarfMetadata{
-				Name: "parent",
+func TestCreateAbsolutePathImports(t *testing.T) {
+	t.Parallel()
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
+	ctx := testutil.TestContext(t)
+	tmpdir := t.TempDir()
+	absoluteFilePath := createFileToImport(t, tmpdir)
+	parentPkg := v1alpha1.ZarfPackage{
+		Kind: v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{
+			Name: "parent",
+		},
+		Components: []v1alpha1.ZarfComponent{
+			{
+				Name: "file-import",
+				Import: v1alpha1.ZarfComponentImport{
+					Path: "child",
+				},
 			},
-			Components: []v1alpha1.ZarfComponent{
-				{
-					Name: "file-import",
-					Import: v1alpha1.ZarfComponentImport{
-						Path: "child",
+		},
+	}
+	// Create package using absolute file path set to be import
+	childPkg := v1alpha1.ZarfPackage{
+		Kind: v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{
+			Name: "child",
+		},
+		Components: []v1alpha1.ZarfComponent{
+			{
+				Name: "file-import",
+				Files: []v1alpha1.ZarfFile{
+					{
+						Source: absoluteFilePath,
+						Target: "file.txt",
 					},
 				},
 			},
-		}
-		// Create package using absolute file path set to be import
-		childPkg := v1alpha1.ZarfPackage{
-			Kind: v1alpha1.ZarfPackageConfig,
-			Metadata: v1alpha1.ZarfMetadata{
-				Name: "child",
-			},
-			Components: []v1alpha1.ZarfComponent{
-				{
-					Name: "file-import",
-					Files: []v1alpha1.ZarfFile{
-						{
-							Source: absoluteFilePath,
-							Target: "file.txt",
-						},
-					},
-				},
-			},
-		}
-		// Create zarf.yaml files in the tempdir
-		writePackageToDisk(t, parentPkg, tmpdir)
-		childDir := filepath.Join(tmpdir, "child")
-		err := os.Mkdir(childDir, 0700)
-		require.NoError(t, err)
-		writePackageToDisk(t, childPkg, childDir)
-		pkg, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
-		require.NoError(t, err)
-		// create the package
-		pkgLayout, err := layout.AssemblePackage(context.Background(), pkg, tmpdir, layout.AssembleOptions{})
-		require.NoError(t, err)
+		},
+	}
+	// Create zarf.yaml files in the tempdir
+	writePackageToDisk(t, parentPkg, tmpdir)
+	childDir := filepath.Join(tmpdir, "child")
+	err := os.Mkdir(childDir, 0700)
+	require.NoError(t, err)
+	writePackageToDisk(t, childPkg, childDir)
+	pkg, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
+	require.NoError(t, err)
+	// create the package
+	pkgLayout, err := layout.AssemblePackage(context.Background(), pkg, tmpdir, layout.AssembleOptions{})
+	require.NoError(t, err)
 
-		// Ensure the component has the correct file
-		importedFileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, "file-import", layout.FilesComponentDir)
-		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(importedFileComponent, "0", "file.txt"))
-	})
+	// Ensure the component has the correct file
+	importedFileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, "file-import", layout.FilesComponentDir)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(importedFileComponent, "0", "file.txt"))
 }


### PR DESCRIPTION
## Description

Allows users to use absolute paths again. Also eliminates some duplication between find-images / inspect and assemble

## Related Issue

Fixes #3867

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
