### PR TITLE
feat!: remove insecure flag

### DIFF
--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -134,7 +134,6 @@ func (o *internalGenCliDocsOptions) run(_ *cobra.Command, _ []string) error {
 					addHiddenDummyFlag(toolCmd, "no-progress")
 					addHiddenDummyFlag(toolCmd, "zarf-cache")
 					addHiddenDummyFlag(toolCmd, "tmpdir")
-					addHiddenDummyFlag(toolCmd, "insecure")
 					addHiddenDummyFlag(toolCmd, "no-color")
 				}
 

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -295,11 +295,6 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packageDeployOptions) preRun(cmd *cobra.Command, _ []string) {
-	// If --insecure was provided, set --skip-signature-validation to match
-	if config.CommonOptions.Insecure {
-		o.skipSignatureValidation = true
-	}
-
 	// Handle deprecated --skip-signature-validation flag for backwards compatibility
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
@@ -554,11 +549,6 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packageMirrorResourcesOptions) preRun(cmd *cobra.Command, _ []string) {
-	// If --insecure was provided, set --skip-signature-validation to match
-	if config.CommonOptions.Insecure {
-		o.skipSignatureValidation = true
-	}
-
 	// Handle deprecated --skip-signature-validation flag for backwards compatibility
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
@@ -728,11 +718,6 @@ func newPackageInspectCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packageInspectOptions) preRun(cmd *cobra.Command, _ []string) {
-	// If --insecure was provided, set --skip-signature-validation to match
-	if config.CommonOptions.Insecure {
-		o.skipSignatureValidation = true
-	}
-
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
 
@@ -1513,11 +1498,6 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packageRemoveOptions) preRun(cmd *cobra.Command, _ []string) {
-	// If --insecure was provided, set --skip-signature-validation to match
-	if config.CommonOptions.Insecure {
-		o.skipSignatureValidation = true
-	}
-
 	// Handle deprecated --skip-signature-validation flag for backwards compatibility
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
@@ -1653,11 +1633,6 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packagePublishOptions) preRun(cmd *cobra.Command, _ []string) {
-	// If --insecure was provided, set --skip-signature-validation to match
-	if config.CommonOptions.Insecure {
-		o.skipSignatureValidation = true
-	}
-
 	// Handle deprecated --skip-signature-validation flag for backwards compatibility
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -81,12 +81,6 @@ func preRun(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// If --insecure was provided, set --insecure-skip-tls-verify and --plain-http to match
-	if config.CommonOptions.Insecure {
-		config.CommonOptions.InsecureSkipTLSVerify = true
-		config.CommonOptions.PlainHTTP = true
-	}
-
 	// Skip for vendor only commands
 	if checkVendorOnlyFromPath(cmd) {
 		return nil
@@ -237,10 +231,8 @@ func setupRootFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", vpr.GetString(VTmpDir), lang.RootCmdFlagTempDir)
 
 	// Security
-	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.Insecure, "insecure", vpr.GetBool(VInsecure), lang.RootCmdFlagInsecure)
 	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.PlainHTTP, "plain-http", vpr.GetBool(VPlainHTTP), lang.RootCmdFlagPlainHTTP)
 	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", vpr.GetBool(VInsecureSkipTLSVerify), lang.RootCmdFlagInsecureSkipTLSVerify)
-	_ = rootCmd.PersistentFlags().MarkDeprecated("insecure", "please use --plain-http or --insecure-skip-tls-verify instead.")
 }
 
 // Execute is the entrypoint for the CLI.

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -27,7 +27,6 @@ const (
 	VArchitecture          = "architecture"
 	VZarfCache             = "zarf_cache"
 	VTmpDir                = "tmp_dir"
-	VInsecure              = "insecure"
 	VPlainHTTP             = "plain_http"
 	VInsecureSkipTLSVerify = "insecure_skip_tls_verify"
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -45,7 +45,6 @@ const (
 	RootCmdFlagArch                  = "Architecture for OCI images and Zarf packages"
 	RootCmdFlagCachePath             = "Specify the location of the Zarf cache directory"
 	RootCmdFlagTempDir               = "Specify the temporary directory to use for intermediate files"
-	RootCmdFlagInsecure              = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."
 	RootCmdFlagPlainHTTP             = "Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture."
 	RootCmdFlagInsecureSkipTLSVerify = "Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture."
 

--- a/src/pkg/images/common.go
+++ b/src/pkg/images/common.go
@@ -187,7 +187,7 @@ func orasTransport(insecureSkipTLSVerify bool, responseHeaderTimeout time.Durati
 func NoopOpt(*crane.Options) {}
 
 // WithGlobalInsecureFlag returns an option for crane that configures insecure
-// based upon Zarf's global --insecure-skip-tls-verify (and --insecure) flags.
+// based upon Zarf's global --insecure-skip-tls-verify flag.
 func WithGlobalInsecureFlag() []crane.Option {
 	if config.CommonOptions.InsecureSkipTLSVerify {
 		return []crane.Option{crane.Insecure}

--- a/src/test/zarf-config-test.toml
+++ b/src/test/zarf-config-test.toml
@@ -4,7 +4,6 @@ no_log_file = true
 no_progress = true
 tmp_dir = 'tmp_dir: c457359e'
 zarf_cache = 'zarf_cache: 978499a5'
-insecure = true
 
 [init]
 components = 'components: 359049b9'

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -6,8 +6,6 @@ package types
 
 // ZarfCommonOptions tracks the user-defined preferences used across commands.
 type ZarfCommonOptions struct {
-	// Allow insecure connections for remote packages
-	Insecure bool
 	// Disable checking the server TLS certificate for validity
 	InsecureSkipTLSVerify bool
 	// Force connections to be over http instead of https


### PR DESCRIPTION
## Description

The insecure flag has been deprecated for one year and is replaced by `--plain-http` and `--insecure-skip-tls-verify`

## Related Issue

Fixes #3420

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
