### PR TITLE
fix: update dependabot npm ignores to compromised library versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,8 +32,9 @@ updates:
     schedule:
       interval: daily
     ignore:
-      # NOTE(mkcp): These packages were compromised as part of a supply chain attack. Zarf was not affected and many of
-      # the packages have been removed, but we are intentionally ignoring these versions as an extra layer of safety.
+      # NOTE(mkcp): 09/08/25 These packages were compromised as part of a supply chain attack. Zarf was not affected and
+      # many of the packages have been removed, but we are intentionally ignoring these versions as an extra layer of
+      # safety.
       - dependency-name: "backslash"
         versions: ["0.2.1"]
       - dependency-name: "chalk"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,3 +31,42 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      # NOTE(mkcp): These packages were compromised as part of a supply chain attack. Zarf was not affected and many of
+      # the packages have been removed, but we are intentionally ignoring these versions as an extra layer of safety.
+      - dependency-name: "backslash"
+        versions: ["0.2.1"]
+      - dependency-name: "chalk"
+        versions: ["5.6.1"]
+      - dependency-name: "chalk-template"
+        versions: ["1.1.1"]
+      - dependency-name: "color-convert"
+        versions: ["3.1.1"]
+      - dependency-name: "color-name"
+        versions: ["2.0.1"]
+      - dependency-name: "color-string"
+        versions: ["2.1.1"]
+      - dependency-name: "wrap-ansi"
+        versions: ["9.0.1"]
+      - dependency-name: "supports-hyperlinks"
+        versions: ["4.1.1"]
+      - dependency-name: "strip-ansi"
+        versions: ["7.1.1"]
+      - dependency-name: "slice-ansi"
+        versions: ["7.1.1"]
+      - dependency-name: "simple-swizzle"
+        versions: ["0.2.3"]
+      - dependency-name: "is-arrayish"
+        versions: ["0.3.3"]
+      - dependency-name: "error-ex"
+        versions: ["1.3.3"]
+      - dependency-name: "has-ansi"
+        versions: ["6.0.1"]
+      - dependency-name: "ansi-regex"
+        versions: ["6.2.1"]
+      - dependency-name: "ansi-styles"
+        versions: ["6.2.2"]
+      - dependency-name: "supports-color"
+        versions: ["10.2.1"]
+      - dependency-name: "debug"
+        versions: ["4.4.2"]


### PR DESCRIPTION
## Description
This PR adds a list of compromised package versions as as result of a supply chain attack, described here: https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised. Zarf was not affected by this attack, and many of the compromised package versions have been removed as of the time of this PR. The CVE has also been flagged and registered, so it's likely that Dependabot already won't generate PRs for versions.

However, out of an abundance of caution, we're intentionally removing these packages from Dependabot updates to ensure we don't pull in a known-bad package. 

## Related Issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
