### PR TITLE
fix(ci): install latest version of syft for release expectations

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -6,6 +6,6 @@ runs:
   steps:
     - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
 
-    - uses: anchore/sbom-action/download-syft@b6a39da80722a2cb0ef5d197531764a89b5d48c3 # v0.15.8
+    - uses: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
 
     - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0


### PR DESCRIPTION
## Description

Nightly release exposed an issue with regards to the required versions of syft needed to perform the release. See issue for full diagnosis. 

## Related Issue

Fixes #4215 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
