### PR TITLE
chore: update dependabot github actions frequency & grouping

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,8 +21,12 @@ updates:
           - "github.com/docker/*"
   - package-ecosystem: github-actions
     directory: /
+    groups:
+      actions-organization:
+        patterns:
+          - "actions/*"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
## Description

This lowers the frequency of GitHub actions from dependabot to once a weekly to lower noise. It also groups together actions from the [actions organization](https://github.com/actions), as these are generally trusted and break very rarely so group reviews are not complex.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
