### PR TITLE
feat: add flag to update images in zarf.yaml

### DIFF
--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -31,6 +31,7 @@ zarf dev find-images [ DIRECTORY ] [flags]
       --registry-url string         Override the ###ZARF_REGISTRY### value (default "127.0.0.1:31999")
   -p, --repo-chart-path string      If git repos hold helm charts, often found with gitops tools, specify the chart path, e.g. "/" or "/chart"
       --skip-cosign                 Skip searching for cosign artifacts related to discovered images
+  -u, --update                      Update the images in the zarf.yaml file if needed. Formatting such as comments and newlines may change.
       --why string                  Prints the source manifest for the specified image
 ```
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -620,6 +620,7 @@ type devFindImagesOptions struct {
 	why                 string
 	skipCosign          bool
 	registryURL         string
+	update              bool
 }
 
 func newDevFindImagesCommand(v *viper.Viper) *cobra.Command {
@@ -655,6 +656,8 @@ func newDevFindImagesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVar(&o.why, "why", "", lang.CmdDevFlagFindImagesWhy)
 	// skip searching cosign artifacts in find images
 	cmd.Flags().BoolVar(&o.skipCosign, "skip-cosign", false, lang.CmdDevFlagFindImagesSkipCosign)
+	// update images in zarf.yaml file
+	cmd.Flags().BoolVarP(&o.update, "update", "u", false, lang.CmdDevFlagFindImagesUpdate)
 
 	cmd.Flags().StringVar(&o.registryURL, "registry-url", defaultRegistry, lang.CmdDevFlagRegistry)
 
@@ -737,6 +740,13 @@ func (o *devFindImagesOptions) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 	fmt.Println(componentDefinition)
+
+	if o.update {
+		if err := packager.UpdateImages(ctx, baseDir, imagesScans); err != nil {
+			return fmt.Errorf("unable to create update: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -398,6 +398,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0 -a skeleton`
 	CmdDevFlagRegistry             = "Override the ###ZARF_REGISTRY### value"
 	CmdDevFlagFindImagesWhy        = "Prints the source manifest for the specified image"
 	CmdDevFlagFindImagesSkipCosign = "Skip searching for cosign artifacts related to discovered images"
+	CmdDevFlagFindImagesUpdate     = "Update the images in the zarf.yaml file if needed. Formatting such as comments and newlines may change."
 
 	CmdDevLintShort = "Lints the given package for valid schema and recommended practices"
 	CmdDevLintLong  = "Verifies the package schema, checks if any variables won't be evaluated, and checks for unpinned images/repos/files"

