### PR TITLE
feat: log git repo clone

### DIFF
--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -113,6 +113,8 @@ func Clone(ctx context.Context, rootPath, address string, shallow bool) (*Reposi
 		return nil
 	}
 
+	l.Info("cloning Git repository", "address", address)
+
 	repo, err := git.PlainCloneContext(ctx, r.path, false, cloneOpts)
 	if err != nil {
 		l.Info("falling back to host 'git', failed to clone the repo with Zarf", "url", gitURLNoRef, "error", err)


### PR DESCRIPTION
## Description

While reviewing #4348 I ran into a situation where a zarf package cloned the repo https://github.com/argoproj/argo-cd. This is a huge repo with many branches / tags so this took over 3 minutes even on my fast internet (>500mbs). Zarf should notify users when a clone is happening, so that when it is taking a long time, they know what the cause is. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
