### PR TITLE
fix(ci): remove nightly environment

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -167,7 +167,6 @@ jobs:
     needs: [repo-gate, build-release]
     if: ${{ needs.repo-gate.outputs.should_run == 'true' }}
     runs-on: large-ubuntu-zarf-release
-    environment: release
     env:
       CLI_VERSION: ${{ needs.build-release.outputs.cli_version }}
     permissions:


### PR DESCRIPTION
## Description

Nightly release workflow is currently failing due to the use of the `release` environment on the `create-release` job. 

> branch "main" is not allowed to deploy to release due to environment protection rules.

This removes the environment - as the protections to block what branches/tags can push to the environment prevent `main` and access to the environment secrets are not required.  

## Related Issue

Relates to #3928

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
