### PR TITLE
docs: mark differential as stable

### DIFF
--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -24,7 +24,7 @@ zarf package create [ DIRECTORY ] [flags]
 
 ```
   -c, --confirm                     Confirm package creation without prompting
-      --differential string         [beta] Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package
+      --differential string         Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package
   -f, --flavor string               The flavor of components to include in the resulting package (i.e. have a matching or empty "only.flavor" key)
   -h, --help                        help for create
   -m, --max-package-size int        Specify the maximum size of the package in megabytes, packages larger than this will be split into multiple parts to be loaded onto smaller media (i.e. DVDs). Use 0 to disable splitting.

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -267,7 +267,7 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 	CmdPackageCreateFlagSigningKeyPassword    = "Password to the private key used for signing packages"
 	CmdPackageCreateFlagDeprecatedKey         = "[Deprecated] Path to private key file for signing packages (use --signing-key instead)"
 	CmdPackageCreateFlagDeprecatedKeyPassword = "[Deprecated] Password to the private key file used for signing packages (use --signing-key-pass instead)"
-	CmdPackageCreateFlagDifferential          = "[beta] Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package"
+	CmdPackageCreateFlagDifferential          = "Build a package that only contains the differential changes from local resources and differing remote resources from the specified previously built package"
 	CmdPackageCreateFlagRegistryOverride      = "Specify a mapping of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)"
 	CmdPackageCreateFlagFlavor                = "The flavor of components to include in the resulting package (i.e. have a matching or empty \"only.flavor\" key)"
 	CmdPackageCreateFlagValuesFiles           = "[alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times."


### PR DESCRIPTION
## Description

There is no issue for this, but differential has been around for well over a year and has seen at least some use. It is generally a simple feature to maintain, I vote that it should be considered stable

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
