### PR TITLE
feat!: remove global plainHTTP and insecureSkipTLSVerify in favor of optional parameters

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/packager"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // setBaseDirectory sets the base directory. This is a directory with a zarf.yaml.
@@ -21,12 +21,15 @@ func setBaseDirectory(args []string) string {
 	return "."
 }
 
-func defaultRemoteOptions() packager.RemoteOptions {
-	return packager.RemoteOptions{
-		PlainHTTP:             config.CommonOptions.PlainHTTP,
-		InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
+func defaultRemoteOptions() types.RemoteOptions {
+	return types.RemoteOptions{
+		PlainHTTP:             plainHTTP,
+		InsecureSkipTLSVerify: insecureSkipTLSVerify,
 	}
 }
+
+var plainHTTP bool
+var insecureSkipTLSVerify bool
 
 var isCleanPathRegex = regexp.MustCompile(`^[a-zA-Z0-9\_\-\/\.\~\\:]+$`)
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -109,6 +109,7 @@ func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) err
 		CachePath:        cachePath,
 		IsInteractive:    true,
 		SkipVersionCheck: true,
+		RemoteOptions:    defaultRemoteOptions(),
 	}
 	pkg, err := load.PackageDefinition(ctx, setBaseDirectory(args), loadOpts)
 	if err != nil {
@@ -202,6 +203,7 @@ func (o *devInspectManifestsOptions) run(ctx context.Context, args []string) err
 		KubeVersion:        o.kubeVersion,
 		CachePath:          cachePath,
 		IsInteractive:      true,
+		RemoteOptions:      defaultRemoteOptions(),
 	}
 	resources, err := packager.InspectDefinitionResources(ctx, setBaseDirectory(args), opts)
 	var lintErr *lint.LintError
@@ -309,6 +311,7 @@ func (o *devInspectValuesFilesOptions) run(ctx context.Context, args []string) e
 		KubeVersion:        o.kubeVersion,
 		CachePath:          cachePath,
 		IsInteractive:      true,
+		RemoteOptions:      defaultRemoteOptions(),
 	}
 	resources, err := packager.InspectDefinitionResources(ctx, setBaseDirectory(args), opts)
 	var lintErr *lint.LintError
@@ -754,6 +757,7 @@ func (o *devFindImagesOptions) run(cmd *cobra.Command, args []string) error {
 		SkipCosign:          o.skipCosign,
 		CachePath:           cachePath,
 		IsInteractive:       true,
+		RemoteOptions:       defaultRemoteOptions(),
 	}
 	imagesScans, err := packager.FindImages(ctx, basePath, findImagesOptions)
 	var lintErr *lint.LintError
@@ -880,9 +884,10 @@ func (o *devLintOptions) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	err = packager.Lint(ctx, basePath, packager.LintOptions{
-		Flavor:       o.flavor,
-		SetVariables: o.setPkgTmpl,
-		CachePath:    cachePath,
+		Flavor:        o.flavor,
+		SetVariables:  o.setPkgTmpl,
+		CachePath:     cachePath,
+		RemoteOptions: defaultRemoteOptions(),
 	})
 	var lintErr *lint.LintError
 	if errors.As(err, &lintErr) {

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -820,6 +820,7 @@ func (o *packageInspectValuesFilesOptions) run(ctx context.Context, args []strin
 		SetVariables:  o.setVariables,
 		KubeVersion:   o.kubeVersion,
 		IsInteractive: true,
+		RemoteOptions: defaultRemoteOptions(),
 	}
 	resources, err := packager.InspectPackageResources(ctx, pkgLayout, resourceOpts)
 	if err != nil {
@@ -934,6 +935,7 @@ func (o *packageInspectManifestsOptions) run(ctx context.Context, args []string)
 		SetVariables:  o.setVariables,
 		KubeVersion:   o.kubeVersion,
 		IsInteractive: true,
+		RemoteOptions: defaultRemoteOptions(),
 	}
 
 	resources, err := packager.InspectPackageResources(ctx, pkgLayout, resourceOpts)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -231,8 +231,8 @@ func setupRootFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", vpr.GetString(VTmpDir), lang.RootCmdFlagTempDir)
 
 	// Security
-	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.PlainHTTP, "plain-http", vpr.GetBool(VPlainHTTP), lang.RootCmdFlagPlainHTTP)
-	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", vpr.GetBool(VInsecureSkipTLSVerify), lang.RootCmdFlagInsecureSkipTLSVerify)
+	rootCmd.PersistentFlags().BoolVar(&plainHTTP, "plain-http", vpr.GetBool(VPlainHTTP), lang.RootCmdFlagPlainHTTP)
+	rootCmd.PersistentFlags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", vpr.GetBool(VInsecureSkipTLSVerify), lang.RootCmdFlagInsecureSkipTLSVerify)
 }
 
 // Execute is the entrypoint for the CLI.

