### PR TITLE
fix(ci): fix issue with nightly tag latest

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -46,16 +46,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Get the latest tag (e.g., v1.2.3 or 1.2.3)
-          LATEST_TAG="$(git describe --tags --abbrev=0)"
 
-          # Preserve any non-numeric prefix (commonly "v")
-          PREFIX="${LATEST_TAG%%[0-9]*}"            # "v" or ""
-          CORE="${LATEST_TAG#"$PREFIX"}"            # strip prefix -> "1.2.3[-suffix][+build]"
+          # Find the latest stable semver tag (ignores prereleases, nightly, etc.)
+          LATEST_TAG="$(git tag --sort=-version:refname \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -n1)"
 
-          # Strip any pre-release/build metadata from the core version
-          CORE="${CORE%%-*}"                        # drop "-rc1" etc.
-          CORE="${CORE%%+*}"                        # drop "+build" etc.
+          if [[ -z "${LATEST_TAG}" ]]; then
+            echo "No stable tags found, defaulting to 0.0.0"
+            LATEST_TAG="v0.0.0"
+          fi
+
+          PREFIX="${LATEST_TAG%%[0-9]*}"   # usually "v" or ""
+          CORE="${LATEST_TAG#"$PREFIX"}"
 
           IFS='.' read -r MAJOR MINOR PATCH <<<"${CORE}"
           : "${MAJOR:=0}" ; : "${MINOR:=0}" ; : "${PATCH:=0}"
@@ -66,9 +69,9 @@ jobs:
 
           echo "Computed nightly: ${NEW_TAG}"
 
-          # Outputs / ENV
           echo "cli_version=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           echo "CLI_VERSION=${NEW_TAG}" >> "$GITHUB_ENV"
+
 
       - name: Setup golang
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0


### PR DESCRIPTION
## Description

Resolves the issue of goreleaser force push on the nightly tag making the latest tag resolve to `nightly` instead of the latest semver. 

## Related Issue

Relates to #3928

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
