### PR TITLE
feat: Add opt-in option for zarf init

### DIFF
--- a/packages/zarf-agent/agent-values.yaml
+++ b/packages/zarf-agent/agent-values.yaml
@@ -1,0 +1,3 @@
+mode:
+  namespaces: "###ZARF_VAR_AGENT_NAMESPACES_MODE###"
+  objects: "###ZARF_VAR_AGENT_OBJECTS_MODE###"

--- a/packages/zarf-agent/chart/templates/_helpers.tpl
+++ b/packages/zarf-agent/chart/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Generate selector expression based on mode.
+Active mode: exclude resources with zarf.dev/agent: skip|ignore
+Passive mode: only include resources with zarf.dev/agent: mutate, exclude resources with zarf.dev/agent: skip|ignore
+Usage: {{ include "zarf-agent.webhook.selectorExpression" "active" }}
+*/}}
+{{- define "zarf-agent.webhook.selectorExpression" -}}
+- key: zarf.dev/agent
+  operator: NotIn
+  values:
+    - "skip"
+    - "ignore"
+{{- if eq . "passive" }}
+- key: zarf.dev/agent
+  operator: In
+  values:
+    - "mutate"
+{{- end -}}
+{{- end -}}
+
+{{/* Namespace selector expression - passes namespace mode to selectorExpression */}}
+{{- define "zarf-agent.webhook.namespaceSelectorExpression" -}}
+{{- include "zarf-agent.webhook.selectorExpression" .Values.mode.namespaces -}}
+{{- end -}}
+
+{{/* Object selector expression - passes object mode to selectorExpression */}}
+{{- define "zarf-agent.webhook.objectSelectorExpression" -}}
+{{- include "zarf-agent.webhook.selectorExpression" .Values.mode.objects -}}
+{{- end -}}

--- a/packages/zarf-agent/chart/templates/webhook.yaml
+++ b/packages/zarf-agent/chart/templates/webhook.yaml
@@ -11,20 +11,10 @@ webhooks:
           values:
             # Ensure we don't mess with kube-system
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
         # Ignore K3s Klipper
         - key: svccontroller.k3s.cattle.io/svcname
           operator: DoesNotExist
@@ -57,20 +47,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
     clientConfig:
       service:
         name: {{ .Values.service.name }}
@@ -100,20 +80,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
     clientConfig:
       service:
         name: {{ .Values.service.name }}
@@ -144,20 +114,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
     clientConfig:
       service:
         name: {{ .Values.service.name }}
@@ -188,20 +148,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
     clientConfig:
       service:
         name: {{ .Values.service.name }}
@@ -230,20 +180,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
         - key: argocd.argoproj.io/secret-type
           operator: In
           values:
@@ -276,20 +216,10 @@ webhooks:
           operator: NotIn
           values:
             - "kube-system"
-        # Allow ignoring whole namespaces
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.namespaceSelectorExpression" . | nindent 8 }}
     objectSelector:
       matchExpressions:
-        # Always ignore specific resources if requested by annotation/label
-        - key: zarf.dev/agent
-          operator: NotIn
-          values:
-            - "skip"
-            - "ignore"
+        {{- include "zarf-agent.webhook.objectSelectorExpression" . | nindent 8 }}
     clientConfig:
       service:
         name: agent-hook
@@ -306,6 +236,52 @@ webhooks:
           - "v1alpha1"
         resources:
           - "appprojects"
+    admissionReviewVersions:
+      - "v1"
+      - "v1beta1"
+    sideEffects: None
+  # This webhook ensures pods in the zarf namespace are always mutated,
+  # even when passive mode is enabled. This is needed for internal components like gitea.
+  - name: agent-zarf-internal.zarf.dev
+    namespaceSelector:
+      matchExpressions:
+        # Only target the zarf namespace
+        - key: "kubernetes.io/metadata.name"
+          operator: In
+          values:
+            - "zarf"
+        - key: zarf.dev/agent
+          operator: NotIn
+          values:
+            - "skip"
+            - "ignore"
+    objectSelector:
+      matchExpressions:
+        - key: zarf.dev/agent
+          operator: NotIn
+          values:
+            - "skip"
+            - "ignore"
+        # Ignore K3s Klipper
+        - key: svccontroller.k3s.cattle.io/svcname
+          operator: DoesNotExist
+    clientConfig:
+      service:
+        name: {{ .Values.service.name }}
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate/pod"
+      caBundle: "###ZARF_AGENT_CA###"
+    rules:
+      - operations:
+          - "CREATE"
+          - "UPDATE"
+        apiGroups:
+          - ""
+        apiVersions:
+          - "v1"
+        resources:
+          - "pods"
+          - "pods/ephemeralcontainers"
     admissionReviewVersions:
       - "v1"
       - "v1beta1"

