### PR TITLE
docs: clean up 'understanding' file

### DIFF
--- a/site/src/content/docs/getting-started/understanding.mdx
+++ b/site/src/content/docs/getting-started/understanding.mdx
@@ -32,7 +32,6 @@ For Zarf-specific concepts, see the following pages:
 ### AirGap Basics
 
 - [What is AirGap](https://ibm.github.io/kubernetes-networking/vpc/airgap/)
-- [AirGap Software Delivery Linux Foundation Course](https://training.linuxfoundation.org/training/modern-air-gap-software-delivery-lfs281/) - Created by Defense Unicorns
 
 ### GitOps Basics
 


### PR DESCRIPTION
## Description

Updates the [understanding page in the docs](https://docs.zarf.dev/getting-started/understanding/).

1. [AirGap Software Delivery Linux Foundation Course](https://training.linuxfoundation.org/training/modern-air-gap-software-delivery-lfs281/) leads to a page that says, "THE TRAINING OR CERTIFICATION PRODUCT YOU ARE SEARCHING FOR IS NO LONGER AVAILABLE."
2. Removes a duplicate link.

## Related Issue

N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
