### PR TITLE
fix: wait shell escaping

### DIFF
--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -30,14 +30,18 @@ func isJSONPathWaitType(condition string) bool {
 	return true
 }
 
-var shellRegex = regexp.MustCompile(`[^\w@%+=:,./-]`)
+// unsafeShellCharsRegex matches any character that is NOT a letter, digit, underscore (/w) or shell safe special characters
+var unsafeShellCharsRegex = regexp.MustCompile(`[^\w@%+=:,./-]`)
 
-func ShellQuote(s string) string {
+// Source: https://github.com/alessio/shellescape/blob/v1.6.0/shellescape.go#L30-L42
+// SPDX-License-Identifier: MIT
+// Minor edits: Simplified for use case
+func shellQuote(s string) string {
 	if len(s) == 0 {
 		return "''"
 	}
 
-	if shellRegex.MatchString(s) {
+	if unsafeShellCharsRegex.MatchString(s) {
 		return fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "'\"'\"'"))
 	}
 
@@ -61,7 +65,7 @@ func ExecuteWait(ctx context.Context, waitTimeout, waitNamespace, condition, kin
 	if isJSONPathWaitType(condition) {
 		waitType = "jsonpath="
 		// Ensure any conditions aren't shell escaped
-		condition = ShellQuote(condition)
+		condition = shellQuote(condition)
 	} else {
 		waitType = "condition="
 	}


### PR DESCRIPTION
## Description

Currently when waiting for a jsonpath expression with bash special characters, the args passed to `kubectl wait` aren't properly escaped.

```console
$ zarf tools wait-for -n onebrief clusters cnpg-postgresql \
    '{.status.conditions[?(@.type=="Ready")].status}=True' \
    -l debug \
    --timeout 3s
DBG logger successfully initialized cfg.level=debug cfg.format=console cfg.destination=os.Stderr cfg.color=true
DBG User-configured features: features=
INF using config file location=zarf-config.yaml
DBG using temporary directory tmpDir=
INF waiting for clusters/cnpg-postgresql in namespace onebrief to exist.
DBG checking resource existence namespace=-n onebrief kind=clusters identifier=cnpg-postgresql
DBG cmd done cmd=[-e -c zarf tools kubectl get -n onebrief clusters cnpg-postgresql] stdout=NAME              AGE   INSTANCES   READY   STATUS                     PRIMARY
cnpg-postgresql   26h   1           1       Cluster in healthy state   cnpg-postgresql-1
 stderr= error=<nil>
INF waiting for clusters/cnpg-postgresql in namespace onebrief to be {.status.conditions[?(@.type=="Ready")].status}=True.
DBG wait error error=exit status 2
DBG checking resource existence namespace=-n onebrief kind=clusters identifier=cnpg-postgresql
DBG cmd done cmd=[-e -c zarf tools kubectl get -n onebrief clusters cnpg-postgresql] stdout=NAME              AGE   INSTANCES   READY   STATUS                     PRIMARY
cnpg-postgresql   26h   1           1       Cluster in healthy state   cnpg-postgresql-1
 stderr= error=<nil>
INF waiting for clusters/cnpg-postgresql in namespace onebrief to be {.status.conditions[?(@.type=="Ready")].status}=True.
DBG wait error error=exit status 2
ERR wait timed out
```

The same `kubectl wait` succeeds without issue

```console
$ kubectl wait -n onebrief \
  clusters cnpg-postgresql \
  --for jsonpath='{.status.conditions[?(@.type=="Ready")].status}=True' \
  --timeout=5s
cluster.postgresql.cnpg.io/cnpg-postgresql condition met
```

This is due to

```log
DBG wait done cmd=[-e -c build/zarf-mac-apple tools kubectl wait -n onebrief clusters cnpg-postgresql --for jsonpath={.status.conditions[?(@.type=="Ready")].status}=True --timeout=5s] stdout= stderr=sh: -c: line 0: syntax error near unexpected token `(' error=exit status 2
DBG wait error error=exit status 2
```

## Related Issue

Fixes #3844

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
