### PR TITLE
feat/fix(template): allow templates to be disabled in actions

### DIFF
--- a/examples/values-templating/zarf.yaml
+++ b/examples/values-templating/zarf.yaml
@@ -51,6 +51,17 @@ components:
           - sourcePath: ".database.host2"
             targetPath: ".config.database.host"
 
+  - name: actions-with-raw-templates
+    description: "This component demonstrates using template: false to pass go-template syntax to external tools"
+    required: true
+    actions:
+      onCreate:
+        after:
+          # You can disable templating when you need to pass go-template syntax to another tool that uses {{ }} delimiters
+          - cmd: |
+              echo "This {{ .wontBeProcessed }} stays as-is"
+            template: false
+
 
 # YAML keys starting with `x-` are custom keys that are ignored by the Zarf CLI
 # The `x-mdx` key is used to render the markdown content for https://docs.zarf.dev/ref/examples

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -306,6 +306,17 @@ type ZarfComponentAction struct {
 	Description string `json:"description,omitempty"`
 	// Wait for a condition to be met before continuing. Must specify either cmd or wait for the action. See the 'zarf tools wait-for' command for more info.
 	Wait *ZarfComponentActionWait `json:"wait,omitempty"`
+	// Disable go-template processing on the cmd field. This is useful when the cmd contains go-templates that should be passed to another system.
+	Template *bool `json:"template,omitempty"`
+}
+
+// ShouldTemplate returns if the action cmd should be templated or not.
+func (a ZarfComponentAction) ShouldTemplate() bool {
+	if a.Template != nil {
+		return *a.Template
+	}
+	// Default to true
+	return true
 }
 
 // ZarfComponentActionWait specifies a condition to wait for before continuing

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -86,10 +86,12 @@ func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfCom
 		cmdEscaped = helpers.Truncate(cmd, 60, false)
 	}
 
-	// Apply go-templates in cmds
-	cmd, err = template.Apply(ctx, cmd, tmplObjs)
-	if err != nil {
-		return fmt.Errorf("could not tempalte cmd %s: %w", cmdEscaped, err)
+	// Apply go-templates in cmds if templating is enabled
+	if action.ShouldTemplate() {
+		cmd, err = template.Apply(ctx, cmd, tmplObjs)
+		if err != nil {
+			return fmt.Errorf("could not template cmd %s: %w", cmdEscaped, err)
+		}
 	}
 
 	l.Info("running command", "cmd", cmdEscaped)

--- a/src/test/e2e/42_values_test.go
+++ b/src/test/e2e/42_values_test.go
@@ -48,6 +48,11 @@ func TestValues(t *testing.T) {
 	require.NoError(t, err, "unable to get action configmap")
 	require.Contains(t, kubectlOut, "myValue")
 
+	// Verify the raw template configmap was NOT processed by Zarf (template: false)
+	kubectlOut, _, err = e2e.Kubectl(t, "get", "configmap", "test-raw-template-configmap", "-o", "jsonpath='{.data.rawTemplate}'")
+	require.NoError(t, err, "unable to get raw template configmap")
+	require.Contains(t, kubectlOut, "template={{ .shouldNotBeProcessed }}")
+
 	// Remove the package
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "test-values", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)

--- a/src/test/packages/42-values/raw-template-configmap.yaml
+++ b/src/test/packages/42-values/raw-template-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-raw-template-configmap
+  namespace: default
+data:
+  rawTemplate: "{{ .Values.rawTemplate }}"

--- a/src/test/packages/42-values/zarf.yaml
+++ b/src/test/packages/42-values/zarf.yaml
@@ -22,6 +22,12 @@ components:
             setValues:
               - key: .yaml
                 type: yaml
+          # Test that template: false prevents Zarf from processing go-templates
+          - cmd: echo 'template={{ .shouldNotBeProcessed }}'
+            template: false
+            setValues:
+              - key: .rawTemplate
+                type: string
     manifests:
       - name: test-configmap
         template: true
@@ -31,3 +37,7 @@ components:
         template: true
         files:
           - action-configmap.yaml
+      - name: test-raw-template-configmap
+        template: true
+        files:
+          - raw-template-configmap.yaml

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -627,6 +627,10 @@
         "wait": {
           "$ref": "#/$defs/ZarfComponentActionWait",
           "description": "Wait for a condition to be met before continuing. Must specify either cmd or wait for the action. See the 'zarf tools wait-for' command for more info."
+        },
+        "template": {
+          "type": "boolean",
+          "description": "Disable go-template processing on the cmd field. This is useful when the cmd contains go-templates that should be passed to another system."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Description
When we designed values, we accounted for skipping templates in files and manifests. However, this usecase is also needed in actions, where sometimes the {{ }} template syntax is used by the system being called, and we need to pass the raw string through. This PR adds a key to actions: `template` that defaults to true. Users can optionally disable templates in their actions by setting it to false.

This also fixes a typo in the error chain from failed actions templating.

## Related Issue

Fixes #4282
Relates to #3946 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
