### PR TITLE
Fix an issue where a Git URL with an environment variable cannot be cloned.

### DIFF
--- a/examples/helm-charts/zarf.yaml
+++ b/examples/helm-charts/zarf.yaml
@@ -35,6 +35,8 @@ components:
         version: 6.4.0
         namespace: podinfo-from-git
         # In this case `url` will load the helm chart located in the podinfo git repository
+        # For a private repository, the URL format can be as follows:
+        # url: https://${username}:${password}@github.com/private-repository.git
         url: https://github.com/stefanprodan/podinfo.git
         # By default git will look in the root of the git repository but you can define a sub directory with `gitPath`
         gitPath: charts/podinfo

--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -76,7 +76,7 @@ func Clone(ctx context.Context, rootPath, address string, shallow bool) (*Reposi
 
 	// Clone the repository
 	cloneOpts := &git.CloneOptions{
-		URL:        gitURLNoRef,
+		URL:        os.ExpandEnv(gitURLNoRef),
 		RemoteName: onlineRemoteName,
 	}
 	if ref.IsTag() || ref.IsBranch() {


### PR DESCRIPTION
## Description
When cloning a project, credentials can be embedded in the URL, e.g., `https://username:password@github.com/xxx/xxx.git`. However, embedding credentials directly in the command is not always a good idea. For example, as outlined in the [Zarf documentation](https://docs.zarf.dev/ref/components/#helm-charts), a Git repository can be defined within a component. While public repositories work perfectly, private repositories require authentication. Hardcoding a password in the Git URL is a poor practice, so leveraging environment variables to define the password in the OS shell or CI/CD pipeline is a better approach.

The issue arises because the `go-git` library does not automatically parse environment variables in the URL. Therefore, the environment variables must be expanded manually before pulling the repository.

## Related Issue
https://github.com/zarf-dev/zarf/issues/4052

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
