### PR TITLE
fix(ci): let goreleaser handle tags

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -216,7 +216,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          GORELEASER_CURRENT_TAG: ${{ env.CLI_VERSION }}
 
       - name: Report Disk Space on Failure
         if: failure()

--- a/.goreleaser-pro.yaml
+++ b/.goreleaser-pro.yaml
@@ -4,7 +4,7 @@ pro: true
 
 nightly:
   # Allows you to change the version of the generated nightly release.
-  version_template: "{{ .Version }}"
+  version_template: "{{ incpatch .Version }}-nightly"
 
   # Tag name to create if publish_release is enabled.
   tag_name: nightly


### PR DESCRIPTION
## Description

Nightly currently failing due to an error in the changelog generation. 

Believe this is due to `GORELEASER_CURRENT_TAG` use. Original goal was to isolate version definition to a single location - but we may need to try a strategy where goreleaser manages the tags itself.

if you review the last [nightly](https://github.com/zarf-dev/zarf/actions/runs/17606032726/job/50017337363) you will see an error around `git log` and goreleaser being unable to interpret that the version it is trying to compare against is the version we're trying to produce. 

## Related Issue

Relates to #3928 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
