### PR TITLE
feat: remove hints from deploy yaml print

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -327,7 +327,7 @@ func deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts packager.
 func confirmDeploy(ctx context.Context, pkgLayout *layout.PackageLayout, setVariables map[string]string) (err error) {
 	l := logger.From(ctx)
 
-	err = utils.ColorPrintYAML(pkgLayout.Pkg, getPackageYAMLHints(pkgLayout.Pkg, setVariables), true)
+	err = utils.ColorPrintYAML(pkgLayout.Pkg, getPackageYAMLHints(pkgLayout.Pkg, setVariables), false)
 	if err != nil {
 		return fmt.Errorf("unable to print package definition: %w", err)
 	}
@@ -381,12 +381,6 @@ func getPackageYAMLHints(pkg v1alpha1.ZarfPackage, setVariables map[string]strin
 		}
 		hints = utils.AddRootListHint(hints, "name", variable.Name, fmt.Sprintf("currently set to %s", value))
 	}
-
-	hints = utils.AddRootHint(hints, "metadata", "information about this package\n")
-	hints = utils.AddRootHint(hints, "build", "info about the machine, zarf version, and user that created this package\n")
-	hints = utils.AddRootHint(hints, "components", "components selected for this operation")
-	hints = utils.AddRootHint(hints, "constants", "static values set by the package author")
-	hints = utils.AddRootHint(hints, "variables", "deployment-specific values that are set on each package deployment")
 
 	return hints
 }


### PR DESCRIPTION
## Description

This removes most of the hints from the package yaml. The only one that is kept is the hint that gives the variable values as this hint could be relied on, and it doesn't take up extra newlines. Otherwise, the feedback I've gotten from users is that the hints don't add much value. As we've seen the general user base of Zarf shift towards more automated deploys, keeping there is less of a case for keeping these in. Additionally there is currently a bug with how the hints display variables.

## Related Issue

Fixes #2974

## visual changes

### before / currently

<img width="1333" height="1009" alt="image" src="https://github.com/user-attachments/assets/a4fc6030-7c6e-4b8b-9380-04a30e1ca0b0" />


### after

<img width="1326" height="1005" alt="image" src="https://github.com/user-attachments/assets/385cb777-0a57-4725-b375-e36c5799b327" />


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
