### PR TITLE
chore(deps): pin goreleaser action in nightly

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -199,7 +199,7 @@ jobs:
           echo HELM_VERSION=$(go list -f '{{.Version}}' -m helm.sh/helm/v3) >> $GITHUB_ENV
 
       - name: Run GoReleaser (Nightly)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser-pro
           version: "~> v2"


### PR DESCRIPTION
## Description

Pins the goreleaser-action dependency to resolve the security finding.

## Related Issue

Fixes https://github.com/zarf-dev/zarf/security/code-scanning/195

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
