### PR TITLE
chore: remove re-declared vars in test loops

### DIFF
--- a/src/internal/agent/hooks/argocd-application_test.go
+++ b/src/internal/agent/hooks/argocd-application_test.go
@@ -91,7 +91,6 @@ func TestArgoAppWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)

--- a/src/internal/agent/hooks/argocd-appproject_test.go
+++ b/src/internal/agent/hooks/argocd-appproject_test.go
@@ -89,7 +89,6 @@ func TestArgoAppProjectWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)

--- a/src/internal/agent/hooks/argocd-repository_test.go
+++ b/src/internal/agent/hooks/argocd-repository_test.go
@@ -123,7 +123,6 @@ func TestArgoRepoWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)

--- a/src/internal/agent/hooks/common_test.go
+++ b/src/internal/agent/hooks/common_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// Kubernetes’ compiled-in default if the apiserver flag
+	// Kubernetes' compiled-in default if the apiserver flag
 	// --service-node-port-range is not overridden.
 	defaultNodePortMin = 30000
 	defaultNodePortMax = 32767
@@ -135,7 +135,6 @@ func TestConfigMediaTypes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.TestContext(t)
@@ -167,7 +166,7 @@ func GetAvailableNodePort() (int, error) {
 		return 0, err
 	}
 
-	// Seed a *local* rand.Rand so concurrent callers don’t step on each other.
+	// Seed a *local* rand.Rand so concurrent callers don't step on each other.
 	seed := int64(binary.LittleEndian.Uint64(random64()))
 	r := rand.New(rand.NewSource(seed))
 

--- a/src/internal/agent/hooks/flux-gitrepo_test.go
+++ b/src/internal/agent/hooks/flux-gitrepo_test.go
@@ -118,7 +118,6 @@ func TestFluxMutationWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)

--- a/src/internal/agent/hooks/flux-helmrepo_test.go
+++ b/src/internal/agent/hooks/flux-helmrepo_test.go
@@ -226,7 +226,6 @@ func TestFluxHelmMutationWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := createTestClientWithZarfState(ctx, t, s)

--- a/src/internal/agent/hooks/flux-ocirepo_test.go
+++ b/src/internal/agent/hooks/flux-ocirepo_test.go
@@ -352,7 +352,6 @@ func TestFluxOCIMutationWebhook(t *testing.T) {
 	s := &state.State{RegistryInfo: state.RegistryInfo{Address: fmt.Sprintf("127.0.0.1:%d", port)}}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// t.Parallel()
 			c := createTestClientWithZarfState(ctx, t, s)

--- a/src/internal/agent/hooks/pods_test.go
+++ b/src/internal/agent/hooks/pods_test.go
@@ -172,7 +172,6 @@ func TestPodMutationWebhook(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rr := sendAdmissionRequest(t, tt.admissionReq, handler)

--- a/src/pkg/cluster/distro_test.go
+++ b/src/pkg/cluster/distro_test.go
@@ -170,10 +170,8 @@ func TestDetectDistro(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.distro, func(t *testing.T) {
 			t.Parallel()
-
 			distro := detectDistro(tt.node, tt.namespaces)
 			require.Equal(t, tt.distro, distro)
 		})

--- a/src/pkg/cluster/tunnel_test.go
+++ b/src/pkg/cluster/tunnel_test.go
@@ -149,10 +149,8 @@ func TestServiceInfoFromNodePortURL(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			svc, port, err := serviceInfoFromNodePortURL(tt.services, tt.nodePortURL)
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)

--- a/src/pkg/lint/findings_test.go
+++ b/src/pkg/lint/findings_test.go
@@ -42,7 +42,6 @@ func TestLintError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			lintErr := &LintError{

--- a/src/pkg/lint/validate_test.go
+++ b/src/pkg/lint/validate_test.go
@@ -141,7 +141,6 @@ func TestZarfPackageValidate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidatePackage(tt.pkg)
@@ -180,7 +179,6 @@ func TestValidateManifest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateManifest(tt.manifest)
@@ -244,7 +242,6 @@ func TestValidateReleaseName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateReleaseName(tt.chartName, tt.releaseName)
@@ -313,7 +310,6 @@ func TestValidateChart(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateChart(tt.chart)
@@ -434,7 +430,6 @@ func TestValidateComponentActions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateActions(tt.actions)
@@ -480,7 +475,6 @@ func TestValidateComponentAction(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateAction(tt.action)

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -164,7 +164,6 @@ func TestIdentifySource(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -81,7 +81,6 @@ func TestMergeStateRegistry(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -162,7 +161,6 @@ func TestMergeStateGit(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -252,7 +250,6 @@ func TestMergeStateArtifact(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/src/pkg/utils/network_test.go
+++ b/src/pkg/utils/network_test.go
@@ -58,7 +58,6 @@ func TestParseChecksum(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -125,7 +124,6 @@ func TestDownloadToFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Description

Declaring vars at the start of each loop is no longer necessary as of go 1.22 https://go.dev/blog/loopvar-preview

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
