### PR TITLE
fix: return the correct error on io.CopyN failure

### DIFF
--- a/src/internal/split/split.go
+++ b/src/internal/split/split.go
@@ -81,7 +81,7 @@ func SplitFile(ctx context.Context, srcPath string, chunkSize int) (_ string, er
 
 		written, copyErr := io.CopyN(dstFile, srcFile, int64(chunkSize))
 		if copyErr != nil && !errors.Is(copyErr, io.EOF) {
-			return "", err
+			return "", copyErr
 		}
 
 		_, err = dstFile.Seek(0, io.SeekStart)


### PR DESCRIPTION
## Description

The code was erroneously returning `err` instead of `copyErr`, which will be set to `nil` from the [`os.OpenFile`](https://github.com/zarf-dev/zarf/blob/5b8df04f819e974fb12386f5b08fd824d29b0fb3/src/internal/split/split.go#L70) above.

Instead, I believe the intent was to return `copyErr` if it is an unexpected error (i.e. not `io.EOF`).

## Related Issue

Sorry, I didn't create an issue for this.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
