### PR TITLE
feat(feature): add cmd integration and "axolotl mode"

### DIFF
--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -23,7 +23,7 @@ zarf COMMAND [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
   -h, --help                       help for zarf
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -23,6 +23,7 @@ zarf COMMAND [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
   -h, --help                       help for zarf
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -26,7 +26,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -26,6 +26,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -49,6 +49,7 @@ zarf completion bash
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -49,7 +49,7 @@ zarf completion bash
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -40,6 +40,7 @@ zarf completion fish [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -40,7 +40,7 @@ zarf completion fish [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -37,7 +37,7 @@ zarf completion powershell [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -37,6 +37,7 @@ zarf completion powershell [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -51,6 +51,7 @@ zarf completion zsh [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -51,7 +51,7 @@ zarf completion zsh [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -41,6 +41,7 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -41,7 +41,7 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -24,7 +24,7 @@ zarf connect list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -24,6 +24,7 @@ zarf connect list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -36,6 +36,7 @@ zarf destroy --confirm [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -36,7 +36,7 @@ zarf destroy --confirm [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -20,7 +20,7 @@ Commands useful for developing packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -20,6 +20,7 @@ Commands useful for developing packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -37,6 +37,7 @@ zarf dev deploy [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -37,7 +37,7 @@ zarf dev deploy [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -38,7 +38,7 @@ zarf dev find-images [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -38,6 +38,7 @@ zarf dev find-images [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -33,7 +33,7 @@ zarf dev generate-config [ FILENAME ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -33,6 +33,7 @@ zarf dev generate-config [ FILENAME ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -35,6 +35,7 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -35,7 +35,7 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect.md
@@ -20,7 +20,7 @@ Commands to get information about a Zarf package using a `zarf.yaml`
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect.md
@@ -20,6 +20,7 @@ Commands to get information about a Zarf package using a `zarf.yaml`
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_definition.md
@@ -30,6 +30,7 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_definition.md
@@ -30,7 +30,7 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
@@ -28,7 +28,7 @@ zarf dev inspect manifests [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
@@ -28,6 +28,7 @@ zarf dev inspect manifests [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
@@ -32,7 +32,7 @@ zarf dev inspect values-files [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
@@ -32,6 +32,7 @@ zarf dev inspect values-files [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -30,6 +30,7 @@ zarf dev lint [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -30,7 +30,7 @@ zarf dev lint [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -26,7 +26,7 @@ zarf dev patch-git HOST FILE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -26,6 +26,7 @@ zarf dev patch-git HOST FILE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -25,7 +25,7 @@ zarf dev sha256sum { FILE | URL } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -25,6 +25,7 @@ zarf dev sha256sum { FILE | URL } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -86,6 +86,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -86,7 +86,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -22,6 +22,7 @@ Zarf package commands for creating, deploying, and inspecting packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -22,7 +22,7 @@ Zarf package commands for creating, deploying, and inspecting packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -42,6 +42,7 @@ zarf package create [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -42,7 +42,7 @@ zarf package create [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -38,6 +38,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -38,7 +38,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -31,6 +31,7 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -31,7 +31,7 @@ zarf package inspect [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -26,7 +26,7 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -26,6 +26,7 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -26,6 +26,7 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -26,7 +26,7 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -28,6 +28,7 @@ zarf package inspect manifests [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -28,7 +28,7 @@ zarf package inspect manifests [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -26,6 +26,7 @@ zarf package inspect sbom [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -26,7 +26,7 @@ zarf package inspect sbom [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -32,7 +32,7 @@ zarf package inspect values-files [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -32,6 +32,7 @@ zarf package inspect values-files [ PACKAGE ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -25,7 +25,7 @@ zarf package list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -25,6 +25,7 @@ zarf package list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -73,6 +73,7 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -73,7 +73,7 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -41,6 +41,7 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -41,7 +41,7 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -41,7 +41,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -41,6 +41,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -32,6 +32,7 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -32,7 +32,7 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
   -k, --key string                 Path to public key file for validating signed packages
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -28,6 +28,7 @@ zarf say [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -28,7 +28,7 @@ zarf say [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -20,7 +20,7 @@ Collection of additional tools to make airgap easier
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -20,6 +20,7 @@ Collection of additional tools to make airgap easier
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -20,6 +20,7 @@ Compresses/Decompresses generic archives, including Zarf packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -20,7 +20,7 @@ Compresses/Decompresses generic archives, including Zarf packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -24,6 +24,7 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -24,7 +24,7 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -25,7 +25,7 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -25,6 +25,7 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -24,7 +24,7 @@ zarf tools archiver version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -24,6 +24,7 @@ zarf tools archiver version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -25,7 +25,7 @@ zarf tools clear-cache [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -25,6 +25,7 @@ zarf tools clear-cache [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -26,7 +26,7 @@ zarf tools download-init [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -26,6 +26,7 @@ zarf tools download-init [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -24,7 +24,7 @@ zarf tools gen-key [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -24,6 +24,7 @@ zarf tools gen-key [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -25,7 +25,7 @@ zarf tools gen-pki HOST [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -25,6 +25,7 @@ zarf tools gen-pki HOST [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -45,6 +45,7 @@ $ zarf tools get-creds artifact
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -45,7 +45,7 @@ $ zarf tools get-creds artifact
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_helm.md
+++ b/site/src/content/docs/commands/zarf_tools_helm.md
@@ -39,7 +39,7 @@ Subset of the Helm CLI that includes the repo and dependency commands for managi
 ### Options inherited from parent commands
 
 ```
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_helm.md
+++ b/site/src/content/docs/commands/zarf_tools_helm.md
@@ -39,6 +39,7 @@ Subset of the Helm CLI that includes the repo and dependency commands for managi
 ### Options inherited from parent commands
 
 ```
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency.md
@@ -71,7 +71,7 @@ for this case.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency.md
@@ -71,6 +71,7 @@ for this case.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
@@ -41,7 +41,7 @@ zarf tools helm dependency build CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_build.md
@@ -41,6 +41,7 @@ zarf tools helm dependency build CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
@@ -37,7 +37,7 @@ zarf tools helm dependency list CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_list.md
@@ -37,6 +37,7 @@ zarf tools helm dependency list CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
@@ -45,6 +45,7 @@ zarf tools helm dependency update CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_dependency_update.md
@@ -45,7 +45,7 @@ zarf tools helm dependency update CHART [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo.md
@@ -29,6 +29,7 @@ It can be used to add, remove, list, and index chart repositories.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo.md
@@ -29,7 +29,7 @@ It can be used to add, remove, list, and index chart repositories.
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
@@ -36,6 +36,7 @@ zarf tools helm repo add [NAME] [URL] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_add.md
@@ -36,7 +36,7 @@ zarf tools helm repo add [NAME] [URL] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --kube-as-user string             username to impersonate for the operation

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
@@ -40,7 +40,7 @@ zarf tools helm repo index [DIR] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_index.md
@@ -40,6 +40,7 @@ zarf tools helm repo index [DIR] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
@@ -26,7 +26,7 @@ zarf tools helm repo list [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_list.md
@@ -26,6 +26,7 @@ zarf tools helm repo list [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
@@ -25,7 +25,7 @@ zarf tools helm repo remove [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_remove.md
@@ -25,6 +25,7 @@ zarf tools helm repo remove [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
@@ -37,7 +37,7 @@ zarf tools helm repo update [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_repo_update.md
@@ -37,6 +37,7 @@ zarf tools helm repo update [REPO1 [REPO2 ...]] [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_version.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_version.md
@@ -25,7 +25,7 @@ zarf tools helm version [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_helm_version.md
+++ b/site/src/content/docs/commands/zarf_tools_helm_version.md
@@ -25,6 +25,7 @@ zarf tools helm version [flags]
 ```
       --burst-limit int                 client-side default throttling limit (default 100)
       --debug                           enable verbose output
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify        Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --kube-apiserver string           the address and the port for the Kubernetes API server
       --kube-as-group stringArray       group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/site/src/content/docs/commands/zarf_tools_kubectl.md
+++ b/site/src/content/docs/commands/zarf_tools_kubectl.md
@@ -23,7 +23,7 @@ zarf tools kubectl [flags]
 ### Options inherited from parent commands
 
 ```
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_kubectl.md
+++ b/site/src/content/docs/commands/zarf_tools_kubectl.md
@@ -23,6 +23,7 @@ zarf tools kubectl [flags]
 ### Options inherited from parent commands
 
 ```
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_monitor.md
+++ b/site/src/content/docs/commands/zarf_tools_monitor.md
@@ -48,7 +48,8 @@ zarf tools monitor [flags]
 ### Options inherited from parent commands
 
 ```
-      --plain-http   Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --features string   [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --plain-http        Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_monitor.md
+++ b/site/src/content/docs/commands/zarf_tools_monitor.md
@@ -48,8 +48,8 @@ zarf tools monitor [flags]
 ### Options inherited from parent commands
 
 ```
-      --features string   [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
-      --plain-http        Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --features stringToString   [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
+      --plain-http                Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -23,7 +23,7 @@ Tools for working with container registries using go-containertools
 ### Options inherited from parent commands
 
 ```
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -23,6 +23,7 @@ Tools for working with container registries using go-containertools
 ### Options inherited from parent commands
 
 ```
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -37,6 +37,7 @@ $ zarf tools registry catalog reg.example.com
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -37,7 +37,7 @@ $ zarf tools registry catalog reg.example.com
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -27,7 +27,7 @@ zarf tools registry copy SRC DST [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -27,6 +27,7 @@ zarf tools registry copy SRC DST [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -36,6 +36,7 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -36,7 +36,7 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -38,6 +38,7 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -38,7 +38,7 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_export.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_export.md
@@ -36,6 +36,7 @@ $ zarf tools registry export ghcr.io/stefanprodan/podinfo:6.4.0 podinfo.6.4.0.ta
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_export.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_export.md
@@ -36,7 +36,7 @@ $ zarf tools registry export ghcr.io/stefanprodan/podinfo:6.4.0 podinfo.6.4.0.ta
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -27,7 +27,7 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -27,6 +27,7 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -38,6 +38,7 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -38,7 +38,7 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_manifest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_manifest.md
@@ -36,6 +36,7 @@ $ zarf tools registry manifest ghcr.io/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_manifest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_manifest.md
@@ -36,7 +36,7 @@ $ zarf tools registry manifest ghcr.io/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -25,6 +25,7 @@ zarf tools registry prune [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -25,7 +25,7 @@ zarf tools registry prune [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -39,7 +39,7 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -39,6 +39,7 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -42,6 +42,7 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -42,7 +42,7 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -31,7 +31,7 @@ zarf tools registry version [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -31,6 +31,7 @@ zarf tools registry version [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --features string                    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom.md
@@ -45,6 +45,7 @@ zarf tools sbom [flags]
 ### Options inherited from parent commands
 
 ```
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_sbom.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom.md
@@ -45,7 +45,7 @@ zarf tools sbom [flags]
 ### Options inherited from parent commands
 
 ```
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_sbom_attest.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_attest.md
@@ -41,6 +41,7 @@ zarf tools sbom attest --output [FORMAT] <IMAGE> [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_attest.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_attest.md
@@ -41,7 +41,7 @@ zarf tools sbom attest --output [FORMAT] <IMAGE> [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
@@ -20,7 +20,7 @@ Show available catalogers and configuration
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
@@ -20,6 +20,7 @@ Show available catalogers and configuration
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
@@ -28,6 +28,7 @@ zarf tools sbom cataloger list [OPTIONS] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
@@ -28,7 +28,7 @@ zarf tools sbom cataloger list [OPTIONS] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_config.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config.md
@@ -25,7 +25,7 @@ zarf tools sbom config [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_config.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config.md
@@ -25,6 +25,7 @@ zarf tools sbom config [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
@@ -25,6 +25,7 @@ zarf tools sbom config locations [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
@@ -25,7 +25,7 @@ zarf tools sbom config locations [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_convert.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_convert.md
@@ -31,6 +31,7 @@ zarf tools sbom convert [SOURCE-SBOM] -o [FORMAT] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_convert.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_convert.md
@@ -31,7 +31,7 @@ zarf tools sbom convert [SOURCE-SBOM] -o [FORMAT] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_login.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_login.md
@@ -27,6 +27,7 @@ zarf tools sbom login [OPTIONS] [SERVER] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_login.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_login.md
@@ -27,7 +27,7 @@ zarf tools sbom login [OPTIONS] [SERVER] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_scan.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_scan.md
@@ -42,7 +42,7 @@ zarf tools sbom scan [SOURCE] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_scan.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_scan.md
@@ -42,6 +42,7 @@ zarf tools sbom scan [SOURCE] [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_version.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_version.md
@@ -25,7 +25,7 @@ zarf tools sbom version [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_sbom_version.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_version.md
@@ -25,6 +25,7 @@ zarf tools sbom version [flags]
 
 ```
   -c, --config stringArray         syft configuration file(s) to use
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --profile stringArray        configuration profiles to use

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -73,6 +73,7 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -73,7 +73,7 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -57,6 +57,7 @@ $ zarf tools wait-for http google.com success                           #  wait 
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -57,7 +57,7 @@ $ zarf tools wait-for http google.com success                           #  wait 
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_tools_yq.md
+++ b/site/src/content/docs/commands/zarf_tools_yq.md
@@ -86,6 +86,7 @@ zarf tools yq -P sample.json
 ### Options inherited from parent commands
 
 ```
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_yq.md
+++ b/site/src/content/docs/commands/zarf_tools_yq.md
@@ -86,7 +86,7 @@ zarf tools yq -P sample.json
 ### Options inherited from parent commands
 
 ```
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_yq_completion.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_completion.md
@@ -63,6 +63,7 @@ zarf tools yq completion [bash|zsh|fish|powershell]
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_tools_yq_completion.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_completion.md
@@ -63,7 +63,7 @@ zarf tools yq completion [bash|zsh|fish|powershell]
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
@@ -59,7 +59,7 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
@@ -59,6 +59,7 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval.md
@@ -61,7 +61,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
-      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString         [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval.md
@@ -61,6 +61,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
       --debug-node-info                 debug node info
   -e, --exit-status                     set exit status if there are no matches or null or false is returned
       --expression string               forcibly set the expression argument. Useful when yq argument detection thinks your expression is a file.
+      --features string                 [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --from-file string                Load expression from specified file.
   -f, --front-matter string             (extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact
       --header-preprocess               Slurp any header comments and separators before processing expression. (default true)

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -29,7 +29,7 @@ zarf version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
-      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
+      --features stringToString    [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -29,6 +29,7 @@ zarf version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --features string            [ALPHA] Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true"
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running Zarf. Valid options are: warn, info, debug, trace (default "info")

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -37,6 +37,10 @@ const (
 	VLogFormat = "log_format"
 	VNoColor   = "no_color"
 
+	// Root config, Features
+
+	VFeatures = "features"
+
 	// Init config keys
 
 	VInitComponents   = "init.components"

--- a/src/internal/feature/feature.go
+++ b/src/internal/feature/feature.go
@@ -200,6 +200,12 @@ func featuresToMap(fs []Feature) map[Name]Feature {
 	return m
 }
 
+// List of feature names
+var (
+	// AxolotlMode declares the "axolotl-mode" feature
+	AxolotlMode Name = "axolotl-mode"
+)
+
 func init() {
 	features := []Feature{
 		// NOTE: Here is an example default feature flag
@@ -212,12 +218,12 @@ func init() {
 		// 	Stage:       GA,
 		// },
 		{
-			Name: "axolotl-mode",
+			Name: AxolotlMode,
 			Description: "Enabling \"axolotl-mode\" runs `zarf say` at the beginning of each CLI command." +
 				"This fun feature is intended to help with testing feature flags.",
 			Enabled: false,
 			Since:   "v0.60.0",
-			Stage:   "alpha",
+			Stage:   Alpha,
 		},
 	}
 

--- a/src/internal/feature/feature.go
+++ b/src/internal/feature/feature.go
@@ -83,6 +83,14 @@ type Feature struct {
 	Stage `json:"stage,omitempty"`
 }
 
+func (f Feature) String() string {
+	s := "disabled"
+	if f.Enabled {
+		s = "enabled"
+	}
+	return fmt.Sprintf("%s:%s", f.Name, s)
+}
+
 // IsEnabled allows users to optimistically check for a feature. Useful for control flow. Any user-enabled or disabled
 // features take precedence over the default setting.
 func IsEnabled(name Name) bool {
@@ -203,6 +211,14 @@ func init() {
 		// 	Since:       "v0.60.0",
 		// 	Stage:       GA,
 		// },
+		{
+			Name: "axolotl-mode",
+			Description: "Enabling \"axolotl-mode\" runs `zarf say` at the beginning of each CLI command." +
+				"This fun feature is intended to help with testing feature flags.",
+			Enabled: false,
+			Since:   "v0.60.0",
+			Stage:   "alpha",
+		},
 	}
 
 	err := setDefault(features)


### PR DESCRIPTION
## Description
This PR adds `features` to the cmd layer of Zarf. This includes additional viper config, a setup step and user debug notification in `rootCmd.preRun()`, as well as some additional parsing and printing functions where needed.

It also adds the "feature" `"axolotl-mode"` to help test the new `feature` implementation. Enabling the easter egg `"axolotl-mode=true"` is a throwback to before the structured logging overhaul, and allows users to opt-in to the original logo print before CLI commands, printing out the same output as `zarf say`.

Of note is that the string-input for each of (`CLI:--features="...", ENV:ZARF_FEATURES="...", file:features = '...'`) deviates slightly from the current ZEP-0035 revision and the proposal will need to be updated after this is merged. I opted for one flag/key-name, `features` a list of KV pairs, with comma separated pairs and `=` separated: `feature_name=bool`.

I believe this matches expected cli conventions of golang projects better, and using this input string in all places keeps our parsing code much simpler. I also believe one could make an argument in favor of the overall UX for this approach, even though it doesn't use nested keys and maps like a user might expect for files. With one format and one key name, features are named and handled the same in each config source, and users can simply copy-paste their settings from one to another.

Examples below:


### Config file
<img width="415" height="70" alt="Screenshot 2025-08-06 at 13 09 42" src="https://github.com/user-attachments/assets/9542b957-787f-41b6-8c20-58ecf5bf9d21" />
<img width="1063" height="235" alt="Screenshot 2025-08-06 at 13 24 25" src="https://github.com/user-attachments/assets/048ef19e-18e8-4492-af88-ba281fc99265" />

### ENV var
<img width="1066" height="225" alt="Screenshot 2025-08-06 at 13 25 02" src="https://github.com/user-attachments/assets/078f44b1-da77-4e3d-ae8e-19dffaf4c942" />

### CLI flag
<img width="1061" height="224" alt="Screenshot 2025-08-06 at 13 25 40" src="https://github.com/user-attachments/assets/5daad724-ca79-41c5-a670-abed1ad6e7b6" />

### Axolotl Mode enabled
<img width="773" height="421" alt="Screenshot 2025-08-06 at 13 26 02" src="https://github.com/user-attachments/assets/abf89bf6-0457-47d5-b210-0b4f7a9d71ce" />

## Open questions
- Should we be warning users if they provide a user flag that isn't in the defaults? It's hard to imagine a feature that we don't have a described default state for. This didn't come up in the UX section of the proposal but it might be a good follow-up for Beta readiness. Adding this will require an extra read during cmd setup, but shouldn't be prohibitively difficult.
- Should we use `featureName={enabled|disabled}` rather than `featureName={true|false}`? I don't think the expected behavior is even slightly ambiguous, but the former matches our internal model better. It also requires more typing so, 🤷 i could go either way.
- Just a note, but worth mentioning that Features is still in Alpha and the API as well as cmd layers are all subject to change based on feedback!

EDIT:

The current state of the PR is a bit different than the examples. Now we use Viper's `StringToString` map type, which has different parsing rules depending on whether it's a flag, env var, or config file. This behavior is the same as other places we use StringToString, so there's no special UX here - just the same Zarf users are already accustomed to.

## Related Issue
Relates to https://github.com/zarf-dev/proposals/tree/main/0035-feature-flags

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