--- a/packages/zarf-agent/chart/values.yaml
+++ b/packages/zarf-agent/chart/values.yaml
@@ -40,3 +40,7 @@ resources:
 
 affinity: {}
 tolerations: []
+
+mode:
+  namespaces: "active"
+  objects: "active"

--- a/packages/zarf-agent/zarf.yaml
+++ b/packages/zarf-agent/zarf.yaml
@@ -3,6 +3,14 @@ metadata:
   name: init-package-zarf-agent
   description: Install the zarf agent mutating webhook on a new cluster
 
+variables:
+  - name: AGENT_NAMESPACES_MODE
+    description: "The namespace selection mode for the Zarf agent: 'active' (default, mutates all namespaces except those with zarf.dev/agent=ignore) or 'passive' (only mutates namespaces with zarf.dev/agent=mutate)"
+    default: "active"
+  - name: AGENT_OBJECTS_MODE
+    description: "The object selection mode for the Zarf agent: 'active' (default, mutates all objects except those with zarf.dev/agent=ignore) or 'passive' (only mutates objects with zarf.dev/agent=mutate)"
+    default: "active"
+
 constants:
   - name: AGENT_IMAGE
     value: "###ZARF_PKG_TMPL_AGENT_IMAGE###"
@@ -25,6 +33,8 @@ components:
         localPath: chart
         version: 0.1.0
         namespace: zarf
+        valuesFiles:
+          - agent-values.yaml
     actions:
       onCreate:
         before:

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -71,6 +71,11 @@ const (
 	VInitArtifactPushUser  = "init.artifact.push_username"
 	VInitArtifactPushToken = "init.artifact.push_token"
 
+	// Init Agent config keys
+
+	VInitAgentNamespacesMode = "init.agent.namespaces_mode"
+	VInitAgentObjectsMode    = "init.agent.objects_mode"
+
 	// Package config keys
 
 	VPkgOCIConcurrency = "package.oci_concurrency"
@@ -236,6 +241,10 @@ func setDefaults() {
 
 	// Package publish opts that are non-zero values
 	v.SetDefault(VPkgPublishRetries, 1)
+
+	// Init defaults
+	v.SetDefault(VInitAgentNamespacesMode, "active")
+	v.SetDefault(VInitAgentObjectsMode, "active")
 }
 
 // GetStringSlice returns a string slice from viper

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -166,6 +166,9 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInitFlagArtifactPushUser  = "[alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts."
 	CmdInitFlagArtifactPushToken = "[alpha] API Token for the push-user to access the artifact registry"
 
+	CmdInitFlagAgentNamespacesMode = "The namespace selection mode for the Zarf agent: 'active' (mutates all namespaces except ignored ones) or 'passive' (only mutates namespaces with zarf.dev/agent=mutate label)"
+	CmdInitFlagAgentObjectsMode    = "The object selection mode for the Zarf agent: 'active' (mutates all objects except ignored ones) or 'passive' (only mutates objects with zarf.dev/agent=mutate label)"
+
 	// zarf internal
 	CmdInternalShort = "Internal tools used by zarf"
 


### PR DESCRIPTION
## Description
This PR adds flags `--agent-namespaces-mode=[active|passive]` and `--agent-objects-mode=[active|passive]` to `zarf init` command. By default, both are set to _active_. When using either of them to _passive_,  _MutatingWebhookConfiguration_ will be deployed with rules that enforce namespaces/objects to be labeled with `zarf.dev/agent: mutate`, or else the images won't be mutated. An exception that was added is _zarf_ namespace, there effectively modes are always _active_ (which enables us deploy there _Gitea_ for instance)

examples:

- **agent-namespaces-mode=active**; **agent-objects-mode=active**: Current zarf behaviour
- **agent-namespaces-mode=passive**; **agent-objects-mode=active**: If namespace is labeled with `zarf.dev/agent: mutate` then like current zarf behaviour on this whole namespace. Otherwise no images are mutated at all. If the pod is labeled with `zarf.dev/agent: ignore`, then it won't be mutated neither.
- **agent-namespaces-mode=active**; **agent-objects-mode=passive**: If a pod is labeled with `zarf.dev/agent: mutate` then image is mutated pod. Otherwise no mutation is applied.
- **agent-namespaces-mode=passive**; **agent-objects-mode=passive**: Only if both namespace and pod in the namespace are labeled `zarf.dev/agent: mutate` then image mutation occurs.

## Related Issue

Relates to #4419

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
