### PR TITLE
CI: image archive test flake

### DIFF
--- a/src/test/packages/44-image-tar/pod.yaml
+++ b/src/test/packages/44-image-tar/pod.yaml
@@ -9,5 +9,5 @@ spec:
   containers:
   - name: alpine
     image: ghcr.io/zarf-dev/images/alpine:3.21.3
-    command: ["sleep", "1"]
+    command: ["sleep", "infinity"]
   restartPolicy: Always


### PR DESCRIPTION
## Description

Test 44 image archives has been failing lately as seen by https://github.com/zarf-dev/zarf/actions/runs/20819481889/job/59803742229. It seems like the pod is crashing and starting, I believe because of the sleep 1 job. Looks like in some scenarios kubernetes never gets the chance to see the pod as healthy. I updated this to sleep infinity to avoid this in the future

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
