### PR TITLE
feat: add OCI support for Argo CD sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ build-examples: ## Build all of the example packages
 
 	@test -s ./build/zarf-package-podinfo-flux-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/podinfo-flux -o build -a $(ARCH) --confirm
 
-	@test -s ./build/zarf-package-argocd-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/argocd -o build -a $(ARCH) --confirm
+	@test -s ./build/zarf-package-argocd-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/argocd -o build -a $(ARCH) --confirm --features="values=true"
 
 	@test -s ./build/zarf-package-yolo-$(ARCH).tar.zst || $(ZARF_BIN) package create examples/yolo -o build -a $(ARCH) --confirm
 

--- a/examples/argocd/baseline/values.yaml
+++ b/examples/argocd/baseline/values.yaml
@@ -19,6 +19,19 @@ configs:
       url: https://github.com/argoproj/argocd-example-apps.git
       username: ""
       password: ""
+    oci-helm:
+      name: podinfo-helm
+      url: oci://ghcr.io/stefanprodan/charts/podinfo
+      username: ""
+      password: ""
+      type: helm
+      enableOCI: "true"
+    oci-manifests:
+      name: oci-repo
+      url: oci://registry-1.docker.io/dhpup/oci-edge
+      username: ""
+      password: ""
+      type: oci
 
 redis:
   image:

--- a/examples/argocd/oci-helm/values.yaml
+++ b/examples/argocd/oci-helm/values.yaml
@@ -1,0 +1,19 @@
+---
+applications:
+  - name: oci-helm
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    sources:
+      - repoURL: oci://ghcr.io/stefanprodan/charts/podinfo
+        path: .
+        targetRevision: 6.9.2
+        helm:
+          valueFiles:
+            - values.yaml
+    syncPolicy:
+      automated: { }
+    destination:
+      namespace: podinfo-oci
+      server: https://kubernetes.default.svc

--- a/examples/argocd/oci-manifests/values.yaml
+++ b/examples/argocd/oci-manifests/values.yaml
@@ -1,0 +1,16 @@
+---
+applications:
+  - name: oci-manifests
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    sources:
+      - repoURL: oci://registry-1.docker.io/dhpup/oci-edge
+        path: .
+        targetRevision: 1.0.6
+    syncPolicy:
+      automated: { }
+    destination:
+      namespace: oci-manifests
+      server: https://kubernetes.default.svc

--- a/examples/argocd/values/values.yaml
+++ b/examples/argocd/values/values.yaml
@@ -1,0 +1,2 @@
+extraObjects: []
+repoServer: {}

--- a/examples/argocd/zarf.yaml
+++ b/examples/argocd/zarf.yaml
@@ -2,6 +2,9 @@ kind: ZarfPackageConfig
 metadata:
   name: argocd
   description: Example showcasing installing ArgoCD
+values:
+  files:
+    - values/values.yaml
 
 components:
   - name: argocd-helm-chart

--- a/examples/argocd/zarf.yaml
+++ b/examples/argocd/zarf.yaml
@@ -8,18 +8,24 @@ components:
     required: true
     charts:
       - name: argo-cd
-        version: 5.54.0
+        version: 9.0.5
         namespace: argocd
         url: https://argoproj.github.io/argo-helm
         releaseName: argocd-baseline
         valuesFiles:
           - baseline/values.yaml
+        # Required for 'src/test/external' to validate external git server.
+        values:
+          - sourcePath: ".extraObjects"
+            targetPath: ".extraObjects"
+          - sourcePath: ".repoServer"
+            targetPath: ".repoServer"
     images:
-      - docker.io/library/redis:7.0.15-alpine
-      - quay.io/argoproj/argocd:v2.9.6
-      # Cosign artifacts for images - argocd - argocd-helm-chart
-      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.sig
-      - quay.io/argoproj/argocd:sha256-2dafd800fb617ba5b16ae429e388ca140f66f88171463d23d158b372bb2fae08.att
+      - docker.io/library/redis:7.2.11-alpine
+      - quay.io/argoproj/argocd:v3.1.9
+      # Cosign artifacts for images - argocd-helm-chart
+      - quay.io/argoproj/argocd:sha256-9c33285c0b86a66e9cf9fcafc448e48e0ab7c4678b20b3723556bb6cce8ea0b9.sig
+      - quay.io/argoproj/argocd:sha256-9c33285c0b86a66e9cf9fcafc448e48e0ab7c4678b20b3723556bb6cce8ea0b9.att
   - name: argocd-apps
     required: true
     charts:
@@ -69,6 +75,32 @@ components:
                 name: app=guestbook-ui
                 namespace: guestbook
                 condition: ready
+  - name: oci-helm
+    required: true
+    charts:
+      - name: argocd-apps
+        version: 1.6.1
+        namespace: podinfo-oci
+        url: https://argoproj.github.io/argo-helm
+        releaseName: argocd-apps
+        valuesFiles:
+          - oci-helm/values.yaml
+    images:
+      - ghcr.io/stefanprodan/charts/podinfo:6.9.2
+      - ghcr.io/stefanprodan/podinfo:6.9.2
+  - name: oci-manifests
+    required: true
+    charts:
+      - name: argocd-apps
+        version: 1.6.1
+        namespace: oci-manifests
+        url: https://argoproj.github.io/argo-helm
+        releaseName: argocd-apps
+        valuesFiles:
+          - oci-manifests/values.yaml
+    images:
+      - registry-1.docker.io/dhpup/oci-edge:1.0.6
+      - ghcr.io/dhpup/guestbook:0.1.40
 
 documentation:
   readme: readme.md

--- a/packages/zarf-agent/chart/templates/webhook.yaml
+++ b/packages/zarf-agent/chart/templates/webhook.yaml
@@ -290,6 +290,7 @@ webhooks:
           operator: In
           values:
             - repository
+            - repo-creds
     clientConfig:
       service:
         name: {{ .Values.service.name }}

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -80,9 +80,15 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 		"operation", r.Operation,
 		"gitServer", s.GitServer.Address)
 
+	// Get the registry service info if this is a NodePort service to use the internal kube-dns
+	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	patches := make([]operations.PatchOperation, 0)
 	if app.Spec.Source != nil {
-		patchedURL, err := getPatchedRepoURL(ctx, app.Spec.Source.RepoURL, s.GitServer)
+		patchedURL, err := getPatchedRepoURL(ctx, app.Spec.Source.RepoURL, registryAddress, clusterIP, s.GitServer, r)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +97,7 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 
 	if len(app.Spec.Sources) > 0 {
 		for idx, source := range app.Spec.Sources {
-			patchedURL, err := getPatchedRepoURL(ctx, source.RepoURL, s.GitServer)
+			patchedURL, err := getPatchedRepoURL(ctx, source.RepoURL, registryAddress, clusterIP, s.GitServer, r)
 			if err != nil {
 				return nil, err
 			}
@@ -107,7 +113,12 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 	}, nil
 }
 
-func getPatchedRepoURL(ctx context.Context, repoURL string, gs state.GitServerInfo) (string, error) {
+func getPatchedRepoURL(
+	ctx context.Context,
+	repoURL, registryAddress, clusterIP string,
+	gs state.GitServerInfo,
+	r *v1.AdmissionRequest,
+) (string, error) {
 	l := logger.From(ctx)
 
 	// Skip mutation if the URL already points to the Zarf git server to prevent double-hashing
@@ -122,6 +133,82 @@ func getPatchedRepoURL(ctx context.Context, repoURL string, gs state.GitServerIn
 		return repoURL, nil
 	}
 
+	isOCIURL := helpers.IsOCIURL(repoURL)
+
+	shouldMutate, isPatchedClusterIP, err := shouldMutateURL(r.Operation, isOCIURL, repoURL, registryAddress, clusterIP, gs)
+	if err != nil {
+		return "", fmt.Errorf(lang.AgentErrHostnameMatch, err)
+	}
+
+	if !shouldMutate {
+		return repoURL, nil
+	}
+
+	if isOCIURL {
+		return mutateOCIURL(ctx, repoURL, registryAddress, isPatchedClusterIP)
+	}
+	return mutateGitURL(ctx, repoURL, gs)
+}
+
+func shouldMutateURL(operation v1.Operation, isOCIURL bool, repoURL, registryAddress, clusterIP string, gs state.GitServerInfo) (bool, bool, error) {
+	isCreate := operation == v1.Create
+	isUpdate := operation == v1.Update
+	if isCreate {
+		return true, false, nil
+	}
+
+	var isPatched bool
+	var isPatchedClusterIP bool
+	var err error
+	if isOCIURL {
+		zarfStateAddress := helpers.OCIURLPrefix + registryAddress
+		isPatched, err = helpers.DoHostnamesMatch(zarfStateAddress, repoURL)
+		if err != nil {
+			return false, false, err
+		}
+		if clusterIP != "" {
+			zarfStateClusterIPAddress := helpers.OCIURLPrefix + clusterIP
+			isPatchedClusterIP, err = helpers.DoHostnamesMatch(zarfStateClusterIPAddress, repoURL)
+			if err != nil {
+				return false, false, err
+			}
+		}
+	} else {
+		isPatched, err = helpers.DoHostnamesMatch(gs.Address, repoURL)
+	}
+
+	return (isUpdate && !isPatched), isPatchedClusterIP, err
+}
+
+func mutateOCIURL(ctx context.Context, repoURL, registryAddress string, isPatchedClusterIP bool) (string, error) {
+	l := logger.From(ctx)
+	var patchedSrc string
+	var err error
+
+	if isPatchedClusterIP {
+		patchedSrc, err = transform.ImageTransformHostWithoutChecksum(registryAddress, repoURL)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
+		}
+	} else {
+		patchedSrc, err = transform.ImageTransformHost(registryAddress, repoURL)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
+		}
+	}
+
+	patchedRefInfo, err := transform.ParseImageRef(patchedSrc)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
+	}
+
+	patchedURL := helpers.OCIURLPrefix + patchedRefInfo.Name
+	l.Debug("mutated ArgoCD application OCI repoURL to the Zarf Registry URL", "original", repoURL, "mutated", patchedURL)
+	return patchedURL, nil
+}
+
+func mutateGitURL(ctx context.Context, repoURL string, gs state.GitServerInfo) (string, error) {
+	l := logger.From(ctx)
 	transformedURL, err := transform.GitURL(gs.Address, repoURL, gs.PushUsername)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -58,16 +58,12 @@ func NewApplicationMutationHook(ctx context.Context, cluster *cluster.Cluster) o
 	}
 }
 
