### PR TITLE
fix: auto uppercase variables

### DIFF
--- a/src/pkg/variables/variables.go
+++ b/src/pkg/variables/variables.go
@@ -7,6 +7,7 @@ package variables
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 )
@@ -27,6 +28,7 @@ func (vc *VariableConfig) PopulateVariables(variables []v1alpha1.InteractiveVari
 	}
 
 	for _, variable := range variables {
+		variable.Name = strings.ToUpper(variable.Name)
 		_, present := vc.setVariableMap[variable.Name]
 
 		// Variable is present, no need to continue checking

--- a/src/pkg/variables/variables_test.go
+++ b/src/pkg/variables/variables_test.go
@@ -99,6 +99,16 @@ func TestPopulateVariables(t *testing.T) {
 				"NAME": {Variable: v1alpha1.Variable{Name: "NAME"}, Value: "Set"},
 			},
 		},
+		{
+			vc: VariableConfig{setVariableMap: SetVariableMap{}, prompt: prompt},
+			vars: []v1alpha1.InteractiveVariable{
+				{Variable: v1alpha1.Variable{Name: "lowercase"}},
+			},
+			presets: map[string]string{"LOWERCASE": "set"},
+			wantVars: SetVariableMap{
+				"LOWERCASE": {Variable: v1alpha1.Variable{Name: "LOWERCASE"}, Value: "set"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Description

The name in variables are always made uppercase when they are used. We automatically make set variables from the CLI uppercase, but we don't do this with variables from the SDK. This changes it so we simply always make the variable names uppercase

## Related Issue

Fixes #4081

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
