### PR TITLE
fix(tools,wait): add an http client with a timeout slightly shorter than waitInterval to wait.go

### DIFF
--- a/src/pkg/utils/wait.go
+++ b/src/pkg/utils/wait.go
@@ -208,7 +208,10 @@ func waitForNetworkEndpoint(ctx context.Context, resource, name, condition strin
 						l.Debug(err.Error())
 						continue
 					}
-					resp.Body.Close()
+					err = resp.Body.Close()
+					if err != nil {
+						l.Debug(err.Error())
+					}
 
 					// If the status code is not in the 2xx range, try again.
 					if resp.StatusCode < 200 || resp.StatusCode > 299 {
@@ -235,7 +238,10 @@ func waitForNetworkEndpoint(ctx context.Context, resource, name, condition strin
 					l.Debug(err.Error())
 					continue
 				}
-				resp.Body.Close()
+				err = resp.Body.Close()
+				if err != nil {
+					l.Debug(err.Error())
+				}
 
 				if resp.StatusCode != code {
 					l.Debug("did not receive expected status code", "expected", code, "actual", resp.StatusCode)

--- a/src/pkg/utils/wait_test.go
+++ b/src/pkg/utils/wait_test.go
@@ -64,7 +64,7 @@ func TestWaitForNetworkEndpoint(t *testing.T) {
 	t.Cleanup(successServer.Close)
 
 	// Server that accepts connection but never responds (simulates hanging)
-	hangingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	hangingServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		// Block until the request context is cancelled
 		<-r.Context().Done()
 	}))


### PR DESCRIPTION
## Description
A user submitted this bug that appeared in CI. Initially it seemed that wait-for was only checking service health once, but looking through the code, it appears that the request will not timeout until the process is cancelled or reaped in some way. This PR adds an http client timeout similar to the waitInterval rather than prescribing a default.

## Related Issue
Fixes #4452 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
