### PR TITLE
fix: cleanup temp directory on pull and differential package loads

### DIFF
--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -66,9 +66,9 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		if err != nil {
 			return "", fmt.Errorf("failed to load differential package: %w", err)
 		}
-		defer func() {
-			err = errors.Join(err, pkgLayout.Cleanup())
-		}()
+		if err := pkgLayout.Cleanup(); err != nil {
+			return "", err
+		}
 		differentialPkg = pkgLayout.Pkg
 	}
 

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -81,9 +81,9 @@ func Pull(ctx context.Context, source, destination string, opts PullOptions) (_ 
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		err = errors.Join(err, pkgLayout.Cleanup())
-	}()
+	if err := pkgLayout.Cleanup(); err != nil {
+		return "", err
+	}
 	filename, err := pkgLayout.FileName()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

When `zarf package pull` is run or differential package is used we currently are not cleaning up the package we place in the temp directory. This PR corrects that 

## Related Issue

Fixes #3705

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
