### PR TITLE
feat: add --no-git-checksum flag to mirror-resources command

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -481,7 +481,7 @@ func (o *devPatchGitOptions) run(cmd *cobra.Command, args []string) error {
 	// Perform git url transformation via regex
 	text := string(content)
 
-	processedText := transform.MutateGitURLsInText(l.Warn, host, text, o.gitPushUsername)
+	processedText := transform.MutateGitURLsInText(l.Warn, host, text, o.gitPushUsername, false)
 
 	// Print the differences
 	dmp := diffmatchpatch.New()

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -468,6 +468,7 @@ type packageMirrorResourcesOptions struct {
 	confirm                 bool
 	shasum                  string
 	noImgChecksum           bool
+	noGitChecksum           bool
 	skipSignatureValidation bool
 	retries                 int
 	optionalComponents      string
@@ -503,6 +504,7 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().BoolVar(&o.noImgChecksum, "no-img-checksum", false, lang.CmdPackageMirrorFlagNoChecksum)
+	cmd.Flags().BoolVar(&o.noGitChecksum, "no-git-checksum", false, lang.CmdPackageMirrorFlagNoGitChecksum)
 	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
@@ -637,8 +639,9 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		}
 
 		mirrorOpt := packager.RepoPushOptions{
-			Cluster: c,
-			Retries: o.retries,
+			Cluster:       c,
+			Retries:       o.retries,
+			NoGitChecksum: o.noGitChecksum,
 		}
 		err = packager.PushReposToRepository(ctx, pkgLayout, o.gitServer, mirrorOpt)
 		if err != nil {

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -285,8 +285,9 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 	CmdPackageDeployFlagNamespace              = "[Alpha] Override the namespace for package deployment. Requires the package to have only one distinct namespace defined."
 	CmdPackageDeployFlagValuesFiles            = CmdPackageCreateFlagValuesFiles
 
-	CmdPackageMirrorFlagComponents = "Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported."
-	CmdPackageMirrorFlagNoChecksum = "Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images."
+	CmdPackageMirrorFlagComponents    = "Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported."
+	CmdPackageMirrorFlagNoChecksum    = "Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images."
+	CmdPackageMirrorFlagNoGitChecksum = "Turns off the addition of a checksum to git repository names while mirroring git repositories."
 
 	CmdPackageInspectFlagSbomOut    = "Specify an output directory for the SBOMs from the inspected Zarf package"
 	CmdPackageInspectFlagListImages = "List images in the package (prints to stdout)"

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -123,7 +123,7 @@ func getPatchedRepoURL(ctx context.Context, repoURL string, gs state.GitServerIn
 	// Mutate the repoURL if necessary
 	if isCreate || (isUpdate && !isPatched) {
 		// Mutate the git URL so that the hostname matches the hostname in the Zarf state
-		transformedURL, err := transform.GitURL(gs.Address, patchedURL, gs.PushUsername)
+		transformedURL, err := transform.GitURL(gs.Address, patchedURL, gs.PushUsername, false)
 		if err != nil {
 			return "", fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -89,7 +89,7 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	// Mutate the repoURL if necessary
 	if isCreate || (isUpdate && !isPatched) {
 		// Mutate the git URL so that the hostname matches the hostname in the Zarf state
-		transformedURL, err := transform.GitURL(s.GitServer.Address, repoCreds.URL, s.GitServer.PushUsername)
+		transformedURL, err := transform.GitURL(s.GitServer.Address, repoCreds.URL, s.GitServer.PushUsername, false)
 		if err != nil {
 			return nil, fmt.Errorf("unable the git url: %w", err)
 		}

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -76,7 +76,7 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	// Mutate the git URL if necessary
 	if isCreate || (isUpdate && !isPatched) {
 		// Mutate the git URL so that the hostname matches the hostname in the Zarf state
-		transformedURL, err := transform.GitURL(s.GitServer.Address, patchedURL, s.GitServer.PushUsername)
+		transformedURL, err := transform.GitURL(s.GitServer.Address, patchedURL, s.GitServer.PushUsername, false)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", AgentErrTransformGitURL, err)
 		}

--- a/src/internal/agent/http/proxy.go
+++ b/src/internal/agent/http/proxy.go
@@ -75,7 +75,7 @@ func proxyRequestTransform(r *http.Request, s *state.State) error {
 	} else {
 		switch {
 		case isGitUserAgent(r.UserAgent()):
-			targetURL, err = transform.GitURL(s.GitServer.Address, getTLSScheme(r.TLS)+r.Host+r.URL.String(), s.GitServer.PushUsername)
+			targetURL, err = transform.GitURL(s.GitServer.Address, getTLSScheme(r.TLS)+r.Host+r.URL.String(), s.GitServer.PushUsername, false)
 		case isPipUserAgent(r.UserAgent()):
 			targetURL, err = transform.PipTransformURL(s.ArtifactServer.Address, getTLSScheme(r.TLS)+r.Host+r.URL.String())
 		case isNpmUserAgent(r.UserAgent()):

--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -37,7 +37,7 @@ func Open(rootPath, address string) (*Repository, error) {
 		return nil, err
 	}
 	if os.IsNotExist(err) {
-		repoFolder, err = transform.GitURLtoRepoName(address)
+		repoFolder, err = transform.GitURLtoRepoName(address, false)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse git url %s: %w", address, err)
 		}
@@ -161,7 +161,7 @@ func (r *Repository) Path() string {
 }
 
 // Push pushes the repository to the remote git server.
-func (r *Repository) Push(ctx context.Context, address, username, password string) error {
+func (r *Repository) Push(ctx context.Context, address, username, password string, noChecksum bool) error {
 	l := logger.From(ctx)
 	repo, err := git.PlainOpen(r.path)
 	if err != nil {
@@ -176,7 +176,7 @@ func (r *Repository) Push(ctx context.Context, address, username, password strin
 	if len(remote.Config().URLs) == 0 {
 		return fmt.Errorf("repository has zero remotes configured")
 	}
-	targetURL, err := transform.GitURL(address, remote.Config().URLs[0], username)
+	targetURL, err := transform.GitURL(address, remote.Config().URLs[0], username, noChecksum)
 	if err != nil {
 		return fmt.Errorf("unable to transform the git url: %w", err)
 	}

--- a/src/pkg/transform/git_test.go
+++ b/src/pkg/transform/git_test.go
@@ -69,7 +69,7 @@ func TestMutateGitURLsInText(t *testing.T) {
 	https://www.defenseunicorns.com/
 	`
 
-	resultingText := MutateGitURLsInText(dummyLogger, "https://gitlab.com", originalText, "repo-owner")
+	resultingText := MutateGitURLsInText(dummyLogger, "https://gitlab.com", originalText, "repo-owner", false)
 	require.Equal(t, expectedText, resultingText)
 }
 


### PR DESCRIPTION
This commit adds a --no-git-checksum flag to the mirror-resources command, similar to the existing --no-img-checksum flag. When enabled, this flag prevents the addition of a CRC32 checksum suffix to git repository names during mirroring operations.

Changes:
- Add noGitChecksum field to packageMirrorResourcesOptions struct
- Add --no-git-checksum flag definition and language constant
- Add NoGitChecksum field to RepoPushOptions struct
- Update GitURLtoRepoName() to accept noChecksum parameter
- Update GitURL() to accept and pass noChecksum parameter
- Update repository.Push() to accept and use noChecksum parameter
- Update MutateGitURLsInText() to accept noChecksum parameter
- Update all callers to pass appropriate noChecksum value
- Maintain backward compatibility for existing callers

## Description

...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
