### PR TITLE
chore: allow backwards compatibility with empty chart version 

### DIFF
--- a/src/internal/packager/helm/common.go
+++ b/src/internal/packager/helm/common.go
@@ -75,6 +75,11 @@ func ChartFromZarfManifest(manifest v1alpha1.ZarfManifest, manifestPath, package
 
 // StandardName generates a predictable full path for a helm chart for Zarf.
 func StandardName(destination string, chart v1alpha1.ZarfChart) string {
+	// While it is not possible for v1alpha1 packages to be created with an empty version, future API versions will allow this.
+	// This check is introduced in v0.65.0, allowing future packages with empty versions to have backwards compatibility
+	if chart.Version == "" {
+		return filepath.Join(destination, chart.Name)
+	}
 	return filepath.Join(destination, chart.Name+"-"+chart.Version)
 }
 


### PR DESCRIPTION
## Description

The v1beta1 schema will remove the field `.components.[x].charts.[x].version`. see https://github.com/zarf-dev/proposals/pull/52. However, this will make these packages incompatible with current versions of Zarf. By adding this change now, v1beta1 charts will be backwards compatible in the future (without having to add a `-` to every filepath).

## Related Issue

Relates to https://github.com/zarf-dev/zarf/issues/3813
Relates to #2245


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