--- a/src/internal/packager/helm/template.go
+++ b/src/internal/packager/helm/template.go
@@ -17,18 +17,17 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
+	"github.com/zarf-dev/zarf/src/types"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/releaseutil"
-
-	"github.com/zarf-dev/zarf/src/config"
 )
 
 // TemplateChart generates a helm template from a given chart.
 func TemplateChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *chart.Chart, values chartutil.Values,
-	kubeVersion string, variableConfig *variables.VariableConfig, isInteractive bool) (string, error) {
+	kubeVersion string, variableConfig *variables.VariableConfig, isInteractive bool, remoteOptions types.RemoteOptions) (string, error) {
 	if variableConfig == nil {
 		variableConfig = template.GetZarfVariableConfig(ctx, isInteractive)
 	}
@@ -49,7 +48,8 @@ func TemplateChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *cha
 	client.IncludeCRDs = true
 	// TODO: Further research this with regular/OCI charts
 	client.Verify = false
-	client.InsecureSkipTLSverify = config.CommonOptions.InsecureSkipTLSVerify
+	client.PlainHTTP = remoteOptions.PlainHTTP
+	client.InsecureSkipTLSverify = remoteOptions.InsecureSkipTLSVerify
 	if kubeVersion != "" {
 		parsedKubeVersion, err := chartutil.ParseKubeVersion(kubeVersion)
 		if err != nil {

--- a/src/internal/packager/helm/template_test.go
+++ b/src/internal/packager/helm/template_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestChartTemplate(t *testing.T) {
@@ -24,7 +25,7 @@ func TestChartTemplate(t *testing.T) {
 		LocalPath: chartPath,
 	}
 	tmpdir := t.TempDir()
-	err := PackageChart(ctx, chart, tmpdir, tmpdir)
+	err := PackageChart(ctx, chart, tmpdir, tmpdir, types.RemoteOptions{})
 	require.NoError(t, err)
 	kubeVersion := ""
 	vc := template.GetZarfVariableConfig(ctx, false)
@@ -32,7 +33,7 @@ func TestChartTemplate(t *testing.T) {
 	vc.SetVariable("port", "8080", false, false, v1alpha1.RawVariableType)
 	helmChart, values, err := LoadChartData(chart, tmpdir, tmpdir, nil)
 	require.NoError(t, err)
-	manifest, err := TemplateChart(ctx, chart, helmChart, values, kubeVersion, vc, false)
+	manifest, err := TemplateChart(ctx, chart, helmChart, values, kubeVersion, vc, false, types.RemoteOptions{})
 	require.NoError(t, err)
 	b, err := os.ReadFile(filepath.Join("testdata", "template", "expected", "manifest.yaml"))
 	require.NoError(t, err)

--- a/src/pkg/images/common.go
+++ b/src/pkg/images/common.go
@@ -19,7 +19,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -189,8 +188,8 @@ func NoopOpt(*crane.Options) {}
 
 // WithGlobalInsecureFlag returns an option for crane that configures insecure
 // based upon Zarf's global --insecure-skip-tls-verify flag.
-func WithGlobalInsecureFlag() []crane.Option {
-	if config.CommonOptions.InsecureSkipTLSVerify {
+func WithGlobalInsecureFlag(insecure bool) []crane.Option {
+	if insecure {
 		return []crane.Option{crane.Insecure}
 	}
 	// passing a nil option will cause panic

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // CreateOptions are the optional parameters to create
@@ -34,7 +35,7 @@ type CreateOptions struct {
 	CachePath               string
 	WithBuildMachineInfo    bool
 	// applicable when output is an OCI registry
-	RemoteOptions
+	types.RemoteOptions
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
 	// SkipVersionCheck skips version requirement validation
@@ -54,6 +55,7 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		IsInteractive:      opts.IsInteractive,
 		SkipRequiredValues: true,
 		SkipVersionCheck:   opts.SkipVersionCheck,
+		RemoteOptions:      opts.RemoteOptions,
 	}
 	pkg, err := load.PackageDefinition(ctx, packagePath, loadOpts)
 	if err != nil {
@@ -93,6 +95,7 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		SigningKeyPassword:   opts.SigningKeyPassword,
 		CachePath:            opts.CachePath,
 		WithBuildMachineInfo: opts.WithBuildMachineInfo,
+		RemoteOptions:        opts.RemoteOptions,
 	}
 	pkgLayout, err := layout.AssemblePackage(ctx, pkg, pkgPath.BaseDir, assembleOpt)
 	if err != nil {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
+	"github.com/zarf-dev/zarf/src/types"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,7 +62,7 @@ type DeployOptions struct {
 	// Namespace is an optional namespace override for package deployment
 	NamespaceOverride string
 	// Remote Options for image pushes
-	RemoteOptions
+	types.RemoteOptions
 	// How to configure Zarf state if it's not already been configured
 	GitServer      state.GitServerInfo
 	RegistryInfo   state.RegistryInfo

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/pkg/state"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // DevDeployOptions are the optionalParameters to DevDeploy
@@ -45,7 +46,7 @@ type DevDeployOptions struct {
 	CachePath      string
 	// SkipVersionCheck skips version requirement validation
 	SkipVersionCheck bool
-	RemoteOptions
+	types.RemoteOptions
 }
 
 // DevDeploy creates + deploys a package in one shot
@@ -66,6 +67,7 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 		CachePath:        opts.CachePath,
 		IsInteractive:    false,
 		SkipVersionCheck: opts.SkipVersionCheck,
+		RemoteOptions:    opts.RemoteOptions,
 	}
 	pkg, err := load.PackageDefinition(ctx, packagePath, loadOpts)
 	if err != nil {
@@ -137,10 +139,7 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 		Timeout:        opts.Timeout,
 		Retries:        opts.Retries,
 		OCIConcurrency: opts.OCIConcurrency,
-		RemoteOptions: RemoteOptions{
-			PlainHTTP:             config.CommonOptions.PlainHTTP,
-			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
-		},
+		RemoteOptions:  opts.RemoteOptions,
 	})
 	if err != nil {
 		return err

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/value"
+	"github.com/zarf-dev/zarf/src/types"
 	v1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,6 +64,7 @@ type FindImagesOptions struct {
 	CachePath string
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
+	types.RemoteOptions
 }
 
 // ComponentImageScan contains the results of FindImages for a component
@@ -89,6 +91,7 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 		CachePath:        opts.CachePath,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
+		RemoteOptions:    opts.RemoteOptions,
 	}
 	pkg, err := load.PackageDefinition(ctx, packagePath, loadOpts)
 	if err != nil {
@@ -156,7 +159,7 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 		matchedImages := map[string]bool{}
 		maybeImages := map[string]bool{}
 		for _, zarfChart := range component.Charts {
-			chartResource, values, err := getTemplatedChart(ctx, zarfChart, component.Name, packagePath, compBuildPath, variableConfig, value.Values{}, opts.KubeVersionOverride, opts.IsInteractive)
+			chartResource, values, err := getTemplatedChart(ctx, zarfChart, component.Name, packagePath, compBuildPath, variableConfig, value.Values{}, opts.KubeVersionOverride, opts.IsInteractive, opts.RemoteOptions)
 			if err != nil {
 				return nil, err
 			}
@@ -241,7 +244,7 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 		var validMaybeImages []string
 		if len(sortedExpectedImages) > 0 {
 			for _, image := range sortedExpectedImages {
-				if descriptor, err := crane.Head(image, images.WithGlobalInsecureFlag()...); err != nil {
+				if descriptor, err := crane.Head(image, images.WithGlobalInsecureFlag(opts.InsecureSkipTLSVerify)...); err != nil {
 					// Test if this is a real image, if not just quiet log to debug, this is normal
 					l.Debug("suspected image does not appear to be valid", "error", err)
 				} else {

--- a/src/pkg/packager/lint.go
+++ b/src/pkg/packager/lint.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // LintOptions are the optional parameters to Lint
@@ -16,6 +17,7 @@ type LintOptions struct {
 	SetVariables map[string]string
 	Flavor       string
 	CachePath    string
+	types.RemoteOptions
 }
 
 // Lint lints the given Zarf package
@@ -29,6 +31,7 @@ func Lint(ctx context.Context, packagePath string, opts LintOptions) error {
 		CachePath:        opts.CachePath,
 		IsInteractive:    false,
 		SkipVersionCheck: true,
+		RemoteOptions:    opts.RemoteOptions,
 	}
 	pkg, err := load.PackageDefinition(ctx, packagePath, loadOpts)
 	if err != nil {

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -25,6 +25,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // LoadOptions are the options for LoadPackage.
@@ -41,7 +42,7 @@ type LoadOptions struct {
 	// CachePath is used to cache layers from OCI package pulls
 	CachePath string
 	// Only applicable to OCI + HTTP
-	RemoteOptions
+	types.RemoteOptions
 	// VerificationStrategy for explicit definition
 	layout.VerificationStrategy
 }

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestResolveImportsCircular(t *testing.T) {
@@ -27,7 +28,7 @@ func TestResolveImportsCircular(t *testing.T) {
 	pkg, err := pkgcfg.Parse(ctx, b)
 	require.NoError(t, err)
 
-	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false)
+	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false, types.RemoteOptions{})
 	require.EqualError(t, err, "package testdata/import/circular/second imported in cycle by testdata/import/circular/third in component component")
 }
 
@@ -76,7 +77,7 @@ func TestResolveImports(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false)
+			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false, types.RemoteOptions{})
 			require.NoError(t, err)
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))

--- a/src/pkg/packager/load/load.go
+++ b/src/pkg/packager/load/load.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/value"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // DefinitionOptions are the optional parameters to load.PackageDefinition
@@ -37,6 +38,7 @@ type DefinitionOptions struct {
 	IsInteractive bool
 	// SkipVersionCheck skips version requirement validation
 	SkipVersionCheck bool
+	types.RemoteOptions
 }
 
 // PackageDefinition returns a validated package definition after flavors, imports, variables, and values are applied.
@@ -63,7 +65,7 @@ func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionO
 		return v1alpha1.ZarfPackage{}, err
 	}
 	pkg.Metadata.Architecture = config.GetArch(pkg.Metadata.Architecture)
-	pkg, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck)
+	pkg, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck, opts.RemoteOptions)
 	if err != nil {
 		return v1alpha1.ZarfPackage{}, err
 	}

--- a/src/pkg/packager/mirror.go
+++ b/src/pkg/packager/mirror.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // ImagePushOptions are optional parameters to push images in a zarf package to a registry
@@ -32,7 +33,7 @@ type ImagePushOptions struct {
 	NoImageChecksum bool
 	Retries         int
 	OCIConcurrency  int
-	RemoteOptions
+	types.RemoteOptions
 }
 
 // PushImagesToRegistry pushes images in the package layout to the specified registry

--- a/src/pkg/packager/packager.go
+++ b/src/pkg/packager/packager.go
@@ -17,12 +17,6 @@ import (
 // ValuesOverrides is a map of component names to chart names containing Helm Chart values to override values on deploy.
 type ValuesOverrides map[string]map[string]map[string]any
 
-// RemoteOptions are common options when calling a remote
-type RemoteOptions struct {
-	PlainHTTP             bool
-	InsecureSkipTLSVerify bool
-}
-
 func getPopulatedVariableConfig(ctx context.Context, pkg v1alpha1.ZarfPackage, setVariables map[string]string, isInteractive bool) (*variables.VariableConfig, error) {
 	variableConfig := template.GetZarfVariableConfig(ctx, isInteractive)
 	variableConfig.SetConstants(pkg.Constants)

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
+	"github.com/zarf-dev/zarf/src/types"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -33,7 +34,7 @@ type PublishFromOCIOptions struct {
 	Architecture string
 	// Retries is the number of times to retry a failed push
 	Retries int
-	RemoteOptions
+	types.RemoteOptions
 }
 
 // PublishFromOCI takes a source and destination registry reference and a PublishFromOCIOpts and copies the package from the source to the destination.
@@ -107,7 +108,7 @@ type PublishPackageOptions struct {
 	SigningKeyPassword string
 	// Retries specifies the number of retries to use
 	Retries int
-	RemoteOptions
+	types.RemoteOptions
 }
 
 // PublishPackage takes a package layout and pushes the package to the given registry.
@@ -173,7 +174,7 @@ type PublishSkeletonOptions struct {
 	SkipVersionCheck bool
 	// WithBuildMachineInfo controls whether to include build machine information (hostname and username) in the package metadata
 	WithBuildMachineInfo bool
-	RemoteOptions
+	types.RemoteOptions
 }
 
 // PublishSkeleton takes a Path to the package definition and uploads a skeleton package to the given a registry.
@@ -206,6 +207,7 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 		Flavor:             opts.Flavor,
 		SkipVersionCheck:   opts.SkipVersionCheck,
 		SkipRequiredValues: true,
+		RemoteOptions:      opts.RemoteOptions,
 	})
 	if err != nil {
 		return registry.Reference{}, err
@@ -255,7 +257,7 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 }
 
 // pushToRemote pushes a package to the given reference
-func pushToRemote(ctx context.Context, layout *layout.PackageLayout, ref registry.Reference, concurrency int, retries int, remoteOpts RemoteOptions) error {
+func pushToRemote(ctx context.Context, layout *layout.PackageLayout, ref registry.Reference, concurrency int, retries int, remoteOpts types.RemoteOptions) error {
 	arch := layout.Pkg.Metadata.Architecture
 	// Set platform
 	platform := oci.PlatformForArch(arch)

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -20,14 +20,15 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/test/testutil"
+	"github.com/zarf-dev/zarf/src/types"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
-func defaultTestRemoteOptions() RemoteOptions {
-	return RemoteOptions{
+func defaultTestRemoteOptions() types.RemoteOptions {
+	return types.RemoteOptions{
 		PlainHTTP: true,
 	}
 }

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
+	"github.com/zarf-dev/zarf/src/types"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -41,7 +42,7 @@ type PullOptions struct {
 	OCIConcurrency int
 	// CachePath is used to cache layers from OCI package pulls
 	CachePath string
-	RemoteOptions
+	types.RemoteOptions
 	// VerificationStrategy for explicit definition
 	layout.VerificationStrategy
 }
@@ -102,7 +103,7 @@ type pullOCIOptions struct {
 	OCIConcurrency int
 	CachePath      string
 	PublicKeyPath  string
-	RemoteOptions
+	types.RemoteOptions
 	layout.VerificationStrategy
 }
 

--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -67,10 +67,7 @@ type Remote struct {
 // with zarf opination embedded
 func NewRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {
 	l := logger.From(ctx)
-
 	modifiers := append([]oci.Modifier{
-		oci.WithPlainHTTP(config.CommonOptions.PlainHTTP),
-		oci.WithInsecureSkipVerify(config.CommonOptions.InsecureSkipTLSVerify),
 		oci.WithLogger(l),
 		oci.WithUserAgent("zarf/" + config.CLIVersion),
 	}, mods...)

--- a/src/pkg/zoci/pull_test.go
+++ b/src/pkg/zoci/pull_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"github.com/zarf-dev/zarf/src/test/testutil"
+	"github.com/zarf-dev/zarf/src/types"
 	_ "modernc.org/sqlite"
 	"oras.land/oras-go/v2/registry"
 )
@@ -45,7 +46,7 @@ func TestAssembleLayers(t *testing.T) {
 			name: "Assemble layers from a package",
 			path: "testdata/basic",
 			opts: packager.PublishPackageOptions{
-				RemoteOptions: packager.RemoteOptions{
+				RemoteOptions: types.RemoteOptions{
 					PlainHTTP: true,
 				},
 				OCIConcurrency: 3,

--- a/src/types/runtime.go
+++ b/src/types/runtime.go
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021-Present The Zarf Authors
 
-// Package types contains all the types used by Zarf.
+// Package types contains types used globally throughout Zarf
 package types
+
+// RemoteOptions are common options when calling a remote service
+type RemoteOptions struct {
+	PlainHTTP             bool
+	InsecureSkipTLSVerify bool
+}
 
 // ZarfCommonOptions tracks the user-defined preferences used across commands.
 type ZarfCommonOptions struct {
-	// Disable checking the server TLS certificate for validity
-	InsecureSkipTLSVerify bool
-	// Force connections to be over http instead of https
-	PlainHTTP bool
 	// Path to use to cache images and git repos on package create
 	CachePath string
 	// Location Zarf should use as a staging ground when managing files and images for package creation and deployment


### PR DESCRIPTION
## Description

Breaking changes: 
- packager.RemoteOptions -> types.RemoteOptions
- config.CommonOptions.PlainHTTP and config.CommonOptions.InsecureTLSSkipVerify have both been removed in favor of passing in `types.RemoteOptions` explicitly. 
- Some functions that didn't accept remoteOptions before now accept remoteOptions

I noticed the codebase sometimes sends `remoteOptions` to functions and sometimes relies on global state. This removes the global state and always sends in remoteOptions to relevant functions


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
