### PR TITLE
fix: publish unique images in the injector

### DIFF
--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -43,6 +43,10 @@ var zarfImageRegex = regexp.MustCompile(`(?m)^(127\.0\.0\.1|\[::1\]):`)
 func (c *Cluster) StartInjection(ctx context.Context, tmpDir, imagesDir string, injectorSeedSrcs []string, registryNodePort int, pkgName string) (int, error) {
 	l := logger.From(ctx)
 	start := time.Now()
+
+	// The injector breaks if the same image is added multiple times
+	injectorSeedSrcs = helpers.Unique(injectorSeedSrcs)
+
 	// Stop any previous running injection before starting.
 	err := c.StopInjection(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

There is a subtle bug in the injector right now where if you unpack the same image multiple times it will error. In our normal image push logic, we unique the images, however this is not done for the injector

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
