### PR TITLE
chore: add `push` alias for `zarf package publish`

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1376,6 +1376,7 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "publish { PACKAGE_SOURCE | SKELETON DIRECTORY } REPOSITORY",
+		Aliases: []string{"push"},
 		Short:   lang.CmdPackagePublishShort,
 		Example: lang.CmdPackagePublishExample,
 		Args:    cobra.ExactArgs(2),


### PR DESCRIPTION
## Description

This adds `push` alias to `zarf package publish`.

The goal is to help folks who have not been able to retrain their muscle memory from `push`/`pull` pair that's used across the ecosystem for interacting with Registries.

## Related Issue

Discussed out-of-band 🙂 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
