### PR TITLE
fix: find the agent release when deployed with a custom named init package

### DIFF
--- a/src/internal/packager/helm/zarf.go
+++ b/src/internal/packager/helm/zarf.go
@@ -126,8 +126,9 @@ func UpdateZarfAgentValues(ctx context.Context, opts InstallUpgradeOptions) erro
 	found := false
 	for _, release := range releases {
 		// Update the Zarf Agent release with the new values
-		// Maintaining the "raw-init" release name for backwards compatibility
-		if release.Chart.Name() == "raw-init-zarf-agent-zarf-agent" {
+		// Before the Zarf agent was converted to a Helm chart, the name could differ depending on the name of the init package
+		// To stay backwards compatible with these package , we exclude the package name section of the release name
+		if strings.Contains(release.Chart.Name(), "zarf-agent-zarf-agent") {
 			found = true
 			chart := v1alpha1.ZarfChart{
 				Namespace:   "zarf",


### PR DESCRIPTION
## Description

This only comes into play when the custom init package was deployed on a version of Zarf <v0.58.0. 

To test this:
 1. I did a git checkout on tag v0.57.0
 2. changed the name of the init package to custom-init
 3. make init-package
 4. verified that on zarf v0.66.0 `zarf tools update-creds` doesn't work 
 5. ran `build/zarf tools update-creds agent` with the built Zarf from this branch
## Related Issue

Fixes #4397


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
