### PR TITLE
fix: correct image push failures by avoiding unnecessary platform specification

### DIFF
--- a/src/internal/packager/images/push.go
+++ b/src/internal/packager/images/push.go
@@ -248,7 +248,6 @@ func copyImage(ctx context.Context, src *oci.Store, remote oras.Target, srcName 
 
 	copyOpts := oras.DefaultCopyOptions
 	copyOpts.Concurrency = concurrency
-	copyOpts.WithTargetPlatform(desc.Platform)
 
 	trackedRemote := NewTrackedTarget(remote, size, DefaultReport(logger.From(ctx), "image push in progress", srcName))
 	trackedRemote.StartReporting(ctx)


### PR DESCRIPTION
## Description

Currently we specify the target platform on image push. We get the target platform from the index.json. In theory, this will work fine, however since some images such as the arm64/linux/v8 platform of `docker.io/library/redis:7.0.15-alpine` include their platform in their index.json but not their manifest when we tell oras that it should push an image of platform `arm64/linux/v8` it doesn't find the platform in the manifest and fails. 

Looking in registry explorer at the redis image [index.json](https://oci.dag.dev/?image=redis%3A7.0.15-alpine) we can see that platform is specified for arm64/linux/v8, however when we look at [the manifest](https://oci.dag.dev/?image=redis@sha256:4c609b1ccae44c2a0f7b3eca475af5d0f1f02f8fb7df3970ee4d7ab6a5590f56&mt=application%2Fvnd.oci.image.manifest.v1%2Bjson&size=2484) we see that platform is not specified.  This differs from the amd64 image where platform is not specified in the index which is why we don't run into any issues during amd64 pushes. 

Zarf already does a check on each descriptor before push to validate that it's a manifest media type. By definition a manifest can only be a single platform so there is no reason to specify the platform of the image we are pushing. 

## Related Issue

Fixes #4108


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
