### PR TITLE
docs: use fully-qualified brew install command

### DIFF
--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -9,7 +9,7 @@ import { Tabs, TabItem, Code } from '@astrojs/starlight/components';
 [Homebrew](https://brew.sh) is a package manager for macOS and Linux. You can install Zarf with Homebrew by running the following:
 
 ```bash
-brew tap defenseunicorns/tap && brew install zarf
+brew install defenseunicorns/tap/zarf
 ```
 
 ## GitHub Releases


### PR DESCRIPTION
## Description

Brew supports passing in a "fully-qualified" reference to a formula, which automates the `tap` step before installing, making it a single command to run.

I'm not sure how long this has been around, but as best as I can tell this is not new functionality (I want to say I've used this syntax for the past ~2 years or so).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
