### PR TITLE
fix: publish breaks when Zarf package name and existing directory nam…

### DIFF
--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -311,7 +311,7 @@ func TestPublishPackageDirectoryNameCollision(t *testing.T) {
 
 			// Ensure we restore the original directory
 			t.Cleanup(func() {
-				_ = os.Chdir(origDir)
+				require.NoError(t, os.Chdir(origDir))
 			})
 
 			// Publish test package

--- a/src/pkg/zoci/push.go
+++ b/src/pkg/zoci/push.go
@@ -51,7 +51,11 @@ func (r *Remote) PushPackage(ctx context.Context, pkgLayout *layout.PackageLayou
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			l.Warn("failed to remove temp directory", "path", tempDir, "error", err)
+		}
+	}()
 
 	src, err := file.New(tempDir)
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes issue where publish fails if executed from a directory containing a subdirectory name that matches the package name. To avoid the issue this PR introduces a tmp directory for the local OCI store instead of making it in the current working directory.

## Related Issue

Fixes #4148 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
