### PR TITLE
docs: update wordpress example and tutorial

### DIFF
--- a/examples/wordpress/wordpress-values.yaml
+++ b/examples/wordpress/wordpress-values.yaml
@@ -6,11 +6,25 @@ wordpressFirstName: ###ZARF_VAR_WORDPRESS_FIRST_NAME###
 wordpressLastName: ###ZARF_VAR_WORDPRESS_LAST_NAME###
 wordpressBlogName: ###ZARF_VAR_WORDPRESS_BLOG_NAME###
 
+# All images are temporarily using the legacy Bitnami repos due to:
+# https://github.com/bitnami/containers/issues/83267
+image:
+  repository: bitnamilegacy/wordpress
+  tag: 6.8.2-debian-12-r4
+
 # This value turns on the metrics exporter and thus will require another image.
 metrics:
   enabled: true
+  image:
+    repository: bitnamilegacy/apache-exporter
+    tag: 1.0.10-debian-12-r55
 
 # Sets the WordPress service as a ClusterIP service to not conflict with potential
 # pre-existing LoadBalancer services.
 service:
   type: ClusterIP
+
+mariadb:
+  image:
+    repository: bitnamilegacy/mariadb
+    tag: 12.0.2-debian-12-r0

--- a/examples/wordpress/zarf.yaml
+++ b/examples/wordpress/zarf.yaml
@@ -1,7 +1,7 @@
 kind: ZarfPackageConfig # ZarfPackageConfig is the package kind for most normal zarf packages
 metadata:
   name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
-  version: 16.0.4       # (optional) a version we can track as we release updates or publish to a registry
+  version: 26.0.0       # (optional) a version we can track as we release updates or publish to a registry
   description: |        # (optional) a human-readable description of the package that you are creating
     A Zarf Package that deploys the WordPress blogging and content management platform
 
@@ -44,14 +44,14 @@ components:
     charts:
       - name: wordpress
         url: oci://registry-1.docker.io/bitnamicharts/wordpress
-        version: 16.0.4
+        version: 26.0.0
         namespace: wordpress
         valuesFiles:
           - wordpress-values.yaml
     images:
-      - docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2
-      - docker.io/bitnami/mariadb:10.11.2-debian-11-r21
-      - docker.io/bitnami/wordpress:6.2.0-debian-11-r18
+      - docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55
+      - docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0
+      - docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4
     manifests:
       - name: connect-services
         namespace: wordpress

--- a/site/public/tutorials/package_create_wordpress.html
+++ b/site/public/tutorials/package_create_wordpress.html
@@ -59,7 +59,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">metadata</b>:<b style="color:#55ffff;"></b>
 <b style="color:#55ffff;">  name</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the WordPress blogging and content management platform</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 26.0.0</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">components</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> Deploys the Bitnami-packaged WordPress chart into the cluster</b>
@@ -67,7 +67,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">charts</b>:
   -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">url</b>:<b style="color:#ff55ff;"> oci://registry-1.docker.io/bitnamicharts/wordpress</b>
-<b style="color:#ff55ff;">    </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
+<b style="color:#ff55ff;">    </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 26.0.0</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">namespace</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">valuesFiles</b>:
     -<b style="color:#ff55ff;"> wordpress-values.yaml</b>
@@ -77,9 +77,9 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">files</b>:
     -<b style="color:#ff55ff;"> connect-services.yaml</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">images</b>:
-  -<b style="color:#ff55ff;"> docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2</b>
-<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/mariadb:10.11.2-debian-11-r21</b>
-<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/wordpress:6.2.0-debian-11-r18</b>
+  -<b style="color:#ff55ff;"> docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55</b>
+<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0</b>
+<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">variables</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_USERNAME</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the WordPress admin account</b>

