### PR TITLE
feat: stop retrying helm

### DIFF
--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -29,7 +29,7 @@ zarf dev deploy [flags]
   -h, --help                               help for deploy
       --no-yolo                            Disable the YOLO mode default override and create / deploy the package as-defined
       --registry-override stringToString   Specify a map of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet) (default [])
-      --retries int                        Number of retries to perform for Zarf operations like git/image pushes or Helm installs (default 3)
+      --retries int                        Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --timeout duration                   Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
 ```
 

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -75,7 +75,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --registry-push-username string   Username to access to the registry Zarf is configured to use (default "zarf-push")
       --registry-secret string          Registry secret value
       --registry-url string             External registry url address to use for this Zarf cluster
-      --retries int                     Number of retries to perform for Zarf operations like git/image pushes or Helm installs (default 3)
+      --retries int                     Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --set stringToString              Specify deployment variables to set on the command line (KEY=value) (default [])
       --skip-signature-validation       Skip validating the signature of the Zarf package
       --storage-class string            Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -27,7 +27,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
   -c, --confirm                     Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
   -h, --help                        help for deploy
   -n, --namespace string            [Alpha] Override the namespace for package deployment. Requires the package to have only one distinct namespace defined.
-      --retries int                 Number of retries to perform for Zarf operations like git/image pushes or Helm installs (default 3)
+      --retries int                 Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --set stringToString          Specify deployment variables to set on the command line (KEY=value) (default [])
       --shasum string               Shasum of the package to deploy. Required if deploying a remote https package.
       --skip-signature-validation   Skip validating the signature of the Zarf package

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -64,7 +64,7 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
       --registry-push-username string   Username to access to the registry Zarf is configured to use (default "zarf-push")
       --registry-url string             External registry url address to use for this Zarf cluster
       --repos                           mirror only the git repositories
-      --retries int                     Number of retries to perform for Zarf operations like git/image pushes or Helm installs (default 3)
+      --retries int                     Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --shasum string                   Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --skip-signature-validation       Skip validating the signature of the Zarf package
 ```

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -32,7 +32,7 @@ $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
   -c, --confirm                     Confirms package publish without prompting. Skips prompt for the signing key password
   -f, --flavor string               The flavor of components to include in the resulting package. The flavor will be appended to the package tag
   -h, --help                        help for publish
-      --retries int                 Number of retries to perform for Zarf operations like git/image pushes or Helm installs (default 1)
+      --retries int                 Number of retries to perform for Zarf operations like git/image pushes (default 1)
       --signing-key string          Private key for signing or re-signing packages with a new key. Accepts either a local file path or a Cosign-supported key provider
       --signing-key-pass string     Password to the private key used for publishing packages
       --skip-signature-validation   Skip validating the signature of the Zarf package

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -210,7 +210,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdPackageFlagConcurrency             = "Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries."
 	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
 	CmdPackageFlagSkipSignatureValidation = "Skip validating the signature of the Zarf package"
-	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes or Helm installs"
+	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes"
 
 	CmdPackageCreateShort = "Creates a Zarf package from a given directory or the current directory"
 	CmdPackageCreateLong  = "Builds an archive of resources and dependencies defined by the 'zarf.yaml' in the specified directory.\n" +


### PR DESCRIPTION
## Description

We should not retry the Helm install. As far as I know there is no way that the Helm install will recover after the first retry. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
