### PR TITLE
fix!: correct proxy var

### DIFF
--- a/packages/zarf-registry/registry-values.yaml
+++ b/packages/zarf-registry/registry-values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets:
 
 proxy:
   enabled: ###ZARF_REGISTRY_PROXY###
-  hostNetwork: ###ZARF_VAR_HOST_NETWORK###
+  hostNetwork: ###ZARF_VAR_HOST_NETWORK_PROXY###
   tolerations:
     ###ZARF_VAR_PROXY_TOLERATIONS###
   image:


### PR DESCRIPTION
## Description

The proxy var is not correctly used. The values.yaml file currently uses `ZARF_VAR_HOST_NETWORK` 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
