### PR TITLE
ci: stop building examples

### DIFF
--- a/.github/actions/packages/action.yaml
+++ b/.github/actions/packages/action.yaml
@@ -6,10 +6,6 @@ inputs:
     description: 'Build the init package'
     required: false
     default: 'true'
-  build-examples:
-    description: 'Build the example packages'
-    required: false
-    default: 'true'
   os:
     description: 'Which OS to build for'
     required: false
@@ -29,7 +25,3 @@ runs:
         make init-package ARCH=amd64
       shell: ${{ inputs.shell }}
       if: ${{ inputs.init-package == 'true' }}
-    - run: |
-        make build-examples ARCH=amd64
-      shell: ${{ inputs.shell }}
-      if: ${{ inputs.build-examples == 'true' }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Build binary and zarf packages
         uses: ./.github/actions/packages
-        with:
-          build-examples: "false"
 
       # Upload the contents of the build directory for later stages to use
       - name: Upload build artifacts

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -45,7 +45,6 @@ jobs:
         uses: ./.github/actions/packages
         with:
           init-package: "false"
-          build-examples: "false"
 
       - name: Setup k3d
         uses: ./.github/actions/k3d

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Build PR binary and zarf init package
         uses: ./.github/actions/packages
-        with:
-          build-examples: "false"
 
       # Upload the contents of the build directory for later stages to use
       - name: Upload build artifacts


### PR DESCRIPTION
## Description

Currently the action .github/actions/packages has a step to build examples. Only the nightly eks cluster and test-windows workflow uses it, however building examples is no longer needed since we now have every e2e test build the packages it needs within the test.  

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
