### PR TITLE
docs(examples): fix misleading comment in examples/values-templating

### DIFF
--- a/examples/values-templating/zarf.yaml
+++ b/examples/values-templating/zarf.yaml
@@ -73,7 +73,7 @@ components:
               echo "Organization: {{ .Values.site.organization }}"
               echo "Environment: {{ .Values.app.environment }}"
             template: true
-          # Without template: true (the default), go-template syntax is passed through unchanged
+          # Without template: true, go-template syntax is passed through unchanged
           - cmd: |
               echo "This {{ .wontBeProcessed }} stays as-is"
 


### PR DESCRIPTION
## Description
Spotted a misleading comment that didn't get updated when changing templating: true default behavior.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
