### PR TITLE
feat: allow interactive remove

### DIFF
--- a/packages/distros/eks/zarf.yaml
+++ b/packages/distros/eks/zarf.yaml
@@ -60,6 +60,7 @@ components:
     actions:
       onDeploy:
         before:
+          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) utils write-kubeconfig -c ${ZARF_VAR_EKS_CLUSTER_NAME}
           - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) delete cluster -f eks.yaml --disable-nodegroup-eviction --wait
         after:
           # clean up after ourselves

--- a/packages/distros/eks/zarf.yaml
+++ b/packages/distros/eks/zarf.yaml
@@ -60,7 +60,6 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) utils write-kubeconfig -c ${ZARF_VAR_EKS_CLUSTER_NAME}
           - cmd: ./binaries/eksctl_$(uname -s)_$(uname -m) delete cluster -f eks.yaml --disable-nodegroup-eviction --wait
         after:
           # clean up after ourselves

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -22,7 +22,7 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
 
 ```
       --components string           Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
-  -c, --confirm                     REQUIRED. Confirm the removal action to prevent accidental deletions
+  -c, --confirm                     Confirms the removal action
   -h, --help                        help for remove
   -n, --namespace string            [Alpha] Override the namespace for package removal. Applicable only to packages deployed using the namespace flag.
       --skip-signature-validation   Skip validating the signature of the Zarf package

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1132,7 +1132,6 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdPackageRemoveFlagConfirm)
-	_ = cmd.MarkFlagRequired("confirm")
 	cmd.Flags().StringVar(&pkgConfig.PkgOpts.OptionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageRemoveFlagComponents)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", v.GetString(VPkgDeployNamespace), lang.CmdPackageRemoveFlagNamespace)
 	cmd.Flags().BoolVar(&pkgConfig.PkgOpts.SkipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
@@ -1180,6 +1179,20 @@ func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
 		Timeout:           config.ZarfDefaultTimeout,
 		NamespaceOverride: o.namespaceOverride,
 	}
+	if !config.CommonOptions.Confirm {
+		err = utils.ColorPrintYAML(pkg, nil, true)
+		if err != nil {
+			return fmt.Errorf("unable to print package definition: %w", err)
+		}
+		prompt := &survey.Confirm{
+			Message: "remove this Zarf package?",
+		}
+		var confirm bool
+		if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
+			return fmt.Errorf("package remove cancelled")
+		}
+	}
+
 	err = packager.Remove(ctx, pkg, removeOpt)
 	if err != nil {
 		return err

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -292,7 +292,7 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 
 	CmdPackageRemoveShort          = "Removes a Zarf package that has been deployed already (runs offline)"
 	CmdPackageRemoveLong           = "Removes a Zarf package that has been deployed already (runs offline). Remove reverses the deployment order, the last component is removed first."
-	CmdPackageRemoveFlagConfirm    = "REQUIRED. Confirm the removal action to prevent accidental deletions"
+	CmdPackageRemoveFlagConfirm    = "Confirms the removal action"
 	CmdPackageRemoveFlagComponents = "Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported."
 	CmdPackageRemoveFlagNamespace  = "[Alpha] Override the namespace for package removal. Applicable only to packages deployed using the namespace flag."
 


### PR DESCRIPTION
## Description

This allows users to preform an interactive remove when `--confirm` is not set

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