-// mutateApplication mutates the git repository url to point to the repository URL defined in the ZarfState.
+// mutateApplication mutates the repository url to point to the repository URL defined in the ZarfState.
 func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
 	l := logger.From(ctx)
 	s, err := cluster.LoadState(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if !s.GitServer.IsConfigured() {
-		l.Debug("no Zarf git server configured, skipping ArgoCD Application mutation")
-		return &operations.Result{Allowed: true}, nil
 	}
 
 	app := Application{}
@@ -75,16 +71,25 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
 
-	l.Info("using the Zarf git server URL to mutate the ArgoCD Application",
-		"name", app.Name,
-		"operation", r.Operation,
-		"gitServer", s.GitServer.Address)
+	requiresGit, requiresRegistry := classifySourceSchemes(app)
+
+	gitUsable := requiresGit && s.GitServer.IsConfigured()
+	registryUsable := requiresRegistry && s.RegistryInfo.IsConfigured()
+
+	if !gitUsable && !registryUsable {
+		l.Debug("no Zarf services configured for source URL schemes, skipping ArgoCD Application mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	// Get the registry service info if this is a NodePort service to use the internal kube-dns
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
 	if err != nil {
 		return nil, err
 	}
+
+	l.Info("mutating the ArgoCD Application",
+		"name", app.Name,
+		"operation", r.Operation)
 
 	patches := make([]operations.PatchOperation, 0)
 	if app.Spec.Source != nil {
@@ -134,6 +139,15 @@ func getPatchedRepoURL(
 	}
 
 	isOCIURL := helpers.IsOCIURL(repoURL)
+
+	if isOCIURL && registryAddress == "" {
+		l.Debug("no Zarf registry configured, skipping OCI repoURL mutation", "url", repoURL)
+		return repoURL, nil
+	}
+	if !isOCIURL && !gs.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping git repoURL mutation", "url", repoURL)
+		return repoURL, nil
+	}
 
 	shouldMutate, isPatchedClusterIP, err := shouldMutateURL(r.Operation, isOCIURL, repoURL, registryAddress, clusterIP, gs)
 	if err != nil {
@@ -220,6 +234,26 @@ func mutateGitURL(ctx context.Context, repoURL string, gs state.GitServerInfo) (
 	patchedURL := transformedURL.String()
 	l.Debug("mutated ArgoCD application repoURL to the Zarf URL", "original", repoURL, "mutated", patchedURL)
 	return patchedURL, nil
+}
+
+// classifySourceSchemes inspects the URL schemes of all sources in an ArgoCD Application spec and
+// reports whether the application has git sources (requiring the Zarf git server) or OCI sources
+// (requiring the Zarf registry).
+func classifySourceSchemes(app Application) (requiresGit, requiresRegistry bool) {
+	check := func(repoURL string) {
+		if helpers.IsOCIURL(repoURL) {
+			requiresRegistry = true
+		} else {
+			requiresGit = true
+		}
+	}
+	if app.Spec.Source != nil {
+		check(app.Spec.Source.RepoURL)
+	}
+	for _, src := range app.Spec.Sources {
+		check(src.RepoURL)
+	}
+	return
 }
 
 // Patch updates of the Argo source spec.

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -150,7 +150,13 @@ func getPatchedRepoURL(
 	return mutateGitURL(ctx, repoURL, gs)
 }
 
-func shouldMutateURL(operation v1.Operation, isOCIURL bool, repoURL, registryAddress, clusterIP string, gs state.GitServerInfo) (bool, bool, error) {
+// shouldMutateURL reports whether the given repoURL should be mutated for the admission operation.
+//
+// shouldMutate is true for Create operations and for Update operations where repoURL has not
+// already been patched to the Zarf-managed registry or git server address.
+//
+// isPatchedClusterIP is true when repoURL already matches the registry cluster-IP address
+func shouldMutateURL(operation v1.Operation, isOCIURL bool, repoURL, registryAddress, clusterIP string, gs state.GitServerInfo) (shouldMutate bool, isPatchedClusterIP bool, err error) {
 	isCreate := operation == v1.Create
 	isUpdate := operation == v1.Update
 	if isCreate {
@@ -158,8 +164,6 @@ func shouldMutateURL(operation v1.Operation, isOCIURL bool, repoURL, registryAdd
 	}
 
 	var isPatched bool
-	var isPatchedClusterIP bool
-	var err error
 	if isOCIURL {
 		zarfStateAddress := helpers.OCIURLPrefix + registryAddress
 		isPatched, err = helpers.DoHostnamesMatch(zarfStateAddress, repoURL)

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -71,12 +71,16 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
 
-	requiresGit, requiresRegistry := classifySourceSchemes(app)
+	var urls []string
+	if app.Spec.Source != nil {
+		urls = append(urls, app.Spec.Source.RepoURL)
+	}
+	for _, src := range app.Spec.Sources {
+		urls = append(urls, src.RepoURL)
+	}
+	requiresGit, requiresRegistry := classifyURLSchemes(urls)
 
-	gitUsable := requiresGit && s.GitServer.IsConfigured()
-	registryUsable := requiresRegistry && s.RegistryInfo.IsConfigured()
-
-	if !gitUsable && !registryUsable {
+	if !anyZarfServiceUsable(requiresGit, requiresRegistry, s) {
 		l.Debug("no Zarf services configured for source URL schemes, skipping ArgoCD Application mutation")
 		return &operations.Result{Allowed: true}, nil
 	}
@@ -234,26 +238,6 @@ func mutateGitURL(ctx context.Context, repoURL string, gs state.GitServerInfo) (
 	patchedURL := transformedURL.String()
 	l.Debug("mutated ArgoCD application repoURL to the Zarf URL", "original", repoURL, "mutated", patchedURL)
 	return patchedURL, nil
-}
-
-// classifySourceSchemes inspects the URL schemes of all sources in an ArgoCD Application spec and
-// reports whether the application has git sources (requiring the Zarf git server) or OCI sources
-// (requiring the Zarf registry).
-func classifySourceSchemes(app Application) (requiresGit, requiresRegistry bool) {
-	check := func(repoURL string) {
-		if helpers.IsOCIURL(repoURL) {
-			requiresRegistry = true
-		} else {
-			requiresGit = true
-		}
-	}
-	if app.Spec.Source != nil {
-		check(app.Spec.Source.RepoURL)
-	}
-	for _, src := range app.Spec.Sources {
-		check(src.RepoURL)
-	}
-	return
 }
 
 // Patch updates of the Argo source spec.

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -93,11 +93,13 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 
 	l.Info("mutating the ArgoCD Application",
 		"name", app.Name,
-		"operation", r.Operation)
+		"operation", r.Operation,
+		"gitServer", s.GitServer.Address,
+		"registry", registryAddress)
 
 	patches := make([]operations.PatchOperation, 0)
 	if app.Spec.Source != nil {
-		patchedURL, err := getPatchedRepoURL(ctx, app.Spec.Source.RepoURL, registryAddress, clusterIP, s.GitServer, r)
+		patchedURL, err := getPatchedRepoURL(ctx, app.Spec.Source.RepoURL, registryAddress, clusterIP, s.GitServer)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +108,7 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 
 	if len(app.Spec.Sources) > 0 {
 		for idx, source := range app.Spec.Sources {
-			patchedURL, err := getPatchedRepoURL(ctx, source.RepoURL, registryAddress, clusterIP, s.GitServer, r)
+			patchedURL, err := getPatchedRepoURL(ctx, source.RepoURL, registryAddress, clusterIP, s.GitServer)
 			if err != nil {
 				return nil, err
 			}
@@ -122,84 +124,45 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 	}, nil
 }
 
-func getPatchedRepoURL(
-	ctx context.Context,
-	repoURL, registryAddress, clusterIP string,
-	gs state.GitServerInfo,
-	r *v1.AdmissionRequest,
-) (string, error) {
+func getPatchedRepoURL(ctx context.Context, repoURL, registryAddress, clusterIP string, gs state.GitServerInfo) (string, error) {
 	l := logger.From(ctx)
 
-	// Skip mutation if the URL already points to the Zarf git server to prevent double-hashing
-	// on resource recreation (e.g. Helm rollback, GitOps reconciliation).
+	if helpers.IsOCIURL(repoURL) {
+		if registryAddress == "" {
+			l.Debug("no Zarf registry configured, skipping OCI repoURL mutation", "url", repoURL)
+			return repoURL, nil
+		}
+		isPatched, err := helpers.DoHostnamesMatch(helpers.OCIURLPrefix+registryAddress, repoURL)
+		if err != nil {
+			return "", fmt.Errorf(lang.AgentErrHostnameMatch, err)
+		}
+		if isPatched {
+			l.Debug("skipping mutation, ArgoCD Application OCI repoURL already points to Zarf registry", "url", repoURL)
+			return repoURL, nil
+		}
+		var isPatchedClusterIP bool
+		if clusterIP != "" {
+			isPatchedClusterIP, err = helpers.DoHostnamesMatch(helpers.OCIURLPrefix+clusterIP, repoURL)
+			if err != nil {
+				return "", fmt.Errorf(lang.AgentErrHostnameMatch, err)
+			}
+		}
+		return mutateOCIURL(ctx, repoURL, registryAddress, isPatchedClusterIP)
+	}
+
+	if !gs.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping git repoURL mutation", "url", repoURL)
+		return repoURL, nil
+	}
 	isPatched, err := helpers.DoHostnamesMatch(gs.Address, repoURL)
 	if err != nil {
 		return "", fmt.Errorf(lang.AgentErrHostnameMatch, err)
 	}
-
 	if isPatched {
 		l.Debug("skipping mutation, ArgoCD Application repoURL already points to Zarf git server", "url", repoURL)
 		return repoURL, nil
 	}
-
-	isOCIURL := helpers.IsOCIURL(repoURL)
-
-	if isOCIURL && registryAddress == "" {
-		l.Debug("no Zarf registry configured, skipping OCI repoURL mutation", "url", repoURL)
-		return repoURL, nil
-	}
-	if !isOCIURL && !gs.IsConfigured() {
-		l.Debug("no Zarf git server configured, skipping git repoURL mutation", "url", repoURL)
-		return repoURL, nil
-	}
-
-	shouldMutate, isPatchedClusterIP, err := shouldMutateURL(r.Operation, isOCIURL, repoURL, registryAddress, clusterIP, gs)
-	if err != nil {
-		return "", fmt.Errorf(lang.AgentErrHostnameMatch, err)
-	}
-
-	if !shouldMutate {
-		return repoURL, nil
-	}
-
-	if isOCIURL {
-		return mutateOCIURL(ctx, repoURL, registryAddress, isPatchedClusterIP)
-	}
 	return mutateGitURL(ctx, repoURL, gs)
-}
-
-// shouldMutateURL reports whether the given repoURL should be mutated for the admission operation.
-//
-// shouldMutate is true for Create operations and for Update operations where repoURL has not
-// already been patched to the Zarf-managed registry or git server address.
-//
-// isPatchedClusterIP is true when repoURL already matches the registry cluster-IP address
-func shouldMutateURL(operation v1.Operation, isOCIURL bool, repoURL, registryAddress, clusterIP string, gs state.GitServerInfo) (shouldMutate bool, isPatchedClusterIP bool, err error) {
-	isCreate := operation == v1.Create
-	isUpdate := operation == v1.Update
-	if isCreate {
-		return true, false, nil
-	}
-
-	var isPatched bool
-	if isOCIURL {
-		zarfStateAddress := helpers.OCIURLPrefix + registryAddress
-		isPatched, err = helpers.DoHostnamesMatch(zarfStateAddress, repoURL)
-		if err != nil {
-			return false, false, err
-		}
-		if clusterIP != "" {
-			zarfStateClusterIPAddress := helpers.OCIURLPrefix + clusterIP
-			isPatchedClusterIP, err = helpers.DoHostnamesMatch(zarfStateClusterIPAddress, repoURL)
-			if err != nil {
-				return false, false, err
-			}
-		}
-	} else {
-		isPatched, err = helpers.DoHostnamesMatch(gs.Address, repoURL)
-	}
-
-	return (isUpdate && !isPatched), isPatchedClusterIP, err
 }
 
 func mutateOCIURL(ctx context.Context, repoURL, registryAddress string, isPatchedClusterIP bool) (string, error) {

--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -311,6 +311,67 @@ func TestArgoAppWebhook(t *testing.T) {
 	}
 }
 
+func TestArgoAppWebhookOCIWithNoGitServer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{
+		RegistryInfo: state.RegistryInfo{
+			Address: "127.0.0.1:31999",
+		},
+	}
+
+	tests := []admissionTest{
+		{
+			name: "should mutate OCI sources when git server is not configured",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://ghcr.io/stefanprodan/charts/podinfo"},
+					Sources: []ApplicationSource{
+						{RepoURL: "oci://registry-1.docker.io/dhpup/oci-edge"},
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/0/repoURL",
+					"oci://127.0.0.1:31999/dhpup/oci-edge",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should skip git sources when git server is not configured",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "https://github.com/org/repo"},
+				},
+			}),
+			// No patches expected
+			code: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := createTestClientWithZarfState(ctx, t, s)
+			handler := admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c))
+			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
+			verifyAdmission(t, rr, tt)
+		})
+	}
+}
+
 func TestShouldMutateURL(t *testing.T) {
 	t.Parallel()
 

--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -310,3 +310,97 @@ func TestArgoAppWebhook(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldMutateURL(t *testing.T) {
+	t.Parallel()
+
+	gitServerInfo := state.GitServerInfo{
+		Address:      "https://git-server.com",
+		PushUsername: "a-push-user",
+	}
+
+	tests := []struct {
+		name                   string
+		operation              v1.Operation
+		isOCIURL               bool
+		repoURL                string
+		registryAddress        string
+		clusterIP              string
+		wantShouldMutate       bool
+		wantIsPatchedClusterIP bool
+	}{
+		{
+			name:             "create always mutates git URL",
+			operation:        v1.Create,
+			repoURL:          "https://github.com/zarf-dev/zarf.git",
+			wantShouldMutate: true,
+		},
+		{
+			name:             "create always mutates OCI URL",
+			operation:        v1.Create,
+			isOCIURL:         true,
+			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
+			registryAddress:  "127.0.0.1:31999",
+			wantShouldMutate: true,
+		},
+		{
+			name:             "update mutates unpatched git URL",
+			operation:        v1.Update,
+			repoURL:          "https://github.com/zarf-dev/zarf.git",
+			wantShouldMutate: true,
+		},
+		{
+			name:      "update skips already patched git URL",
+			operation: v1.Update,
+			repoURL:   "https://git-server.com/a-push-user/zarf-3883081014",
+		},
+		{
+			name:             "update mutates unpatched OCI URL",
+			operation:        v1.Update,
+			isOCIURL:         true,
+			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
+			registryAddress:  "127.0.0.1:31999",
+			wantShouldMutate: true,
+		},
+		{
+			name:            "update skips already patched OCI registry address",
+			operation:       v1.Update,
+			isOCIURL:        true,
+			repoURL:         "oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+			registryAddress: "127.0.0.1:31999",
+		},
+		{
+			name:                   "update with OCI URL patched to cluster IP sets isPatchedClusterIP",
+			operation:              v1.Update,
+			isOCIURL:               true,
+			repoURL:                "oci://10.11.12.13:5000/stefanprodan/charts/podinfo",
+			registryAddress:        "zarf-docker-registry.zarf.svc.cluster.local:5000",
+			clusterIP:              "10.11.12.13:5000",
+			wantShouldMutate:       true,
+			wantIsPatchedClusterIP: true,
+		},
+		{
+			name:             "update with empty clusterIP never sets isPatchedClusterIP",
+			operation:        v1.Update,
+			isOCIURL:         true,
+			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
+			registryAddress:  "127.0.0.1:31999",
+			wantShouldMutate: true,
+		},
+		{
+			name:      "non-create non-update operation does not mutate",
+			operation: v1.Delete,
+			repoURL:   "https://github.com/zarf-dev/zarf.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			shouldMutate, isPatchedClusterIP, err := shouldMutateURL(tt.operation, tt.isOCIURL, tt.repoURL, tt.registryAddress, tt.clusterIP, gitServerInfo)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantShouldMutate, shouldMutate)
+			require.Equal(t, tt.wantIsPatchedClusterIP, isPatchedClusterIP)
+		})
+	}
+}

--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -117,6 +117,34 @@ func TestArgoAppWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should not re-mutate on create if url already points to zarf registry",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://127.0.0.1:31999/stefanprodan/charts/podinfo"},
+					Sources: []ApplicationSource{
+						{RepoURL: "oci://127.0.0.1:31999/dhpup/oci-edge"},
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/0/repoURL",
+					"oci://127.0.0.1:31999/dhpup/oci-edge",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "should be mutated for OCI repo",
 			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
 				Spec: ApplicationSpec{
@@ -368,100 +396,6 @@ func TestArgoAppWebhookOCIWithNoGitServer(t *testing.T) {
 			handler := admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c))
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
 			verifyAdmission(t, rr, tt)
-		})
-	}
-}
-
-func TestShouldMutateURL(t *testing.T) {
-	t.Parallel()
-
-	gitServerInfo := state.GitServerInfo{
-		Address:      "https://git-server.com",
-		PushUsername: "a-push-user",
-	}
-
-	tests := []struct {
-		name                   string
-		operation              v1.Operation
-		isOCIURL               bool
-		repoURL                string
-		registryAddress        string
-		clusterIP              string
-		wantShouldMutate       bool
-		wantIsPatchedClusterIP bool
-	}{
-		{
-			name:             "create always mutates git URL",
-			operation:        v1.Create,
-			repoURL:          "https://github.com/zarf-dev/zarf.git",
-			wantShouldMutate: true,
-		},
-		{
-			name:             "create always mutates OCI URL",
-			operation:        v1.Create,
-			isOCIURL:         true,
-			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
-			registryAddress:  "127.0.0.1:31999",
-			wantShouldMutate: true,
-		},
-		{
-			name:             "update mutates unpatched git URL",
-			operation:        v1.Update,
-			repoURL:          "https://github.com/zarf-dev/zarf.git",
-			wantShouldMutate: true,
-		},
-		{
-			name:      "update skips already patched git URL",
-			operation: v1.Update,
-			repoURL:   "https://git-server.com/a-push-user/zarf-3883081014",
-		},
-		{
-			name:             "update mutates unpatched OCI URL",
-			operation:        v1.Update,
-			isOCIURL:         true,
-			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
-			registryAddress:  "127.0.0.1:31999",
-			wantShouldMutate: true,
-		},
-		{
-			name:            "update skips already patched OCI registry address",
-			operation:       v1.Update,
-			isOCIURL:        true,
-			repoURL:         "oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
-			registryAddress: "127.0.0.1:31999",
-		},
-		{
-			name:                   "update with OCI URL patched to cluster IP sets isPatchedClusterIP",
-			operation:              v1.Update,
-			isOCIURL:               true,
-			repoURL:                "oci://10.11.12.13:5000/stefanprodan/charts/podinfo",
-			registryAddress:        "zarf-docker-registry.zarf.svc.cluster.local:5000",
-			clusterIP:              "10.11.12.13:5000",
-			wantShouldMutate:       true,
-			wantIsPatchedClusterIP: true,
-		},
-		{
-			name:             "update with empty clusterIP never sets isPatchedClusterIP",
-			operation:        v1.Update,
-			isOCIURL:         true,
-			repoURL:          "oci://ghcr.io/stefanprodan/charts/podinfo",
-			registryAddress:  "127.0.0.1:31999",
-			wantShouldMutate: true,
-		},
-		{
-			name:      "non-create non-update operation does not mutate",
-			operation: v1.Delete,
-			repoURL:   "https://github.com/zarf-dev/zarf.git",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			shouldMutate, isPatchedClusterIP, err := shouldMutateURL(tt.operation, tt.isOCIURL, tt.repoURL, tt.registryAddress, tt.clusterIP, gitServerInfo)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantShouldMutate, shouldMutate)
-			require.Equal(t, tt.wantIsPatchedClusterIP, isPatchedClusterIP)
 		})
 	}
 }

