### PR TITLE
refactor: remove init from src/cmd

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -258,8 +258,7 @@ func Execute(ctx context.Context) {
 		os.Exit(1)
 	}
 
-	// NOTE(mkcp): This line must be run with the unconfigured default logger because user flags are set downstream
-	// in rootCmd's preRun func.
+	// Use default logger in case there was an error prior to the logger being setup
 	logger.Default().Error(err.Error())
 	os.Exit(1)
 }


### PR DESCRIPTION
## Description

Simplifies the cmd layer by removing the call to the go builtin init()

## Related Issue

Fixes #2773 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
