### PR TITLE
fix(make): add linxu arm detection to make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ ifeq ($(OS),Windows_NT)
 else
 	UNAME_S := $(shell uname -s)
 	UNAME_P := $(shell uname -p)
-	ifneq ($(UNAME_S),Linux)
-		ifeq ($(UNAME_S),Darwin)
-			ZARF_BIN := $(addsuffix -mac,$(ZARF_BIN))
+	UNAME_M := $(shell uname -m)
+	ifeq ($(UNAME_S),Linux)
+		ifneq ($(filter $(UNAME_M),aarch64 arm64),)
+			ZARF_BIN := $(addsuffix -arm,$(ZARF_BIN))
+			BUILD_CLI_FOR_SYSTEM = build-cli-linux-arm
 		endif
+	else ifeq ($(UNAME_S),Darwin)
+		ZARF_BIN := $(addsuffix -mac,$(ZARF_BIN))
 		ifeq ($(UNAME_P),i386)
 			ZARF_BIN := $(addsuffix -intel,$(ZARF_BIN))
 			BUILD_CLI_FOR_SYSTEM = build-cli-mac-intel


### PR DESCRIPTION
## Description

Noticed my linux arm development machine was building the amd binary. Added detection to the `BUILD_CLI_FOR_SYSTEM` make target. 

## Related Issue

Fixes #4464

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