--- a/src/pkg/packager/update.go
+++ b/src/pkg/packager/update.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/defenseunicorns/pkg/helpers/v2"
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+)
+
+// UpdateImages updates the images field for components in a zarf.yaml
+func UpdateImages(ctx context.Context, baseDir string, imagesScans []ComponentImageScan) error {
+	l := logger.From(ctx)
+	packageConfigFile := filepath.Join(baseDir, layout.ZarfYAML)
+
+	packageConfigBytes, err := os.ReadFile(packageConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", packageConfigFile, err)
+	}
+
+	zarfPackage := v1alpha1.ZarfPackage{}
+	if err := yaml.Unmarshal(packageConfigBytes, &zarfPackage); err != nil {
+		return fmt.Errorf("failed to parse zarf.yaml: %w", err)
+	}
+
+	if !updateNeeded(zarfPackage, imagesScans) {
+		l.Info("no update needed, images are already up to date", "path", packageConfigFile)
+		return nil
+	}
+
+	astFile, err := parser.ParseBytes(packageConfigBytes, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s as AST: %w", packageConfigFile, err)
+	}
+
+	updatedZarfYaml, err := createUpdate(zarfPackage, imagesScans, astFile)
+	if err != nil {
+		return fmt.Errorf("failed to create update: %w", err)
+	}
+
+	if err := os.WriteFile(packageConfigFile, []byte(updatedZarfYaml), helpers.ReadAllWriteUser); err != nil {
+		return fmt.Errorf("failed to write updated %s: %w", packageConfigFile, err)
+	}
+
+	l.Info("successfully updated images", "path", packageConfigFile)
+	return nil
+}
+
+func createUpdate(zarfPackage v1alpha1.ZarfPackage, imagesScans []ComponentImageScan, astFile *ast.File) (string, error) {
+	// Note: yamlpath support of goccy/go-yaml only has index-based lookup
+	componentToIndex := make(map[string]int, len(zarfPackage.Components))
+	for i, component := range zarfPackage.Components {
+		componentToIndex[component.Name] = i
+	}
+
+	for _, scan := range imagesScans {
+		if len(scan.Matches)+len(scan.PotentialMatches)+len(scan.CosignArtifacts) == 0 {
+			continue
+		}
+
+		componentIndex, exists := componentToIndex[scan.ComponentName]
+		if !exists {
+			continue
+		}
+
+		combined := slices.Concat(scan.Matches, scan.PotentialMatches, scan.CosignArtifacts)
+
+		componentMerge := map[string]any{
+			"images": combined,
+		}
+		componentNode, err := yaml.ValueToNode(componentMerge, yaml.IndentSequence(true))
+		if err != nil {
+			return "", fmt.Errorf("failed to create YAML node for component %s: %w", scan.ComponentName, err)
+		}
+
+		path, err := yaml.PathString(fmt.Sprintf("$.components[%d]", componentIndex))
+		if err != nil {
+			return "", fmt.Errorf("failed to create YAML path for component %s: %w", scan.ComponentName, err)
+		}
+
+		if err := path.MergeFromNode(astFile, componentNode); err != nil {
+			return "", fmt.Errorf("failed to merge images for component %s: %w", scan.ComponentName, err)
+		}
+	}
+
+	return astFile.String(), nil
+}
+
+func updateNeeded(zarfPackage v1alpha1.ZarfPackage, imageScans []ComponentImageScan) bool {
+	scanMap := make(map[string]map[string]struct{}, len(imageScans))
+
+	for _, scan := range imageScans {
+		combined := slices.Concat(scan.Matches, scan.PotentialMatches, scan.CosignArtifacts)
+		imageSet := make(map[string]struct{}, len(combined))
+		for _, img := range combined {
+			imageSet[img] = struct{}{}
+		}
+		scanMap[scan.ComponentName] = imageSet
+	}
+
+	for _, component := range zarfPackage.Components {
+		imageSet, found := scanMap[component.Name]
+		if !found {
+			return true
+		}
+
+		for _, img := range component.Images {
+			if _, found := imageSet[img]; !found {
+				return true
+			}
+		}
+	}
+
+	componentMap := make(map[string]map[string]struct{}, len(zarfPackage.Components))
+	for _, component := range zarfPackage.Components {
+		imageSet := make(map[string]struct{}, len(component.Images))
+		for _, img := range component.Images {
+			imageSet[img] = struct{}{}
+		}
+		componentMap[component.Name] = imageSet
+	}
+
+	for _, scan := range imageScans {
+		componentImages, found := componentMap[scan.ComponentName]
+		if !found {
+			return true
+		}
+
+		combined := slices.Concat(scan.Matches, scan.PotentialMatches, scan.CosignArtifacts)
+		for _, img := range combined {
+			if _, found := componentImages[img]; !found {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/src/pkg/packager/update_test.go
+++ b/src/pkg/packager/update_test.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml/parser"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+func TestUpdateNeeded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		zarfPackage v1alpha1.ZarfPackage
+		imageScans  []ComponentImageScan
+		want        bool
+	}{
+		{
+			name: "equal images in components and images scans",
+			zarfPackage: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: "argocd",
+						Images: []string{
+							"docker.io/library/redis:7.0.15-alpine",
+							"quay.io/argoproj/argocd:v2.9.6",
+							"quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig",
+							"quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.att",
+						},
+					},
+					{
+						Name: "podinfo",
+						Images: []string{
+							"ghcr.io/stefanprodan/podinfo:6.4.0",
+						},
+					},
+				},
+			},
+			imageScans: []ComponentImageScan{
+				{
+					ComponentName: "podinfo",
+					Matches: []string{
+						"ghcr.io/stefanprodan/podinfo:6.4.0",
+					},
+				},
+				{
+
+					ComponentName: "argocd",
+					Matches: []string{
+						"docker.io/library/redis:7.0.15-alpine",
+						"quay.io/argoproj/argocd:v2.9.6",
+					},
+					CosignArtifacts: []string{
+						"quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig",
+						"quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.att",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "new image tags found",
+			zarfPackage: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: "argocd",
+						Images: []string{
+							"docker.io/library/redis:7.0.14-alpine",
+							"quay.io/argoproj/argocd:v2.8.6",
+						},
+					},
+				},
+			},
+			imageScans: []ComponentImageScan{
+				{
+
+					ComponentName: "argocd",
+					Matches: []string{
+						"docker.io/library/redis:7.0.15-alpine",
+						"quay.io/argoproj/argocd:v2.9.6",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "images in components but not in image scans",
+			zarfPackage: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: "argocd",
+						Images: []string{
+							"docker.io/library/redis:7.0.14-alpine",
+							"quay.io/argoproj/argocd:v2.8.6",
+						},
+					},
+				},
+			},
+			imageScans: []ComponentImageScan{
+				{
+
+					ComponentName: "argocd",
+					Matches: []string{
+						"docker.io/library/redis:7.0.14-alpine",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "images in images scans but not in components",
+			zarfPackage: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name: "argocd",
+						Images: []string{
+							"quay.io/argoproj/argocd:v2.8.6",
+						},
+					},
+				},
+			},
+			imageScans: []ComponentImageScan{
+				{
+
+					ComponentName: "argocd",
+					Matches: []string{
+						"docker.io/library/redis:7.0.14-alpine",
+						"quay.io/argoproj/argocd:v2.8.6",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := updateNeeded(tt.zarfPackage, tt.imageScans)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreateUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		zarfPackage v1alpha1.ZarfPackage
+		imageScans  []ComponentImageScan
+		inputYAML   string
+		outputYAML  string
+		wantErr     bool
+	}{
+		{
+			name: "updates multiple components with all artifact types and preserves yaml structure",
+			zarfPackage: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "flux"},
+					{Name: "podinfo"},
+				},
+			},
+			imageScans: []ComponentImageScan{
+				{
+					ComponentName: "flux",
+					Matches: []string{
+						"ghcr.io/fluxcd/helm-controller:v1.1.0",
+						"ghcr.io/fluxcd/image-automation-controller:v0.39.0",
+					},
+					CosignArtifacts: []string{
+						"ghcr.io/fluxcd/helm-controller:sha256-4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48.sig",
+						"ghcr.io/fluxcd/helm-controller:sha256-4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48.att",
+						"ghcr.io/fluxcd/image-automation-controller:sha256-5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20.sig",
+						"ghcr.io/fluxcd/image-automation-controller:sha256-5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20.att",
+					},
+				},
+
+				{
+					ComponentName: "podinfo",
+					Matches:       []string{"ghcr.io/stefanprodan/podinfo:6.4.0"},
+				},
+			},
+			inputYAML: `# Package metadata
+metadata:
+  name: test-package
+
+components:
+  # Flux component
+  - name: flux
+    description: Flux
+    images:
+      - ghcr.io/fluxcd/helm-controller:v1.0.0
+      - ghcr.io/fluxcd/image-automation-controller:v0.38.0
+  - name: podinfo
+    images:
+      - postgres:12
+`,
+			outputYAML: `# Package metadata
+metadata:
+  name: test-package
+
+components:
+  # Flux component
+  - name: flux
+    description: Flux
+    images:
+      - ghcr.io/fluxcd/helm-controller:v1.1.0
+      - ghcr.io/fluxcd/image-automation-controller:v0.39.0
+      - ghcr.io/fluxcd/helm-controller:sha256-4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48.sig
+      - ghcr.io/fluxcd/helm-controller:sha256-4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48.att
+      - ghcr.io/fluxcd/image-automation-controller:sha256-5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20.sig
+      - ghcr.io/fluxcd/image-automation-controller:sha256-5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20.att
+  - name: podinfo
+    images:
+      - ghcr.io/stefanprodan/podinfo:6.4.0
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			astFile, err := parser.ParseBytes([]byte(tt.inputYAML), parser.ParseComments)
+			require.NoError(t, err)
+
+			got, err := createUpdate(tt.zarfPackage, tt.imageScans, astFile)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.outputYAML, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a `--update` / `-u` flag the `zarf dev find-images` command to update the images for the components in the respective zarf.yaml file.

Due to the limitations of of yaml handling, this preserves the comments in the yaml file, but could lead to a change of spacing like e.g. change something like 

```
kind: ZarfPackageConfig # ZarfPackageConfig is the package kind for most normal zarf packages
metadata:
  name: wordpress       # specifies the name of our package and should be unique and unchanging through updates
...
```

To

```
kind: ZarfPackageConfig # ZarfPackageConfig is the package kind for most normal zarf packages
metadata:
  name: wordpress # specifies the name of our package and should be unique and unchanging through updates
...
```

Because of that behaviour, this changes checks before evaluating the change if the write is needed, to not only change spacing if no images are updated. 

## Related Issue

Fixes #2865

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
