### PR TITLE
ci: cleanup pre-installed tools more aggressively and always log cluster info in test-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Report disk space on failure
-        if: always()
+        if: failure()
         run: |
           echo "create-release failed, printing out available diskspace"
           lsblk -f

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -148,11 +148,6 @@ jobs:
       - name: Cleanup files
         uses: ./.github/actions/cleanup-files
 
-      - name: Report disk space
-        if: always()
-        run: |
-          lsblk -f
-
       - name: Run tests
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed
         #       in a previous step. This test run will use Zarf to create a K3s cluster, and a brand new cluster will be

--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -76,14 +76,14 @@ jobs:
 
       - name: Install release version of Zarf
         uses: zarf-dev/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
+        with:
+          download-init-package: true
 
       - name: Initialize the cluster with the release version
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of zarf installed
         #       in a previous step. This test run will the current release to create a K3s cluster.
         run: |
-          sudo env "PATH=$PATH" zarf tools download-init --zarf-cache="${{ runner.temp }}/cache"
           sudo env "PATH=$PATH" CI=true zarf init --components k3s,git-server --nodeport 31337 --confirm
-          sudo env "PATH=$PATH" zarf tools clear-cache --zarf-cache="${{ runner.temp }}/cache"
 
       # Before we run the regular tests we need to aggressively cleanup files to reduce disk pressure
       - name: Cleanup files
@@ -97,12 +97,6 @@ jobs:
           sudo env "PATH=$PATH" CI=true zarf package deploy zarf-package-test-upgrade-package-amd64-6.3.3.tar.zst --confirm
           sudo env "PATH=$PATH" CI=true zarf tools kubectl describe deployments -n=podinfo-upgrade
           sudo env "PATH=$PATH" CI=true zarf tools kubectl describe pods -n=podinfo-upgrade
-          rm zarf-package-test-upgrade-package-amd64-6.3.3.tar.zst
-
-      - name: Report disk space
-        if: always()
-        run: |
-          lsblk -f
 
       - name: Run tests
         # NOTE: "PATH=$PATH" preserves the default user $PATH. This is needed to maintain the version of go installed


### PR DESCRIPTION
## Description

Upgrade is failing because of disk-pressure, likely other jobs are not far off. I added some more tools to our cleanup step. I used this article as a reference https://mathio28.medium.com/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-d5fbe4443692

I noticed that cluster logs are not actually being given on failure during test-upgrade. Also we're only giving logs for a specific deployment despite running the full e2e suite.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