--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -33,12 +35,15 @@ func TestArgoAppWebhook(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := &state.State{GitServer: state.GitServerInfo{
-		Address:      "https://git-server.com",
-		PushUsername: "a-push-user",
-	}}
-	c := createTestClientWithZarfState(ctx, t, s)
-	handler := admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c))
+	s := &state.State{
+		GitServer: state.GitServerInfo{
+			Address:      "https://git-server.com",
+			PushUsername: "a-push-user",
+		},
+		RegistryInfo: state.RegistryInfo{
+			Address: "127.0.0.1:31999",
+		},
+	}
 
 	tests := []admissionTest{
 		{
@@ -112,6 +117,93 @@ func TestArgoAppWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should be mutated for OCI repo",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://ghcr.io/stefanprodan/charts/podinfo"},
+					Sources: []ApplicationSource{
+						{
+							RepoURL: "oci://registry-1.docker.io/dhpup/oci-edge",
+						},
+						{
+							RepoURL: "https://diff-git-server.com/almonds",
+						},
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/0/repoURL",
+					"oci://127.0.0.1:31999/dhpup/oci-edge",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/1/repoURL",
+					"https://git-server.com/a-push-user/almonds-640159520",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI repo with internal service registry",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://ghcr.io/stefanprodan/charts/podinfo"},
+					Sources: []ApplicationSource{
+						{
+							RepoURL: "oci://ghcr.io/stefanprodan/manifests/podinfo",
+						},
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sources/0/repoURL",
+					"oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/manifests/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "should return internal server error on bad git URL",
 			admissionReq: createArgoAppAdmissionRequest(t, v1.Create, &Application{
 				Spec: ApplicationSpec{
@@ -121,11 +213,98 @@ func TestArgoAppWebhook(t *testing.T) {
 			code:        http.StatusInternalServerError,
 			errContains: AgentErrTransformGitURL,
 		},
+		{
+			name: "should not mutate already patched cluster DNS url",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Update, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo"},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should mutate cluster IP to DNS",
+			admissionReq: createArgoAppAdmissionRequest(t, v1.Update, &Application{
+				Spec: ApplicationSpec{
+					Source: &ApplicationSource{RepoURL: "oci://10.11.12.13:5000/stefanprodan/charts/podinfo"},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/source/repoURL",
+					"oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			c := createTestClientWithZarfState(ctx, t, s)
+			handler := admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c))
+			if tt.svc != nil {
+				_, err := c.Clientset.CoreV1().Services("zarf").Create(ctx, tt.svc, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
 			verifyAdmission(t, rr, tt)
 		})

--- a/src/internal/agent/hooks/argocd-applicationset.go
+++ b/src/internal/agent/hooks/argocd-applicationset.go
@@ -64,19 +64,28 @@ func mutateApplicationSet(ctx context.Context, r *v1.AdmissionRequest, cluster *
 	if err != nil {
 		return nil, err
 	}
-	if !s.GitServer.IsConfigured() {
-		l.Debug("no Zarf git server configured, skipping ArgoCD ApplicationSet mutation")
-		return &operations.Result{Allowed: true}, nil
-	}
 
 	appSet := ApplicationSet{}
 	if err = json.Unmarshal(r.Object.Raw, &appSet); err != nil {
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
 
-	l.Info("using the Zarf git server URL to mutate the ArgoCD ApplicationSet",
+	var urls []string
+	for _, generator := range appSet.Spec.Generators {
+		if generator.Git != nil && generator.Git.RepoURL != "" {
+			urls = append(urls, generator.Git.RepoURL)
+		}
+	}
+	requiresGit, requiresRegistry := classifyURLSchemes(urls)
+
+	if !anyZarfServiceUsable(requiresGit, requiresRegistry, s) {
+		l.Debug("no Zarf services configured for source URL schemes, skipping ArgoCD ApplicationSet mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
+
+	l.Info("mutating the ArgoCD ApplicationSet",
 		"name", appSet.Name,
-		"gitServer", s.GitServer.Address)
+		"operation", r.Operation)
 
 	// Get the registry service info if this is a NodePort service to use the internal kube-dns
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)

--- a/src/internal/agent/hooks/argocd-applicationset.go
+++ b/src/internal/agent/hooks/argocd-applicationset.go
@@ -78,11 +78,17 @@ func mutateApplicationSet(ctx context.Context, r *v1.AdmissionRequest, cluster *
 		"name", appSet.Name,
 		"gitServer", s.GitServer.Address)
 
+	// Get the registry service info if this is a NodePort service to use the internal kube-dns
+	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	patches := make([]operations.PatchOperation, 0)
 
 	for genIdx, generator := range appSet.Spec.Generators {
 		if generator.Git != nil && generator.Git.RepoURL != "" {
-			patchedURL, err := getPatchedRepoURL(ctx, generator.Git.RepoURL, s.GitServer)
+			patchedURL, err := getPatchedRepoURL(ctx, generator.Git.RepoURL, registryAddress, clusterIP, s.GitServer, r)
 			if err != nil {
 				return nil, err
 			}

--- a/src/internal/agent/hooks/argocd-applicationset.go
+++ b/src/internal/agent/hooks/argocd-applicationset.go
@@ -83,21 +83,23 @@ func mutateApplicationSet(ctx context.Context, r *v1.AdmissionRequest, cluster *
 		return &operations.Result{Allowed: true}, nil
 	}
 
-	l.Info("mutating the ArgoCD ApplicationSet",
-		"name", appSet.Name,
-		"operation", r.Operation)
-
 	// Get the registry service info if this is a NodePort service to use the internal kube-dns
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
 	if err != nil {
 		return nil, err
 	}
 
+	l.Info("mutating the ArgoCD ApplicationSet",
+		"name", appSet.Name,
+		"operation", r.Operation,
+		"gitServer", s.GitServer.Address,
+		"registry", registryAddress)
+
 	patches := make([]operations.PatchOperation, 0)
 
 	for genIdx, generator := range appSet.Spec.Generators {
 		if generator.Git != nil && generator.Git.RepoURL != "" {
-			patchedURL, err := getPatchedRepoURL(ctx, generator.Git.RepoURL, registryAddress, clusterIP, s.GitServer, r)
+			patchedURL, err := getPatchedRepoURL(ctx, generator.Git.RepoURL, registryAddress, clusterIP, s.GitServer)
 			if err != nil {
 				return nil, err
 			}

--- a/src/internal/agent/hooks/argocd-appproject.go
+++ b/src/internal/agent/hooks/argocd-appproject.go
@@ -66,19 +66,21 @@ func mutateAppProject(ctx context.Context, r *v1.AdmissionRequest, cluster *clus
 		return &operations.Result{Allowed: true}, nil
 	}
 
-	l.Info("mutating the ArgoCD AppProject",
-		"name", proj.Name,
-		"operation", r.Operation)
-
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
 	if err != nil {
 		return nil, err
 	}
 
+	l.Info("mutating the ArgoCD AppProject",
+		"name", proj.Name,
+		"operation", r.Operation,
+		"gitServer", s.GitServer.Address,
+		"registry", registryAddress)
+
 	patches := make([]operations.PatchOperation, 0)
 
 	for idx, repo := range proj.Spec.SourceRepos {
-		patchedURL, err := getPatchedRepoURL(ctx, repo, registryAddress, clusterIP, s.GitServer, r)
+		patchedURL, err := getPatchedRepoURL(ctx, repo, registryAddress, clusterIP, s.GitServer)
 		// The AppProject can also include source repositories like '*' (as in the default project),
 		// which results in an error because '*' cannot be found in Git
 		// For this reason, we will ignore these entries and only patch the Git repositories that are found

--- a/src/internal/agent/hooks/argocd-appproject.go
+++ b/src/internal/agent/hooks/argocd-appproject.go
@@ -53,19 +53,22 @@ func mutateAppProject(ctx context.Context, r *v1.AdmissionRequest, cluster *clus
 	if err != nil {
 		return nil, err
 	}
-	if !s.GitServer.IsConfigured() {
-		l.Debug("no Zarf git server configured, skipping ArgoCD AppProject mutation")
-		return &operations.Result{Allowed: true}, nil
-	}
 
 	proj := AppProject{}
 	if err = json.Unmarshal(r.Object.Raw, &proj); err != nil {
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
 
-	l.Info("using the Zarf git server URL to mutate the ArgoCD AppProject",
+	requiresGit, requiresRegistry := classifyURLSchemes(proj.Spec.SourceRepos)
+
+	if !anyZarfServiceUsable(requiresGit, requiresRegistry, s) {
+		l.Debug("no Zarf services configured for source URL schemes, skipping ArgoCD AppProject mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
+
+	l.Info("mutating the ArgoCD AppProject",
 		"name", proj.Name,
-		"gitServer", s.GitServer.Address)
+		"operation", r.Operation)
 
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
 	if err != nil {

--- a/src/internal/agent/hooks/argocd-appproject.go
+++ b/src/internal/agent/hooks/argocd-appproject.go
@@ -67,10 +67,15 @@ func mutateAppProject(ctx context.Context, r *v1.AdmissionRequest, cluster *clus
 		"name", proj.Name,
 		"gitServer", s.GitServer.Address)
 
+	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	patches := make([]operations.PatchOperation, 0)
 
 	for idx, repo := range proj.Spec.SourceRepos {
-		patchedURL, err := getPatchedRepoURL(ctx, repo, s.GitServer)
+		patchedURL, err := getPatchedRepoURL(ctx, repo, registryAddress, clusterIP, s.GitServer, r)
 		// The AppProject can also include source repositories like '*' (as in the default project),
 		// which results in an error because '*' cannot be found in Git
 		// For this reason, we will ignore these entries and only patch the Git repositories that are found

--- a/src/internal/agent/hooks/argocd-appproject_test.go
+++ b/src/internal/agent/hooks/argocd-appproject_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -33,12 +35,15 @@ func TestArgoAppProjectWebhook(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := &state.State{GitServer: state.GitServerInfo{
-		Address:      "https://git-server.com",
-		PushUsername: "a-push-user",
-	}}
-	c := createTestClientWithZarfState(ctx, t, s)
-	handler := admission.NewHandler().Serve(ctx, NewAppProjectMutationHook(ctx, c))
+	s := &state.State{
+		GitServer: state.GitServerInfo{
+			Address:      "https://git-server.com",
+			PushUsername: "a-push-user",
+		},
+		RegistryInfo: state.RegistryInfo{
+			Address: "127.0.0.1:31999",
+		},
+	}
 
 	tests := []admissionTest{
 		{
@@ -70,6 +75,77 @@ func TestArgoAppProjectWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should be mutated for OCI repo",
+			admissionReq: createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
+				Spec: AppProjectSpec{
+					SourceRepos: []string{
+						"oci://ghcr.io/stefanprodan/charts/podinfo",
+						"oci://registry-1.docker.io/dhpup/oci-edge",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/sourceRepos/0",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sourceRepos/1",
+					"oci://127.0.0.1:31999/dhpup/oci-edge",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI repo with internal service registry",
+			admissionReq: createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
+				Spec: AppProjectSpec{
+					SourceRepos: []string{
+						"oci://ghcr.io/stefanprodan/charts/podinfo",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/sourceRepos/0",
+					"oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "should ignore unknown git URL",
 			admissionReq: createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
 				Spec: AppProjectSpec{
@@ -90,7 +166,12 @@ func TestArgoAppProjectWebhook(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			c := createTestClientWithZarfState(ctx, t, s)
+			handler := admission.NewHandler().Serve(ctx, NewAppProjectMutationHook(ctx, c))
+			if tt.svc != nil {
+				_, err := c.Clientset.CoreV1().Services("zarf").Create(ctx, tt.svc, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
 			verifyAdmission(t, rr, tt)
 		})

--- a/src/internal/agent/hooks/argocd-appproject_test.go
+++ b/src/internal/agent/hooks/argocd-appproject_test.go
@@ -177,3 +177,101 @@ func TestArgoAppProjectWebhook(t *testing.T) {
 		})
 	}
 }
+
+// TestArgoAppProjectWebhookRegistryOnly verifies behaviour when only the Zarf registry is configured
+// and no git server is present (OCI-only deployment).
+func TestArgoAppProjectWebhookRegistryOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{
+		// GitServer intentionally not configured (OCI-only scenario).
+		RegistryInfo: state.RegistryInfo{
+			Address:      "127.0.0.1:31999",
+			PullUsername: "registry-pull-user",
+			PullPassword: "registry-pull-password",
+		},
+	}
+
+	tests := []admissionTest{
+		{
+			name: "OCI sourceRepos should be mutated when only registry is configured",
+			admissionReq: createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
+				Spec: AppProjectSpec{
+					SourceRepos: []string{
+						"oci://ghcr.io/stefanprodan/charts/podinfo",
+						"oci://registry-1.docker.io/dhpup/oci-edge",
+					},
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/spec/sourceRepos/0",
+					"oci://127.0.0.1:31999/stefanprodan/charts/podinfo",
+				),
+				operations.ReplacePatchOperation(
+					"/spec/sourceRepos/1",
+					"oci://127.0.0.1:31999/dhpup/oci-edge",
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"zarf-agent": "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			// Git sourceRepos must not be mutated when there is no git server configured,
+			// regardless of whether a registry is present.
+			name: "git sourceRepos should be skipped when only registry is configured",
+			admissionReq: createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
+				Spec: AppProjectSpec{
+					SourceRepos: []string{
+						"https://some-git-server.com/cashews",
+					},
+				},
+			}),
+			patch: nil,
+			code:  http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := createTestClientWithZarfState(ctx, t, s)
+			handler := admission.NewHandler().Serve(ctx, NewAppProjectMutationHook(ctx, c))
+			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
+			verifyAdmission(t, rr, tt)
+		})
+	}
+}
+
+// TestArgoAppProjectWebhookGitOnly verifies that OCI sourceRepos are not mutated when there is
+// no registry configured (git-only deployment).
+func TestArgoAppProjectWebhookGitOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{
+		GitServer: state.GitServerInfo{
+			Address:      "https://git-server.com",
+			PushUsername: "a-push-user",
+		},
+		// RegistryInfo intentionally not configured (git-only scenario).
+	}
+
+	admissionReq := createArgoAppProjectAdmissionRequest(t, v1.Create, &AppProject{
+		Spec: AppProjectSpec{
+			SourceRepos: []string{
+				"oci://ghcr.io/stefanprodan/charts/podinfo",
+			},
+		},
+	})
+
+	c := createTestClientWithZarfState(ctx, t, s)
+	handler := admission.NewHandler().Serve(ctx, NewAppProjectMutationHook(ctx, c))
+	rr := sendAdmissionRequest(t, admissionReq, handler)
+	verifyAdmission(t, rr, admissionTest{patch: nil, code: http.StatusOK})
+}

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -127,7 +127,7 @@ func populateArgoRepositoryPatchOperations(repoURL string, gitServer state.GitSe
 	return patches
 }
 
-// Helper for getting eiher git server of registry creds
+// Helper for getting either git server of registry creds
 func getCreds(isOCIURL bool, gitServer state.GitServerInfo, registry state.RegistryInfo) (string, string) {
 	if isOCIURL {
 		return registry.PullUsername, registry.PullPassword

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -53,19 +53,11 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	if err != nil {
 		return nil, err
 	}
-	if !s.GitServer.IsConfigured() {
-		l.Debug("no Zarf git server configured, skipping ArgoCD repository secret mutation")
-		return &operations.Result{Allowed: true}, nil
-	}
 
 	secret := corev1.Secret{}
 	if err = json.Unmarshal(r.Object.Raw, &secret); err != nil {
 		return nil, fmt.Errorf(lang.ErrUnmarshal, err)
 	}
-
-	l.Info("using the Zarf git server URL to mutate the ArgoCD Repository secret",
-		"name", secret.Name,
-		"gitServer", s.GitServer.Address)
 
 	url, exists := secret.Data["url"]
 	if !exists {
@@ -76,6 +68,16 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	repoCreds.URL = string(url)
 
 	isOCIURL := helpers.IsOCIURL(repoCreds.URL)
+	requiresGit, requiresRegistry := classifyURLSchemes([]string{repoCreds.URL})
+
+	if !anyZarfServiceUsable(requiresGit, requiresRegistry, s) {
+		l.Debug("no Zarf services configured for source URL schemes, skipping ArgoCD repository secret mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
+
+	l.Info("mutating the ArgoCD repository secret",
+		"name", secret.Name,
+		"operation", r.Operation)
 
 	// Get the registry service info if this is a NodePort service to use the internal kube-dns
 	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -15,8 +15,8 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/pkg/state"
-	"github.com/zarf-dev/zarf/src/pkg/transform"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -49,10 +49,6 @@ func NewRepositorySecretMutationHook(ctx context.Context, cluster *cluster.Clust
 // mutateRepositorySecret mutates the git URL in the ArgoCD repository secret to point to the repository URL defined in the ZarfState.
 func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Cluster) (*operations.Result, error) {
 	l := logger.From(ctx)
-	isCreate := r.Operation == v1.Create
-	isUpdate := r.Operation == v1.Update
-	var isPatched bool
-
 	s, err := cluster.LoadState(ctx)
 	if err != nil {
 		return nil, err
@@ -79,29 +75,29 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	var repoCreds RepoCreds
 	repoCreds.URL = string(url)
 
-	// Check if this is an update operation and the hostname is different from what we have in the zarfState
-	// NOTE: We mutate on updates IF AND ONLY IF the hostname in the request is different from the hostname in the zarfState
-	// NOTE: We are checking if the hostname is different before because we do not want to potentially mutate a URL that has already been mutated.
-	if isUpdate {
-		isPatched, err = helpers.DoHostnamesMatch(s.GitServer.Address, repoCreds.URL)
+	isOCIURL := helpers.IsOCIURL(repoCreds.URL)
+
+	// Get the registry service info if this is a NodePort service to use the internal kube-dns
+	registryAddress, clusterIP, err := cluster.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	patchedURL, err := getPatchedRepoURL(ctx, repoCreds.URL, registryAddress, clusterIP, s.GitServer, r)
+	if err != nil {
+		return nil, err
+	}
+
+	useMTLS := s.RegistryInfo.ShouldUseMTLS()
+	var certs pki.GeneratedPKI
+	if useMTLS && isOCIURL {
+		certs, err = cluster.GetRegistryClientMTLSCert(ctx)
 		if err != nil {
-			return nil, fmt.Errorf(lang.AgentErrHostnameMatch, err)
+			return nil, fmt.Errorf("failed to find registry client mTLS secret: %w", err)
 		}
 	}
 
-	patchedURL := repoCreds.URL
-	// Mutate the repoURL if necessary
-	if isCreate || (isUpdate && !isPatched) {
-		// Mutate the git URL so that the hostname matches the hostname in the Zarf state
-		transformedURL, err := transform.GitURL(s.GitServer.Address, repoCreds.URL, s.GitServer.PushUsername)
-		if err != nil {
-			return nil, fmt.Errorf("unable the git url: %w", err)
-		}
-		patchedURL = transformedURL.String()
-		l.Debug("mutating the ArgoCD repository secret URL to the Zarf URL", "original", repoCreds.URL, "mutated", patchedURL)
-	}
-
-	patches := populateArgoRepositoryPatchOperations(patchedURL, s.GitServer)
+	patches := populateArgoRepositoryPatchOperations(patchedURL, s.GitServer, s.RegistryInfo, isOCIURL, useMTLS, certs)
 	patches = append(patches, getLabelPatch(secret.Labels))
 
 	return &operations.Result{
@@ -111,11 +107,30 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 }
 
 // Patch updates of the Argo Repository Secret.
-func populateArgoRepositoryPatchOperations(repoURL string, gitServer state.GitServerInfo) []operations.PatchOperation {
+func populateArgoRepositoryPatchOperations(repoURL string, gitServer state.GitServerInfo, registryInfo state.RegistryInfo, isOCIURL bool, useMTLS bool, cert pki.GeneratedPKI) []operations.PatchOperation {
 	var patches []operations.PatchOperation
+	username, password := getCreds(isOCIURL, gitServer, registryInfo)
+
 	patches = append(patches, operations.ReplacePatchOperation("/data/url", base64.StdEncoding.EncodeToString([]byte(repoURL))))
-	patches = append(patches, operations.ReplacePatchOperation("/data/username", base64.StdEncoding.EncodeToString([]byte(gitServer.PullUsername))))
-	patches = append(patches, operations.ReplacePatchOperation("/data/password", base64.StdEncoding.EncodeToString([]byte(gitServer.PullPassword))))
+	patches = append(patches, operations.ReplacePatchOperation("/data/username", base64.StdEncoding.EncodeToString([]byte(username))))
+	patches = append(patches, operations.ReplacePatchOperation("/data/password", base64.StdEncoding.EncodeToString([]byte(password))))
+
+	if isOCIURL && registryInfo.IsInternal() && !useMTLS {
+		patches = append(patches, operations.ReplacePatchOperation("/data/insecureOCIForceHttp", base64.StdEncoding.EncodeToString([]byte("true"))))
+	}
+
+	if useMTLS && isOCIURL {
+		patches = append(patches, operations.ReplacePatchOperation("/data/tlsClientCertData", cert.Cert))
+		patches = append(patches, operations.ReplacePatchOperation("/data/tlsClientCertKey", cert.Key))
+	}
 
 	return patches
+}
+
+// Helper for getting eiher git server of registry creds
+func getCreds(isOCIURL bool, gitServer state.GitServerInfo, registry state.RegistryInfo) (string, string) {
+	if isOCIURL {
+		return registry.PullUsername, registry.PullPassword
+	}
+	return gitServer.PullUsername, gitServer.PullPassword
 }

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -85,7 +85,7 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 		return nil, err
 	}
 
-	patchedURL, err := getPatchedRepoURL(ctx, repoCreds.URL, registryAddress, clusterIP, s.GitServer, r)
+	patchedURL, err := getPatchedRepoURL(ctx, repoCreds.URL, registryAddress, clusterIP, s.GitServer)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/agent/hooks/argocd-repository_test.go
+++ b/src/internal/agent/hooks/argocd-repository_test.go
@@ -36,14 +36,20 @@ func TestArgoRepoWebhook(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := &state.State{GitServer: state.GitServerInfo{
-		Address:      "https://git-server.com",
-		PushUsername: "a-push-user",
-		PullPassword: "a-pull-password",
-		PullUsername: "a-pull-user",
-	}}
-	c := createTestClientWithZarfState(ctx, t, s)
-	handler := admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c))
+	s := &state.State{
+		GitServer: state.GitServerInfo{
+			Address:      "https://git-server.com",
+			PushUsername: "a-push-user",
+			PullPassword: "a-pull-password",
+			PullUsername: "a-pull-user",
+		},
+		RegistryInfo: state.RegistryInfo{
+			Address:      "127.0.0.1:31999",
+			NodePort:     31999,
+			PullUsername: "registry-pull-user",
+			PullPassword: "registry-pull-password",
+		},
+	}
 
 	tests := []admissionTest{
 		{
@@ -84,6 +90,339 @@ func TestArgoRepoWebhook(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			name: "should be mutated for OCI repo",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-oci-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://registry-1.docker.io/dhpup/oci-edge"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://127.0.0.1:31999/dhpup/oci-edge")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI Helm repo",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-oci-helm-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":       []byte("oci://ghcr.io/stefanprodan/charts/podinfo"),
+					"enableOCI": []byte("true"),
+					"type":      []byte("helm"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://127.0.0.1:31999/stefanprodan/charts/podinfo")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI Helm repo with internal service registry",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-oci-helm-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":       []byte("oci://ghcr.io/stefanprodan/charts/podinfo"),
+					"enableOCI": []byte("true"),
+					"type":      []byte("helm"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for repo-creds",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+					},
+					Name:      "argo-repo-creds-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url": []byte("https://diff-git-server.com/podinfo"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("https://git-server.com/a-push-user/podinfo-1868163476")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.GitServer.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.GitServer.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI repo for repo-creds",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+					},
+					Name:      "argo-oci-repo-creds-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://registry-1.docker.io/dhpup/oci-edge"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://127.0.0.1:31999/dhpup/oci-edge")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI Helm repo for repo-creds",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+					},
+					Name:      "argo-oci-helm-repo-creds-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":       []byte("oci://ghcr.io/stefanprodan/charts/podinfo"),
+					"enableOCI": []byte("true"),
+					"type":      []byte("helm"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://127.0.0.1:31999/stefanprodan/charts/podinfo")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated for OCI Helm repo with internal service registry for repo-creds",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+					},
+					Name:      "argo-oci-helm-repo-creds-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":       []byte("oci://ghcr.io/stefanprodan/charts/podinfo"),
+					"enableOCI": []byte("true"),
+					"type":      []byte("helm"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts/podinfo")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repo-creds",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 31999,
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
 			name: "matching hostname on update should stay the same, but secret should be added",
 			admissionReq: createArgoRepoAdmissionRequest(t, v1.Update, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -120,11 +459,237 @@ func TestArgoRepoWebhook(t *testing.T) {
 			},
 			code: http.StatusOK,
 		},
+		{
+			name: "should not mutate already patched cluster DNS url",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Update, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: int32(31999),
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should mutate cluster IP to DNS",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Update, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://10.11.12.13:5000/stefanprodan/charts"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: int32(31999),
+							Port:     5000,
+						},
+					},
+					ClusterIP: "10.11.12.13",
+				},
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "should be mutated with mTLS enabled",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-oci-repo-mtls-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://ghcr.io/stefanprodan/charts"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://zarf-docker-registry.zarf.svc.cluster.local:5000/stefanprodan/charts")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/tlsClientCertData",
+					b64.StdEncoding.EncodeToString([]byte("zarf-registry-client-tls-crt")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/tlsClientCertKey",
+					b64.StdEncoding.EncodeToString([]byte("zarf-registry-client-tls-key")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: "zarf",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Port: 5000,
+						},
+					},
+				},
+			},
+			registryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:31999",
+				RegistryMode: state.RegistryModeProxy,
+				PullUsername: "registry-pull-user",
+				PullPassword: "registry-pull-password",
+			},
+			useMTLS: true,
+			code:    http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			testState := s
+			if tt.registryInfo.Address != "" {
+				testState = &state.State{
+					GitServer:    s.GitServer,
+					RegistryInfo: tt.registryInfo,
+				}
+			}
+			c := createTestClientWithZarfState(ctx, t, testState)
+			handler := admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c))
+			if tt.svc != nil {
+				_, err := c.Clientset.CoreV1().Services("zarf").Create(ctx, tt.svc, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+			if tt.useMTLS {
+				certSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "zarf-registry-client-tls",
+						Namespace: state.ZarfNamespaceName,
+					},
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						"tls.crt": []byte("zarf-registry-client-tls-crt"),
+						"tls.key": []byte("zarf-registry-client-tls-key"),
+						"ca.crt":  []byte("zarf-registry-client-tls-ca-crt"),
+					},
+				}
+				_, err := c.Clientset.CoreV1().Secrets(state.ZarfNamespaceName).Create(ctx, certSecret, metav1.CreateOptions{})
+				require.NoError(t, err)
+				testState.RegistryInfo.MTLSStrategy = state.MTLSStrategyZarfManaged
+				err = c.SaveState(ctx, testState)
+				require.NoError(t, err)
+			}
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
 			verifyAdmission(t, rr, tt)
 		})

--- a/src/internal/agent/hooks/argocd-repository_test.go
+++ b/src/internal/agent/hooks/argocd-repository_test.go
@@ -695,3 +695,129 @@ func TestArgoRepoWebhook(t *testing.T) {
 		})
 	}
 }
+
+// TestArgoRepoWebhookRegistryOnly verifies behaviour when only the Zarf registry is configured
+// and no git server is present (OCI-only deployment).
+func TestArgoRepoWebhookRegistryOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{
+		// GitServer intentionally not configured (OCI-only scenario).
+		RegistryInfo: state.RegistryInfo{
+			Address:      "127.0.0.1:31999",
+			NodePort:     31999,
+			PullUsername: "registry-pull-user",
+			PullPassword: "registry-pull-password",
+		},
+	}
+
+	tests := []admissionTest{
+		{
+			name: "OCI repository should be mutated when only registry is configured",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-oci-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url":  []byte("oci://registry-1.docker.io/dhpup/oci-edge"),
+					"type": []byte("oci"),
+				},
+			}),
+			patch: []operations.PatchOperation{
+				operations.ReplacePatchOperation(
+					"/data/url",
+					b64.StdEncoding.EncodeToString([]byte("oci://127.0.0.1:31999/dhpup/oci-edge")),
+				),
+				operations.ReplacePatchOperation(
+					"/data/username",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullUsername)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/password",
+					b64.StdEncoding.EncodeToString([]byte(s.RegistryInfo.PullPassword)),
+				),
+				operations.ReplacePatchOperation(
+					"/data/insecureOCIForceHttp",
+					b64.StdEncoding.EncodeToString([]byte("true")),
+				),
+				operations.ReplacePatchOperation(
+					"/metadata/labels",
+					map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+						"zarf-agent":                     "patched",
+					},
+				),
+			},
+			code: http.StatusOK,
+		},
+		{
+			// A git repository secret must not be mutated when there is no git server configured,
+			// regardless of whether a registry is present.
+			name: "git repository should be skipped when only registry is configured",
+			admissionReq: createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"argocd.argoproj.io/secret-type": "repository",
+					},
+					Name:      "argo-git-repo-secret",
+					Namespace: "argo",
+				},
+				Data: map[string][]byte{
+					"url": []byte("https://some-git-server.com/podinfo"),
+				},
+			}),
+			patch: nil,
+			code:  http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := createTestClientWithZarfState(ctx, t, s)
+			handler := admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c))
+			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
+			verifyAdmission(t, rr, tt)
+		})
+	}
+}
+
+// TestArgoRepoWebhookGitOnly verifies that OCI repository secrets are not mutated when there is
+// no registry configured (git-only deployment).
+func TestArgoRepoWebhookGitOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{
+		GitServer: state.GitServerInfo{
+			Address:      "https://git-server.com",
+			PushUsername: "a-push-user",
+			PullPassword: "a-pull-password",
+			PullUsername: "a-pull-user",
+		},
+		// RegistryInfo intentionally not configured (git-only scenario).
+	}
+
+	admissionReq := createArgoRepoAdmissionRequest(t, v1.Create, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "repository",
+			},
+			Name:      "argo-oci-repo-secret",
+			Namespace: "argo",
+		},
+		Data: map[string][]byte{
+			"url":  []byte("oci://registry-1.docker.io/dhpup/oci-edge"),
+			"type": []byte("oci"),
+		},
+	})
+
+	c := createTestClientWithZarfState(ctx, t, s)
+	handler := admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c))
+	rr := sendAdmissionRequest(t, admissionReq, handler)
+	verifyAdmission(t, rr, admissionTest{patch: nil, code: http.StatusOK})
+}

--- a/src/internal/agent/hooks/common.go
+++ b/src/internal/agent/hooks/common.go
@@ -20,6 +20,13 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
+const (
+	// AgentErrTransformGitURL is thrown when the agent fails to make the git url a Zarf compatible url
+	AgentErrTransformGitURL = "unable to transform the git url"
+	// AgentErrTransformOCIURL is thrown when the agent fails to make the OCI url a Zarf compatible url
+	AgentErrTransformOCIURL = "unable to transform the OCIRepo URL"
+)
+
 func getLabelPatch(currLabels map[string]string) operations.PatchOperation {
 	if currLabels == nil {
 		currLabels = make(map[string]string)

--- a/src/internal/agent/hooks/common.go
+++ b/src/internal/agent/hooks/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/defenseunicorns/pkg/helpers/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/internal/agent/operations"
 	"github.com/zarf-dev/zarf/src/pkg/images"
@@ -33,6 +34,26 @@ func getLabelPatch(currLabels map[string]string) operations.PatchOperation {
 	}
 	currLabels["zarf-agent"] = "patched"
 	return operations.ReplacePatchOperation("/metadata/labels", currLabels)
+}
+
+// classifyURLSchemes reports whether any of the given repository URLs require
+// the Zarf git server or the Zarf registry (OCI).
+func classifyURLSchemes(urls []string) (requiresGit, requiresRegistry bool) {
+	for _, u := range urls {
+		if helpers.IsOCIURL(u) {
+			requiresRegistry = true
+		} else {
+			requiresGit = true
+		}
+	}
+	return
+}
+
+// anyZarfServiceUsable returns true when at least one required Zarf service is
+// configured in the given state. Use this to decide whether a mutation hook
+// should proceed.
+func anyZarfServiceUsable(requiresGit, requiresRegistry bool, s *state.State) bool {
+	return (requiresGit && s.GitServer.IsConfigured()) || (requiresRegistry && s.RegistryInfo.IsConfigured())
 }
 
 func getManifestConfigMediaType(ctx context.Context, zarfState *state.State, transport http.RoundTripper, imageAddress string) (string, error) {

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -21,9 +21,6 @@ import (
 	v1 "k8s.io/api/admission/v1"
 )
 
-// AgentErrTransformGitURL is thrown when the agent fails to make the git url a Zarf compatible url
-const AgentErrTransformGitURL = "unable to transform the git url"
-
 // NewGitRepositoryMutationHook creates a new instance of the git repo mutation hook.
 func NewGitRepositoryMutationHook(ctx context.Context, cluster *cluster.Cluster) operations.Hook {
 	return operations.Hook{

--- a/src/internal/agent/hooks/flux-ocirepo.go
+++ b/src/internal/agent/hooks/flux-ocirepo.go
@@ -120,12 +120,12 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		if isPatchedClusterIP {
 			patchedSrc, err = transform.ImageTransformHostWithoutChecksum(registryAddress, patchedURL)
 			if err != nil {
-				return nil, fmt.Errorf("unable to transform the OCIRepo URL: %w", err)
+				return nil, fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
 			}
 		} else {
 			patchedSrc, err = transform.ImageTransformHost(registryAddress, patchedURL)
 			if err != nil {
-				return nil, fmt.Errorf("unable to transform the OCIRepo URL: %w", err)
+				return nil, fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
 			}
 		}
 
@@ -166,7 +166,7 @@ func mutateOCIRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 		if isChart(mediaType) {
 			patchedSrc, err = transform.ImageTransformHostWithoutChecksum(registryAddress, patchedURL)
 			if err != nil {
-				return nil, fmt.Errorf("unable to transform the OCIRepo URL: %w", err)
+				return nil, fmt.Errorf("%s: %w", AgentErrTransformOCIURL, err)
 			}
 		}
 

--- a/src/test/e2e/22_git_and_gitops_test.go
+++ b/src/test/e2e/22_git_and_gitops_test.go
@@ -201,6 +201,16 @@ func waitArgoDeployment(t *testing.T) {
 
 	expectedMutatedRepoURL := fmt.Sprintf("%s/%s/podinfo-1646971829.git", state.ZarfInClusterGitServiceURL, state.ZarfGitPushUser)
 
+	ctx := logger.WithContext(context.Background(), test.GetLogger(t))
+	c, err := cluster.NewWithWait(ctx)
+	require.NoError(t, err)
+	s, err := c.LoadState(ctx)
+	require.NoError(t, err, "Failed to load Zarf state")
+	registryAddress, _, err := c.GetServiceInfoFromRegistryAddress(ctx, s.RegistryInfo)
+	require.NoError(t, err)
+	expectedMutatedHelmOCIURL := fmt.Sprintf("oci://%s/stefanprodan/charts/podinfo", registryAddress)
+	expectedMutatedManifestOCIURL := fmt.Sprintf("oci://%s/dhpup/oci-edge", registryAddress)
+
 	// Tests the mutation of the private repository Secret for ArgoCD.
 	stdOut, stdErr, err = e2e.Kubectl(t, "get", "secret", "argocd-repo-github-podinfo", "-n", "argocd", "-o", "jsonpath={.data.url}")
 	require.NoError(t, err, stdOut, stdErr)
@@ -213,6 +223,32 @@ func waitArgoDeployment(t *testing.T) {
 	stdOut, stdErr, err = e2e.Kubectl(t, "get", "application", "podinfo", "-n", "argocd", "-o", "jsonpath={.spec.sources[0].repoURL}")
 	require.NoError(t, err, stdOut, stdErr)
 	require.Equal(t, expectedMutatedRepoURL, stdOut)
+
+	// Tests the mutation of the private repository Secret for ArgoCD for Helm OCI.
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "secret", "argocd-repo-oci-helm", "-n", "argocd", "-o", "jsonpath={.data.url}")
+	require.NoError(t, err, stdOut, stdErr)
+
+	expectedMutatedPrivateRepoURLSecret, err = base64.StdEncoding.DecodeString(stdOut)
+	require.NoError(t, err, stdOut, stdErr)
+	require.Equal(t, expectedMutatedHelmOCIURL, string(expectedMutatedPrivateRepoURLSecret))
+
+	// Tests the mutation of the repoURL for Application CRD source(s) for ArgoCD for Helm OCI.
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "application", "oci-helm", "-n", "argocd", "-o", "jsonpath={.spec.sources[0].repoURL}")
+	require.NoError(t, err, stdOut, stdErr)
+	require.Equal(t, expectedMutatedHelmOCIURL, stdOut)
+
+	// Tests the mutation of the private repository Secret for ArgoCD for OCI Manifests.
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "secret", "argocd-repo-oci-manifests", "-n", "argocd", "-o", "jsonpath={.data.url}")
+	require.NoError(t, err, stdOut, stdErr)
+
+	expectedMutatedPrivateRepoURLSecret, err = base64.StdEncoding.DecodeString(stdOut)
+	require.NoError(t, err, stdOut, stdErr)
+	require.Equal(t, expectedMutatedManifestOCIURL, string(expectedMutatedPrivateRepoURLSecret))
+
+	// Tests the mutation of the repoURL for Application CRD source(s) for ArgoCD for OCI Manifests.
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "application", "oci-manifests", "-n", "argocd", "-o", "jsonpath={.spec.sources[0].repoURL}")
+	require.NoError(t, err, stdOut, stdErr)
+	require.Equal(t, expectedMutatedManifestOCIURL, stdOut)
 
 	// Remove the argocd example when deployment completes
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "argocd", "--confirm")

--- a/src/test/e2e/22_git_and_gitops_test.go
+++ b/src/test/e2e/22_git_and_gitops_test.go
@@ -192,11 +192,11 @@ func waitFluxPodInfoDeployment(t *testing.T) {
 func waitArgoDeployment(t *testing.T) {
 	// Deploy the argocd example and verify that it works
 	tmpdir := t.TempDir()
-	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "examples/argocd", "-o", tmpdir, "--skip-sbom")
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
 	require.NoError(t, err, stdOut, stdErr)
 	packageName := fmt.Sprintf("zarf-package-argocd-%s.tar.zst", e2e.Arch)
 	path := filepath.Join(tmpdir, packageName)
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--components=argocd-apps", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--components=argocd-apps", "--confirm", "--features=\"values=true\"")
 	require.NoError(t, err, stdOut, stdErr)
 
 	expectedMutatedRepoURL := fmt.Sprintf("%s/%s/podinfo-1646971829.git", state.ZarfInClusterGitServiceURL, state.ZarfGitPushUser)

--- a/src/test/e2e/22_git_and_gitops_test.go
+++ b/src/test/e2e/22_git_and_gitops_test.go
@@ -196,7 +196,7 @@ func waitArgoDeployment(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 	packageName := fmt.Sprintf("zarf-package-argocd-%s.tar.zst", e2e.Arch)
 	path := filepath.Join(tmpdir, packageName)
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--components=argocd-apps", "--confirm", "--features=\"values=true\"")
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--components=argocd-apps", "--confirm", "--features", "values=true")
 	require.NoError(t, err, stdOut, stdErr)
 
 	expectedMutatedRepoURL := fmt.Sprintf("%s/%s/podinfo-1646971829.git", state.ZarfInClusterGitServiceURL, state.ZarfGitPushUser)

--- a/src/test/e2e/22_git_and_gitops_test.go
+++ b/src/test/e2e/22_git_and_gitops_test.go
@@ -192,7 +192,7 @@ func waitFluxPodInfoDeployment(t *testing.T) {
 func waitArgoDeployment(t *testing.T) {
 	// Deploy the argocd example and verify that it works
 	tmpdir := t.TempDir()
-	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", "examples/argocd", "-o", tmpdir, "--skip-sbom", "--features", "values=true")
 	require.NoError(t, err, stdOut, stdErr)
 	packageName := fmt.Sprintf("zarf-package-argocd-%s.tar.zst", e2e.Arch)
 	path := filepath.Join(tmpdir, packageName)

--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -137,6 +137,8 @@ func (suite *ExtInClusterTestSuite) Test_0_Mirror() {
 	fmt.Println(string(regBody))
 	suite.Equal(200, respReg.StatusCode)
 	suite.Contains(string(regBody), "stefanprodan/podinfo", "registry did not contain the expected image")
+	suite.Contains(string(regBody), "stefanprodan/charts/podinfo", "registry did not contain the expected image")
+	suite.Contains(string(regBody), "dhpup/oci-edge", "registry did not contain the expected image")
 
 	// Check that the git server contains the repos we want (TODO VERIFY NAME AND PORT)
 

--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -107,7 +107,7 @@ func (suite *ExtInClusterTestSuite) Test_0_Mirror() {
 	// Use Zarf to mirror a package to the services (do this as test 0 so that the registry is unpolluted)
 	t := suite.T()
 	tmpdir := t.TempDir()
-	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom")
+	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
 	suite.NoError(err)
 	mirrorArgs := []string{"package", "mirror-resources", filepath.Join(tmpdir, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())), "--confirm"}
 	mirrorArgs = append(mirrorArgs, inClusterMirrorCredentialArgs...)

--- a/src/test/external/ext_in_cluster_test.go
+++ b/src/test/external/ext_in_cluster_test.go
@@ -107,7 +107,7 @@ func (suite *ExtInClusterTestSuite) Test_0_Mirror() {
 	// Use Zarf to mirror a package to the services (do this as test 0 so that the registry is unpolluted)
 	t := suite.T()
 	tmpdir := t.TempDir()
-	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
+	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features", "values=true")
 	suite.NoError(err)
 	mirrorArgs := []string{"package", "mirror-resources", filepath.Join(tmpdir, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())), "--confirm"}
 	mirrorArgs = append(mirrorArgs, inClusterMirrorCredentialArgs...)

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -46,6 +46,32 @@ var outClusterCredentialArgs = []string{
 	"--registry-push-password=" + commonPassword,
 	fmt.Sprintf("--registry-url=%s:%s/test", registryHost, registryPort)}
 
+// Additional values needed for Argo CD in this test.
+// It uses 'curloptResolve' to force-map 'gitea.localhost' for test environments
+// where the system's libcurl/RFC 6761 implementation would otherwise ignore
+const gitConfig = `
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: git-config-localhost-resolve
+    data:
+      gitconfig: |
+        [http]
+            curloptResolve = gitea.localhost:3000:172.31.0.99
+
+repoServer:
+  volumes:
+    - name: gitconfig-volume
+      configMap:
+        name: git-config-localhost-resolve
+
+  volumeMounts:
+    - name: gitconfig-volume
+      mountPath: /etc/gitconfig
+      subPath: gitconfig
+`
+
 type ExtOutClusterTestSuite struct {
 	suite.Suite
 	*require.Assertions
@@ -126,6 +152,8 @@ func (suite *ExtOutClusterTestSuite) Test_0_Mirror() {
 	fmt.Println(string(regBody))
 	suite.Equal(200, respReg.StatusCode)
 	suite.Contains(string(regBody), "stefanprodan/podinfo", "registry did not contain the expected image")
+	suite.Contains(string(regBody), "stefanprodan/charts/podinfo", "registry did not contain the expected image")
+	suite.Contains(string(regBody), "dhpup/oci-edge", "registry did not contain the expected image")
 
 	// Check that the git server contains the repos we want
 	gitRepoURL := fmt.Sprintf("http://%s:%s@%s:3000/api/v1/repos/search", giteaUser, commonPassword, giteaHost)
@@ -156,7 +184,19 @@ func (suite *ExtOutClusterTestSuite) Test_2_DeployGitOps() {
 
 	err = exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", temp, "--skip-sbom")
 	suite.NoError(err)
-	deployArgs = []string{"package", "deploy", filepath.Join(temp, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())), "--confirm"}
+
+	testValuesPath := filepath.Join(temp, "test-values.yaml")
+	err = os.WriteFile(testValuesPath, []byte(gitConfig), 0600)
+	suite.NoError(err)
+
+	deployArgs = []string{
+		"package", "deploy",
+		filepath.Join(temp, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())),
+		"--confirm",
+		"--values", testValuesPath,
+		"--features", "values=true",
+	}
+
 	err = exec.CmdWithPrint(zarfBinPath, deployArgs...)
 	suite.NoError(err)
 }

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -136,7 +136,7 @@ func (suite *ExtOutClusterTestSuite) Test_0_Mirror() {
 	// Use Zarf to mirror a package to the services (do this as test 0 so that the registry is unpolluted)
 	t := suite.T()
 	tmpdir := t.TempDir()
-	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom")
+	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
 	suite.NoError(err)
 	mirrorArgs := []string{"package", "mirror-resources", filepath.Join(tmpdir, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())), "--confirm"}
 	mirrorArgs = append(mirrorArgs, outClusterCredentialArgs...)
@@ -182,7 +182,7 @@ func (suite *ExtOutClusterTestSuite) Test_2_DeployGitOps() {
 	err := exec.CmdWithPrint(zarfBinPath, deployArgs...)
 	suite.NoError(err, "unable to deploy flux example package")
 
-	err = exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", temp, "--skip-sbom")
+	err = exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", temp, "--skip-sbom", "--features=values=true")
 	suite.NoError(err)
 
 	testValuesPath := filepath.Join(temp, "test-values.yaml")

--- a/src/test/external/ext_out_cluster_test.go
+++ b/src/test/external/ext_out_cluster_test.go
@@ -136,7 +136,7 @@ func (suite *ExtOutClusterTestSuite) Test_0_Mirror() {
 	// Use Zarf to mirror a package to the services (do this as test 0 so that the registry is unpolluted)
 	t := suite.T()
 	tmpdir := t.TempDir()
-	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features=\"values=true\"")
+	err := exec.CmdWithPrint(zarfBinPath, "package", "create", "../../../examples/argocd", "-o", tmpdir, "--skip-sbom", "--features", "values=true")
 	suite.NoError(err)
 	mirrorArgs := []string{"package", "mirror-resources", filepath.Join(tmpdir, fmt.Sprintf("zarf-package-argocd-%s.tar.zst", config.GetArch())), "--confirm"}
 	mirrorArgs = append(mirrorArgs, outClusterCredentialArgs...)


### PR DESCRIPTION
## Description

This PR adds the capability to mutate OCI references in Argo CD resources and replaces the given OCI reference to the Zarf registry URL.

This change adds the possibility to use Manifest and Helm Charts in the repoURL in the Application, like explained in the [OCI Docs in Argo CD](https://argo-cd.readthedocs.io/en/stable/user-guide/oci/) with the first two examples. To archive that it also changes the patching of the URL in repository secrets to use the registry instead of the git server if oci is used.

Additionally, added the patching of the repo url for Argo CD [repo-creds](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repository-credentials) secret type.

## Related Issue

Relates to #3046 

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