--- a/site/public/tutorials/package_deploy_wordpress.html
+++ b/site/public/tutorials/package_deploy_wordpress.html
@@ -47,20 +47,12 @@ b.BWHI {background-color: #aaaaaa}
 </head>
 <body>
 <pre>
-<b class="WHI">$ zarf package deploy zarf-package-wordpress-amd64-16.0.4.tar.zst</b><br/>
-<b class=YEL>Saving log file to /tmp/zarf-2023-05-06-19-26-21-1235550716.log</b>
-<b class=YEL></b>
-  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Loading Zarf Package zarf-package-wordpress-amd64-16.0.4.tar.zst</b>
-<b style="color:#55ff55;"></b><b style="color:#55ff55;">  ✔ </b> <b style="color:#55ff55;"></b><b style="color:#55ff55;">All of the checksums matched!</b>
-  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Loading Zarf Package zarf-package-wordpress-amd64-16.0.4.tar.zst</b>
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
+<b class="WHI">$ zarf package deploy zarf-package-wordpress-amd64-26.0.0.tar.zst</b><br/>
 <b style="color:#55ffff;">kind</b>:<b style="color:#ff55ff;"> ZarfPackageConfig</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">metadata</b>:<b style="color:#55ffff;"></b>
 <b style="color:#55ffff;">  name</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> A Zarf Package that deploys the WordPress blogging and content management platform</b>
-<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
+<b style="color:#ff55ff;">  </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 26.0.0</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">architecture</b>:<b style="color:#ff55ff;"> amd64</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">aggregateChecksum</b>:<b style="color:#ff55ff;"> 8375743b716d39346967c70b1bcaf2480a09417c8aa302e4868dd9793663b1ef</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">build</b>:<b style="color:#55ffff;"></b>
@@ -80,7 +72,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ffffff;">  </b><b style="color:#55ffff;">charts</b>:
   -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">url</b>:<b style="color:#ff55ff;"> oci://registry-1.docker.io/bitnamicharts/wordpress</b>
-<b style="color:#ff55ff;">    </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 16.0.4</b>
+<b style="color:#ff55ff;">    </b><b style="color:#55ffff;">version</b>:<b style="color:#ff55ff;"> 26.0.0</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">namespace</b>:<b style="color:#ff55ff;"> wordpress</b>
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">valuesFiles</b>:
     -<b style="color:#ff55ff;"> wordpress-values.yaml</b>
@@ -90,9 +82,9 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">    </b><b style="color:#55ffff;">files</b>:
     -<b style="color:#ff55ff;"> connect-services.yaml</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">images</b>:
-  -<b style="color:#ff55ff;"> docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2</b>
-<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/mariadb:10.11.2-debian-11-r21</b>
-<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnami/wordpress:6.2.0-debian-11-r18</b>
+  -<b style="color:#ff55ff;"> docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55</b>
+<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0</b>
+<b style="color:#ff55ff;">  </b>-<b style="color:#ff55ff;"> docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4</b>
 <b style="color:#ff55ff;"></b><b style="color:#55ffff;">variables</b>:
 -<b style="color:#55ffff;"> name</b>:<b style="color:#ff55ff;"> WORDPRESS_USERNAME</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The username that is used to login to the WordPress admin account</b>
@@ -118,17 +110,7 @@ b.BWHI {background-color: #aaaaaa}
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">description</b>:<b style="color:#ff55ff;"> The blog name that is used for the WordPress admin account</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">default</b>:<b style="color:#ff55ff;"> The Zarf Blog</b>
 <b style="color:#ff55ff;">  </b><b style="color:#55ffff;">prompt</b>:<b style="color:#ffffff;"> true</b>
-
-<b class=YEL>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</b>
-<b class=YEL></b>
-<b class=YEL>This package has 3 artifacts with software bill-of-materials (SBOM) included. You can view them now</b>
-<b class=YEL>in the zarf-sbom folder in this directory or to go directly to one, open this in your browser:</b>
-<b class=YEL></b><b class=WHI></b><b class=HIW>/home/zarf/wordpress/zarf-sbom/sbom-viewer-docker.io_bitnami_apache-exporter_0.13.3-debian-11-r2.html</b><b class=YEL></b><b class=WHI></b><b class=YEL></b>
-<b class=YEL></b>
-<b class=YEL>* This directory will be removed after package deployment.</b>
-<b class=YEL></b>
-<b class=YEL>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</b>
-<b class=YEL></b>
+<b class="BOLD" style="color:#55ff55;">INF </b><b class="BOLD">this package has SBOMs available for review in a temporary directory directory=/home/user/zarf/examples/wordpress/zarf-sbom </b>
 <b class="BOLD" style="color:#55ff55;">? </b><b class="BOLD">Deploy this Zarf package? </b><b class=WHI>(y/N) </b>
 </pre>
 </body>

--- a/site/public/tutorials/package_deploy_wordpress_bottom.html
+++ b/site/public/tutorials/package_deploy_wordpress_bottom.html
@@ -70,8 +70,8 @@ b.BWHI {background-color: #aaaaaa}
   •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Loading the Zarf State from the Kubernetes cluster</b>
   •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Pushing 3 images to the zarf registry</b>
 <b style="color:#55ff55;"></b><b style="color:#55ff55;">  ✔ </b> <b style="color:#55ff55;"></b><b style="color:#55ff55;">Pushed 3 images to the zarf registry</b>
-  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Processing helm chart wordpress:16.0.4 from oci://registry-1.docker.io/bitnamicharts/wordpress</b>
-  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Processing helm chart wordpress:16.0.4 from oci://registry-1.docker.io/bitnamicharts/wordpress</b>
+  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Processing helm chart wordpress:26.0.0 from oci://registry-1.docker.io/bitnamicharts/wordpress</b>
+  •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Processing helm chart wordpress:26.0.0 from oci://registry-1.docker.io/bitnamicharts/wordpress</b>
   •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Starting helm chart generation connect-services</b>
   •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Starting helm chart generation connect-services</b>
   •  <b style="color:#55ffff;"></b><b style="color:#55ffff;">Processing helm chart raw-wordpress-wordpress-connect-services:0.1.1683421314 from Zarf-generated</b>

--- a/site/public/tutorials/package_deploy_wordpress_remove_by_file.html
+++ b/site/public/tutorials/package_deploy_wordpress_remove_by_file.html
@@ -47,7 +47,7 @@ b.BWHI {background-color: #aaaaaa}
 </head>
 <body>
 <pre>
-<b class=WHI>$ zarf package remove zarf-package-wordpress-amd64-16.0.4.tar.zst --confirm</b>
+<b class=WHI>$ zarf package remove zarf-package-wordpress-amd64-26.0.0.tar.zst --confirm</b>
 <b class=YEL>Saving log file to</b>
 <b class=YEL>/var/folders/bk/rz1xx2sd5zn134c0_j1s2n5r0000gp/T/zarf-2023-03-23-09-57-21-154843452.log</b>
 <b class=YEL></b> <b style="color:#55ffff;"></b><b style="color:#55ffff;">Removing zarf package wordpress</b>

--- a/site/public/tutorials/package_deploy_wordpress_suggestions.html
+++ b/site/public/tutorials/package_deploy_wordpress_suggestions.html
@@ -51,7 +51,7 @@ b.BWHI {background-color: #aaaaaa}
 /var/folders/bk/rz1xx2sd5zn134c0_j1s2n5r0000gp/T/zarf-2023-03-23-13-18-54-4086179855.log</b>
 <b class="BOLD" style="color:#55ff55;">? </b><b class="BOLD">Choose or type the package file </b><b class="WHI">zarf-package-helm-oci-chart-arm64-0.0.1.tar.zst</b><b class=CYN>[</b><b class=CYN>tab for suggestions]</b>
 <b class=WHI>  zarf-package-distro-eks-amd64.tar.zst</b>
-<b class=CYN>> zarf-package-wordpress-amd64-16.0.4.tar.zst</b>
+<b class=CYN>> zarf-package-wordpress-amd64-26.0.0.tar.zst</b>
 </pre>
 </body>
 </html>

--- a/site/public/tutorials/prepare_find_images.html
+++ b/site/public/tutorials/prepare_find_images.html
@@ -49,14 +49,14 @@ b.BWHI {background-color: #aaaaaa}
 <pre>
 <b class="WHI">$ zarf prepare find-images</b><br/>
 <b class=YEL>Saving log file to /tmp/zarf-2023-05-06-16-17-52-1241631429.log</b>
-•  <b style="color:#55ffff;">Processing helm chart wordpress:16.0.4 from repo oci://registry-1.docker.io/bitnamicharts/wordpress</b>
+•  <b style="color:#55ffff;">Processing helm chart wordpress:26.0.0 from repo oci://registry-1.docker.io/bitnamicharts/wordpress</b>
 •  <b style="color:#55ffff;">Templating helm chart wordpress</b><br/>
 <b class="WHI">components:</b><br/>
 <b class="WHI">  - name: wordpress</b>
 <b class="WHI">    images:</b>
-<b class="WHI">      - docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2</b>
-<b class="WHI">      - docker.io/bitnami/mariadb:10.11.2-debian-11-r21</b>
-<b class="WHI">      - docker.io/bitnami/wordpress:6.2.0-debian-11-r18</b>
+<b class="WHI">      - docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55</b>
+<b class="WHI">      - docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0</b>
+<b class="WHI">      - docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4</b>
 </pre>
 </body>
 </html>

--- a/site/src/content/docs/ref/dev.mdx
+++ b/site/src/content/docs/ref/dev.mdx
@@ -91,7 +91,7 @@ components:
 
   - name: wordpress
     images:
-      - docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2
-      - docker.io/bitnami/mariadb:10.11.2-debian-11-r21
-      - docker.io/bitnami/wordpress:6.2.0-debian-11-r18
+      - docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55
+      - docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0
+      - docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4
 ```

--- a/site/src/content/docs/ref/values.mdx
+++ b/site/src/content/docs/ref/values.mdx
@@ -43,7 +43,7 @@ Helm [chart hooks](https://helm.sh/docs/topics/charts_hooks/) are not templated 
 ```yaml
     charts:
       - name: wordpress
-        version: 16.0.4
+        version: 26.0.0
         namespace: wordpress
         localPath: chart
         variables:

--- a/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
+++ b/site/src/content/docs/tutorials/0-creating-a-zarf-package.mdx
@@ -33,7 +33,7 @@ A `zarf.yaml` file follows the [Zarf Package Schema](https://github.com/zarf-dev
 kind: ZarfPackageConfig # ZarfPackageConfig is the package kind for most normal zarf packages
 metadata:
   name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
-  version: 16.0.4       # (optional) a version we can track as we release updates or publish to a registry
+  version: 26.0.0       # (optional) a version we can track as we release updates or publish to a registry
   description: |        # (optional) a human-readable description of the package that you are creating
     "A Zarf Package that deploys the WordPress blogging and content management platform"
 ```
@@ -57,7 +57,7 @@ components:
     charts:
       - name: wordpress
         url: oci://registry-1.docker.io/bitnamicharts/wordpress
-        version: 16.0.4
+        version: 26.0.0
         namespace: wordpress
         valuesFiles:
           - wordpress-values.yaml
@@ -74,14 +74,28 @@ wordpressFirstName: Zarf
 wordpressLastName: The Axolotl
 wordpressBlogName: The Zarf Blog
 
+# All images are temporarily using the legacy Bitnami repos due to:
+# https://github.com/bitnami/containers/issues/83267
+image:
+  repository: bitnamilegacy/wordpress
+  tag: 6.8.2-debian-12-r4
+
 # This value turns on the metrics exporter and thus will require another image.
 metrics:
   enabled: true
+  image:
+    repository: bitnamilegacy/apache-exporter
+    tag: 1.0.10-debian-12-r55
 
 # Sets the WordPress service as a ClusterIP service to not conflict with potential
 # pre-existing LoadBalancer services.
 service:
   type: ClusterIP
+
+mariadb:
+  image:
+    repository: bitnamilegacy/mariadb
+    tag: 12.0.2-debian-12-r0
 ```
 
 :::note
@@ -113,14 +127,14 @@ components:
     charts:
       - name: wordpress
         url: oci://registry-1.docker.io/bitnamicharts/wordpress
-        version: 16.0.4
+        version: 26.0.0
         namespace: wordpress
         valuesFiles:
           - wordpress-values.yaml
     images:
-      - docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2
-      - docker.io/bitnami/mariadb:10.11.2-debian-11-r21
-      - docker.io/bitnami/wordpress:6.2.0-debian-11-r18
+      - docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55
+      - docker.io/bitnamilegacy/mariadb:12.0.2-debian-12-r0
+      - docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4
 ```
 
 :::note
@@ -269,7 +283,7 @@ You can skip this confirmation by adding the `--confirm` flag when running the c
 
 :::
 
-This will create a zarf package in the current directory with a package name that looks something like `zarf-package-wordpress-amd64-16.0.4.tar.zst`, although it might be slightly different depending on your system architecture.
+This will create a zarf package in the current directory with a package name that looks something like `zarf-package-wordpress-amd64-26.0.0.tar.zst`, although it might be slightly different depending on your system architecture.
 
 :::tip
 

--- a/src/test/e2e/13_find_images_test.go
+++ b/src/test/e2e/13_find_images_test.go
@@ -70,11 +70,11 @@ func TestFindImages(t *testing.T) {
 		testPackagePath := filepath.Join("examples", "wordpress")
 		sets := []string{"WORDPRESS_USERNAME=zarf", "WORDPRESS_PASSWORD=fake", "WORDPRESS_EMAIL=hello@defenseunicorns.com", "WORDPRESS_FIRST_NAME=zarf", "WORDPRESS_LAST_NAME=zarf", "WORDPRESS_BLOG_NAME=blog"}
 		deploysSet := strings.Join(sets, ",")
-		stdOut, _, err := e2e.Zarf(t, "dev", "find-images", testPackagePath, "--why", "docker.io/bitnami/apache-exporter:0.13.3-debian-11-r2", "--deploy-set", deploysSet)
+		stdOut, _, err := e2e.Zarf(t, "dev", "find-images", testPackagePath, "--why", "docker.io/bitnamilegacy/apache-exporter:1.0.10-debian-12-r55", "--deploy-set", deploysSet)
 		require.NoError(t, err)
 		require.Contains(t, stdOut, "component: wordpress")
 		require.Contains(t, stdOut, "chart: wordpress")
-		require.Contains(t, stdOut, "image: docker.io/bitnami/wordpress:6.2.0-debian-11-r18")
+		require.Contains(t, stdOut, "image: docker.io/bitnamilegacy/wordpress:6.8.2-debian-12-r4")
 	})
 
 	t.Run("zarf test find images --why w/ manifests success", func(t *testing.T) {


### PR DESCRIPTION
## Description

Wordpress example and tutorial is currently broken, because the change of [Bitnami Catalog](https://github.com/bitnami/charts/tree/main/bitnami/wordpress#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog).

This PR updates the example from 16.0.4 to 27.1.3, where the `latest` images will be used. Not sure how future prove this is, but at least works now.

Any options on how to remove the example completely / change the tutorial for another example?

## Related Issue

Fixes #4251

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
