### PR TITLE
fix(distribution): disable otel tracing by default

### DIFF
--- a/packages/zarf-registry/chart/Chart.yaml
+++ b/packages/zarf-registry/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Zarf internal registry
 name: docker-registry
-version: 1.0.0
+version: 1.0.1
 
 maintainers:
   - name: The Zarf Authors

--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: "Registry Realm"
             - name: REGISTRY_AUTH_HTPASSWD_PATH
               value: "/etc/docker/registry/htpasswd"
+            - name: OTEL_TRACES_EXPORTER
+              value: {{ .Values.opentelemetry.exporter | default "otlp" }}
 {{- if .Values.persistence.enabled }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"

--- a/packages/zarf-registry/chart/values.yaml
+++ b/packages/zarf-registry/chart/values.yaml
@@ -104,3 +104,6 @@ serviceAccount:
   create: false
   name: ""
   annotations: {}
+
+opentelemetry:
+  exporter: none

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -73,8 +73,6 @@ caBundle: |
 
 extraEnvVars:
   ###ZARF_VAR_REGISTRY_EXTRA_ENVS###
-  - name: OTEL_TRACES_EXPORTER
-    value: none
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -83,3 +81,6 @@ serviceAccount:
   name: "###ZARF_VAR_REGISTRY_SERVICE_ACCOUNT_NAME###"
   annotations:
     ###ZARF_VAR_REGISTRY_SERVICE_ACCOUNT_ANNOTATIONS###
+
+opentelemetry:
+  exporter: ###ZARF_VAR_REGISTRY_OTEL_EXPORTER###

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -58,6 +58,10 @@ variables:
     default: ""
     autoIndent: true
 
+  - name: REGISTRY_OTEL_EXPORTER
+    description: set the opentelemetry exporter
+    default: "none"
+
   - name: REGISTRY_CREATE_SERVICE_ACCOUNT
     description: Toggle the creation of a new service account for the registry
     default: "false"
@@ -153,7 +157,7 @@ components:
       - name: docker-registry
         releaseName: zarf-docker-registry
         localPath: chart
-        version: 1.0.0
+        version: 1.0.1
         namespace: zarf
         valuesFiles:
           - registry-values.yaml
@@ -180,7 +184,7 @@ components:
       - name: docker-registry
         releaseName: zarf-docker-registry
         localPath: chart
-        version: 1.0.0
+        version: 1.0.1
         namespace: zarf
         valuesFiles:
           - registry-values.yaml


### PR DESCRIPTION
## Description

This PR sets the otel tracing environment variable `OTEL_TRACES_EXPORTER` to `none` to disable the failing otel tracing requests. 

Zarf doesn't ship with otel tracing capabilities in the init package. For users not instrumenting otel in their environments - this will cleanup the logs. 

Open to opinions on preferred location. Goal was to instrument it at the values file layer such that any use of `ZARF_VAR_REGISTRY_EXTRA_ENVS` would not overwrite the value and still be in a position to be configurable if needed.

Before:
```bash
│ 10.244.0.1 - - [29/Oct/2025:11:06:06 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:11.16687033Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                            │
│ 10.244.0.1 - - [29/Oct/2025:11:06:15 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:16.167879234Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                           │
│ 10.244.0.1 - - [29/Oct/2025:11:06:16 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:21.17171464Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                            │
│ 10.244.0.1 - - [29/Oct/2025:11:06:25 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:26.171944215Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                           │
│ 10.244.0.1 - - [29/Oct/2025:11:06:26 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:31.174944993Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                           │
│ 10.244.0.1 - - [29/Oct/2025:11:06:35 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:36.175335786Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                           │
│ 10.244.0.1 - - [29/Oct/2025:11:06:36 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ time="2025-10-29T11:06:41.178909812Z" level=error msg="traces export: Post \"https://localhost:4318/v1/traces\": dial tcp [::1]:4318: connect: connection refused" go.version=go1.23.7 instance.id=596f949a-bb17-488d-913b-920679aead60 service=registry version=3.0.0                                                                                                           │
```

After:
```bash
│ 10.244.0.1 - - [29/Oct/2025:11:08:32 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:08:41 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:08:42 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:08:51 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:08:52 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:01 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:02 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:11 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:12 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:21 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"                                                                                                                                                                                                                                                                                          │
│ 10.244.0.1 - - [29/Oct/2025:11:09:22 +0000] "GET / HTTP/1.1" 200 0 "" "kube-probe/1.34"
```

## Related Issue

Fixes #4323

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
