### PR TITLE
docs: differential packages

### DIFF
--- a/site/src/content/docs/ref/create.mdx
+++ b/site/src/content/docs/ref/create.mdx
@@ -109,4 +109,4 @@ Additionally, you cannot template the component import path using package config
 ## Differential Packages
 
 The `--differential` flag accepts another Zarf package (local or OCI) as a reference. Images and Git repositories that exist in both packages are excluded from the new
-package, reducing its size. This is especially useful in environments where large data transfers are costly or time-consuming. View the [Differential Package Tutorial](/refs/tutorials/9-package-create-differential) for an example.
+package, reducing its size. This is especially useful in environments where large data transfers are costly or time-consuming. View the [Differential Package Tutorial](/tutorials/9-package-create-differential) for an example.


### PR DESCRIPTION
## Description

The purpose of differential packages have often been confusing to users. This adds information to them in the create section of our docs to shore that up. Additionally, if we decide that differential should be moved out of beta, we should have docs for it. 

Fixes: #4312 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
