### PR TITLE
feat!: add custom names of init package in tar ball

### DIFF
--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -264,7 +264,11 @@ func (p *PackageLayout) FileName() (string, error) {
 	var name string
 	switch p.Pkg.Kind {
 	case v1alpha1.ZarfInitConfig:
-		name = fmt.Sprintf("zarf-init-%s", arch)
+		if p.Pkg.Metadata.Name == "" || p.Pkg.Metadata.Name == "init" {
+			name = fmt.Sprintf("zarf-init-%s", arch)
+		} else {
+			name = fmt.Sprintf("zarf-init-%s-%s", p.Pkg.Metadata.Name, arch)
+		}
 	case v1alpha1.ZarfPackageConfig:
 		name = fmt.Sprintf("zarf-package-%s-%s", p.Pkg.Metadata.Name, arch)
 	default:

--- a/src/pkg/packager/layout/package_test.go
+++ b/src/pkg/packager/layout/package_test.go
@@ -101,7 +101,7 @@ func TestPackageFileName(t *testing.T) {
 			expected: "zarf-init-amd64-v0.55.4.tar.zst",
 		},
 		{
-			name: "init package with a custom name",
+			name: "init package with a flavor",
 			pkg: v1alpha1.ZarfPackage{
 				Kind: v1alpha1.ZarfInitConfig,
 				Metadata: v1alpha1.ZarfMetadata{
@@ -113,6 +113,20 @@ func TestPackageFileName(t *testing.T) {
 				},
 			},
 			expected: "zarf-init-amd64-v0.55.4-upstream.tar.zst",
+		},
+		{
+			name: "init package with a custom name",
+			pkg: v1alpha1.ZarfPackage{
+				Kind: v1alpha1.ZarfInitConfig,
+				Metadata: v1alpha1.ZarfMetadata{
+					Version: "v0.55.4",
+					Name:    "my-cool-start",
+				},
+				Build: v1alpha1.ZarfBuildData{
+					Architecture: "amd64",
+				},
+			},
+			expected: "zarf-init-my-cool-start-amd64-v0.55.4.tar.zst",
 		},
 		{
 			name: "regular package with version",


### PR DESCRIPTION
## Description

When the Zarf init package is not empty or when named `init`, this PR will now include that name in the pulled down tar ball.

## Related Issue

Fixes #4095

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
