### PR TITLE
feat: error early during healthchecks when status is terminal

### DIFF
--- a/src/internal/healthchecks/healthchecks.go
+++ b/src/internal/healthchecks/healthchecks.go
@@ -97,7 +97,7 @@ func WaitForReady(ctx context.Context, sw watcher.StatusWatcher, objs []object.O
 	for _, id := range objs {
 		rs := statusCollector.ResourceStatuses[id]
 		if rs.Status != status.CurrentStatus {
-			errs = append(errs, fmt.Errorf("%s: %s not ready, status is %s", rs.Identifier.Name, rs.Identifier.GroupKind.Kind, rs.Status))
+			errs = append(errs, fmt.Errorf("%s: %s not ready, status is %s, message: %s", rs.Identifier.Name, rs.Identifier.GroupKind.Kind, rs.Status, rs.Message))
 		}
 	}
 	// Only append parent context error, otherwise we would error when desired status is achieved.

--- a/src/internal/healthchecks/healthchecks_test.go
+++ b/src/internal/healthchecks/healthchecks_test.go
@@ -87,7 +87,7 @@ func TestRunHealthChecks(t *testing.T) {
 		{
 			name:       "One pod is never ready",
 			podYamls:   []string{podYaml, podCurrentYaml},
-			expectErrs: []error{errors.New("in-progress-pod: Pod not ready, status is InProgress"), context.DeadlineExceeded},
+			expectErrs: []error{errors.New("in-progress-pod: Pod not ready, status is InProgress, message: Pod phase not available"), context.DeadlineExceeded},
 		},
 	}
 
@@ -158,6 +158,5 @@ func TestFailedHealthChecks(t *testing.T) {
 	err = Run(ctx, statusWatcher, objs)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed-job: Job not ready, status is Failed")
-	require.NotContains(t, err.Error(), "context deadline exceeded")
+	require.Equal(t, "failed-job: Job not ready, status is Failed, message: Job Failed. failed: 1/1", err.Error())
 }


### PR DESCRIPTION
## Description

Helm recently made this improvement which made me realize this was also sub-optimal behavior in Zarf. https://github.com/helm/helm/pull/31730. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
