### PR TITLE
fix(ci): add name_template to the release configuration

### DIFF
--- a/.goreleaser-pro.yaml
+++ b/.goreleaser-pro.yaml
@@ -6,6 +6,9 @@ nightly:
   # Allows you to change the version of the generated nightly release.
   version_template: "{{ incpatch .Version }}-nightly"
 
+  # Tag name to create if publish_release is enabled.
+  tag_name: nightly
+
   # Whether to publish a release or not.
   publish_release: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,7 @@ release:
   github:
     owner: zarf-dev
     name: zarf
+  name_template: "v{{ .Version }}"
   prerelease: auto
   mode: append
   extra_files:


### PR DESCRIPTION
## Description

### Summary
Fixes the nightly release naming issue where GitHub releases were titled "nightly" instead of displaying the actual computed version (e.g., v0.64.1-nightly).

The nightly release process was creating GitHub releases with the literal title "nightly" instead of using the dynamically computed version tag. While the workflow correctly computed versions like v0.64.1-nightly and set them in CLI_VERSION, GoReleaser was not using this version for the release title displayed on GitHub.

### Root Cause
The issue stemmed from missing configuration in the GoReleaser release section. In GoReleaser, there are two distinct concepts that control different aspects of releases:
Git Tag Name `nightly.tag_name` controls the actual git tag created in the repository

Release Title/Name `release.name_template` controls the display name shown on the GitHub Releases page

The configuration had:
tag_name: nightly properly set to maintain a single rolling git tag
No name_template in the release section
Without an explicit name_template, GoReleaser defaults to using {{ .Tag }}, which for nightly builds with tag_name: nightly evaluates to the literal string "nightly".

### Solution
Added name_template: "v{{ .Version }}" to the release section in `.goreleaser.yaml`.

Why "v{{ .Version }}" and not "{{ .Version }}"?
GoReleaser's template variables work as follows:
.Tag includes the full tag with prefix (e.g., v0.64.0
.Version has the "v" prefix stripped (e.g., 0.64.0)
Since the workflow computes CLI_VERSION=v0.64.0 with the "v" prefix, and GoReleaser strips it for .Version, we need to add it back in the template to maintain consistency with existing release naming conventions.

This _should_ be backwards compatible with the standard release process.

## Related Issue

Fixes #4286 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
