### PR TITLE
fix(ci): switch to internal registry chart for external test

### DIFF
--- a/src/test/external/docker-registry-values.yaml
+++ b/src/test/external/docker-registry-values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: registry
-  tag: 2.8.3
+  repository: docker.io/library/registry
+  tag: 3.0.0
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: private-registry
@@ -15,5 +15,7 @@ service:
 
 # Note: Super fake and not real htpasswd for testing purposes
 secrets:
-  haSharedSecret: ""
   htpasswd: "push-user:$2a$10$bnke4DeqY4qsAWIRsJCFluayx4v56mxhp/bfwubt.K83fudDzKAue"
+  configData:
+    http:
+      secret: "q1EouKxQvHtNho3MAoLwFJHCz8Fcbc8E4XLzm!McQuwmHGJG"

--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -59,12 +59,7 @@ func (suite *ExtInClusterTestSuite) SetupSuite() {
 	err := exec.CmdWithPrint("helm", helmInstallArgs...)
 	suite.NoError(err, "unable to install gitea chart")
 
-	// Install docker-registry chart to the k8s cluster to act as the 'remote' container registry
-	helmAddArgs := []string{"repo", "add", "twuni", "https://helm.twun.io"}
-	err = exec.CmdWithPrint("helm", helmAddArgs...)
-	suite.NoError(err, "unable to add the docker-registry chart repo")
-
-	helmInstallArgs = []string{"install", "external-registry", "twuni/docker-registry", "-f=docker-registry-values.yaml", "-n=external-registry", "--create-namespace"}
+	helmInstallArgs = []string{"install", "external-registry", "../../../packages/zarf-registry/chart", "-f=docker-registry-values.yaml", "-n=external-registry", "--create-namespace"}
 	err = exec.CmdWithPrint("helm", helmInstallArgs...)
 	suite.NoError(err, "unable to install the docker-registry chart")
 


### PR DESCRIPTION
## Description

This switches the in-cluster external test to use the `zarf-registry` helm chart - removing an external dependency from the test lifecycle. See #4339 for more information about impacts. 

## Related Issue

Fixes #4339

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
