### PR TITLE
feat: support helm charts in kustomizations

### DIFF
--- a/src/internal/packager/kustomize/build.go
+++ b/src/internal/packager/kustomize/build.go
@@ -28,6 +28,8 @@ func Build(path string, destination string, kustomizeAllowAnyDirectory bool, ena
 
 	if enableKustomizePlugins {
 		buildOptions.PluginConfig = krustytypes.MakePluginConfig(krustytypes.PluginRestrictionsNone, krustytypes.BploUseStaticallyLinked)
+		buildOptions.PluginConfig.HelmConfig.Enabled = true
+		buildOptions.PluginConfig.HelmConfig.Command = "helm"
 	}
 
 	kustomizer := krusty.MakeKustomizer(buildOptions)

--- a/src/internal/packager/kustomize/build_test.go
+++ b/src/internal/packager/kustomize/build_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package template provides functions for templating yaml files.
+package kustomize
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		path                       string
+		kustomizeAllowAnyDirectory bool
+		enableKustomizePlugins     bool
+	}{
+		{
+			path:                       path.Join("testdata", "generators"),
+			kustomizeAllowAnyDirectory: false,
+			enableKustomizePlugins:     false,
+		},
+		{
+			path:                       path.Join("testdata", "helm"),
+			kustomizeAllowAnyDirectory: true,
+			enableKustomizePlugins:     true,
+		},
+	}
+
+	for _, test := range tests {
+		tmpdir := t.TempDir()
+
+		builtManifest := path.Join(tmpdir, "generated.yaml")
+
+		err := Build(test.path, builtManifest, test.kustomizeAllowAnyDirectory, test.enableKustomizePlugins)
+		require.NoError(t, err)
+		require.FileExists(t, builtManifest, "built manifest file should exist")
+
+		expectedContent, err := os.ReadFile(path.Join(test.path, "expected.yaml"))
+		buildContent, err := os.ReadFile(builtManifest)
+		require.NoError(t, err)
+
+		require.Equalf(t, expectedContent, buildContent, "Built kustomization should match expected")
+	}
+}

--- a/src/internal/packager/kustomize/testdata/generators/expected.yaml
+++ b/src/internal/packager/kustomize/testdata/generators/expected.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  name: test-t757gk2bmf
+---
+apiVersion: v1
+data:
+  password: cGFzc3dvcmQ=
+  username: dXNlcm5hbWU=
+kind: Secret
+metadata:
+  name: auth-m84m9g76mm
+type: Opaque

--- a/src/internal/packager/kustomize/testdata/generators/kustomization.yaml
+++ b/src/internal/packager/kustomize/testdata/generators/kustomization.yaml
@@ -1,0 +1,9 @@
+configMapGenerator:
+  - name: test
+    literals:
+      - key=value
+secretGenerator:
+  - name: auth
+    literals:
+      - username=username
+      - password=password

--- a/src/internal/packager/kustomize/testdata/helm/chart/Chart.yaml
+++ b/src/internal/packager/kustomize/testdata/helm/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.0.0
+appVersion: "0.0.0"

--- a/src/internal/packager/kustomize/testdata/helm/chart/templates/pod.yaml
+++ b/src/internal/packager/kustomize/testdata/helm/chart/templates/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers:
+    - name: busybox
+      image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/src/internal/packager/kustomize/testdata/helm/chart/values.yaml
+++ b/src/internal/packager/kustomize/testdata/helm/chart/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: busybox
+  tag: 1.0.0

--- a/src/internal/packager/kustomize/testdata/helm/expected.yaml
+++ b/src/internal/packager/kustomize/testdata/helm/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers:
+  - image: busybox:1.0.0
+    name: busybox

--- a/src/internal/packager/kustomize/testdata/helm/kustomization.yaml
+++ b/src/internal/packager/kustomize/testdata/helm/kustomization.yaml
@@ -1,0 +1,6 @@
+helmGlobals:
+  chartHome: .
+helmCharts:
+  - releaseName: chart
+    name: chart
+    repo: ./chart


### PR DESCRIPTION
## Description

Currently kustomizations with helm chart references fail, even with plugins enabled.

```yaml
# zarf.yaml
components:
  - name: keycloak-server
    default: true
    manifests:
      - name: keycloak-server
        namespace: keycloak
        kustomizations:
          - .
        enableKustomizePlugins: true
```

```yaml
# kustomization.yaml
namespace: keycloak
helmCharts:
  - releaseName: keycloak
    name: keycloak
    repo: oci://registry-1.docker.io/bitnamicharts
    version: "23.3.3"
    valuesFile: values.yaml
```

```console
$ zarf dev inspect manifests .

2026-02-03 13:54:02 ERR unable to build kustomization .: trouble configuring builtin HelmChartInflationGenerator with config: `
name: keycloak
namespace: keycloak
releaseName: keycloak
repo: oci://registry-1.docker.io/bitnamicharts
valuesFile: values.yaml
version: 26.3.3
`: must specify --enable-helm
```

This can be worked around with an onCreate action that renders the manifests, but that's kinda jank and breaks `zarf dev inspect` and `zarf dev find-images`.

```yaml
# zarf.yaml
components:
  - name: keycloak-server
    default: true
    actions:
      onCreate:
        before:
          - description: kustomize build
            cmd: kubectl kustomize --enable-helm > generated.yaml
    manifests:
      - name: keycloak-server
        namespace: keycloak
        files:
          - generated.yaml
```

This PR enables helm inside kustomizations when `enableKustomizePlugins` is set, and adds tests to validate functionality

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
