### PR TITLE
feat: allow custom security context

### DIFF
--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -33,9 +33,9 @@ spec:
       {{- end }}
       priorityClassName: system-node-critical
       securityContext:
-        runAsUser: 1000
-        fsGroup: 2000
-        runAsGroup: 2000
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
         seccompProfile:
           type: "RuntimeDefault"
       containers:

--- a/packages/zarf-registry/chart/values.yaml
+++ b/packages/zarf-registry/chart/values.yaml
@@ -30,6 +30,11 @@ service:
 
 resources: {}
 
+securityContext:
+  runAsUser: 1000
+  fsGroup: 2000
+  runAsGroup: 2000
+
 persistence:
   accessMode: "ReadWriteOnce"
   enabled: true

--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -84,3 +84,8 @@ serviceAccount:
 
 opentelemetry:
   exporter: ###ZARF_VAR_REGISTRY_OTEL_EXPORTER###
+
+securityContext:
+  runAsUser: ###ZARF_VAR_REGISTRY_SECURITY_CONTEXT_RUN_AS_USER###
+  fsGroup: ###ZARF_VAR_REGISTRY_SECURITY_CONTEXT_FS_GROUP###
+  runAsGroup: ###ZARF_VAR_REGISTRY_SECURITY_CONTEXT_RUN_AS_GROUP###

--- a/packages/zarf-registry/zarf.yaml
+++ b/packages/zarf-registry/zarf.yaml
@@ -106,6 +106,18 @@ variables:
     description: Decides if host port or host network should be used with the registry proxy
     default: "false"
 
+  - name: REGISTRY_SECURITY_CONTEXT_RUN_AS_USER
+    description: The user ID to run the registry as
+    default: "1000"
+
+  - name: REGISTRY_SECURITY_CONTEXT_FS_GROUP
+    description: The filesystem group ID to run the registry as
+    default: "2000"
+
+  - name: REGISTRY_SECURITY_CONTEXT_RUN_AS_GROUP
+    description: The group ID to run the registry as
+    default: "2000"
+
 constants:
   - name: REGISTRY_IMAGE
     value: "###ZARF_PKG_TMPL_REGISTRY_IMAGE###"


### PR DESCRIPTION
## Description

Adds 3 new registry variables, with defaults, to allow users to control the security context definition

## Related Issue

Fixes #4429

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
