### PR TITLE
feat!: respect component selector ordering

### DIFF
--- a/site/src/content/docs/ref/components.mdx
+++ b/site/src/content/docs/ref/components.mdx
@@ -313,6 +313,13 @@ If you have any `default` components in a package definition you can also exclud
 $ zarf package deploy ./path/to/package.tar.zst --components=optional-component-1,-default-component-1
 ```
 
+For components that match multiple selectors, the last selector takes priority.
+
+```bash
+# exclude all components except component-1
+$ zarf package deploy ./path/to/package.tar.zst --components=-*,component-1
+```
+
 :::
 
 ## Extensions (Removed)

--- a/src/pkg/packager/filters/utils.go
+++ b/src/pkg/packager/filters/utils.go
@@ -18,33 +18,30 @@ const (
 )
 
 func includedOrExcluded(componentName string, requestedComponentNames []string) (selectState, string, error) {
-	// Check if the component has a leading dash indicating it should be excluded - this is done first so that exclusions precede inclusions
-	for _, requestedComponent := range requestedComponentNames {
-		if strings.HasPrefix(requestedComponent, "-") {
-			// If the component glob matches one of the requested components, then return true
-			// This supports globbing with "path" in order to have the same behavior across OSes (if we ever allow namespaced components with /)
-			matched, err := path.Match(strings.TrimPrefix(requestedComponent, "-"), componentName)
-			if err != nil {
-				return unknown, "", err
-			}
-			if matched {
-				return excluded, requestedComponent, nil
-			}
-		}
-	}
-	// Check if the component matches a glob pattern and should be included
+	// In unmatched cases we don't know if we should include or exclude yet
+	var match string
+	var matchType = unknown
+
+	// Check every component request, so last match get's priority
+	// Order is assumed to match user input
 	for _, requestedComponent := range requestedComponentNames {
 		// If the component glob matches one of the requested components, then return true
 		// This supports globbing with "path" in order to have the same behavior across OSes (if we ever allow namespaced components with /)
-		matched, err := path.Match(requestedComponent, componentName)
+		matched, err := path.Match(strings.TrimPrefix(requestedComponent, "-"), componentName)
 		if err != nil {
 			return unknown, "", err
 		}
+
 		if matched {
-			return included, requestedComponent, nil
+			match = requestedComponent
+			// Exclusions are requests with the leading "-"
+			if strings.HasPrefix(requestedComponent, "-") {
+				matchType = excluded
+			} else {
+				matchType = included
+			}
 		}
 	}
 
-	// All other cases we don't know if we should include or exclude yet
-	return unknown, "", nil
+	return matchType, match, nil
 }

--- a/src/pkg/packager/filters/utils_test.go
+++ b/src/pkg/packager/filters/utils_test.go
@@ -45,10 +45,9 @@ func Test_includedOrExcluded(t *testing.T) {
 			name:                    "Test when component is excluded and included",
 			componentName:           "example",
 			requestedComponentNames: []string{"-example", "example"},
-			wantState:               excluded,
-			wantRequestedComponent:  "-example",
+			wantState:               included,
+			wantRequestedComponent:  "example",
 		},
-		// interesting case, excluded wins
 		{
 			name:                    "Test when component is included and excluded",
 			componentName:           "example",


### PR DESCRIPTION
## Description

Current component selection always gives priority to excludes.
This prevents complex logic like excluding all components except one

```bash
# exclude all components except component-1
$ zarf package deploy ./path/to/package.tar.zst --components=-*,component-1
```

## Related Issue

Implements #4362

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
