### PR TITLE
docs: clarify data injections deprecation timeline

### DIFF
--- a/site/src/content/docs/best-practices/data-injections-migration.mdx
+++ b/site/src/content/docs/best-practices/data-injections-migration.mdx
@@ -2,7 +2,7 @@
 title: "Migrate From Data Injections"
 ---
 
-This guide explains how to migrate your Zarf deployment from the Data Injections feature to OCI image-based data delivery methods. Data injections are deprecated in the current ZarfPackageConfig schema and will be fully removed in the next API version. Existing ZarfPackageConfig files with Data Injections will remain valid after the next API version, v1beta1, is introduced. However, Data Injections will not be part of the v1beta1 schema.
+This guide explains how to migrate your Zarf deployment from the Data Injections feature to OCI image-based data delivery methods. Data injections are deprecated in the current ZarfPackageConfig schema and will be fully removed in the next API version of the schema. Existing ZarfPackageConfig files with Data Injections will remain valid after the next API version, v1beta1, is introduced. However, Data Injections will not be part of the v1beta1 schema.
 
 There are several reasons for the deprecation of Data Injections:
 - **Poor User Experience**: Many users have struggled to figure out how to adopt Data Injections.


### PR DESCRIPTION
## Description

I noticed there was some confusion of community members about when data injections would be removed. I understand why they would be confused, given that the community has no sense of what a schema version means to Zarf given that the ZarfPackageConfig is not yet versioned. I'm hoping this line will clarify it. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
