### PR TITLE
fix: buffer `errChan` in `Tunnel.establish` to prevent goroutine leak

### DIFF
--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -519,7 +519,7 @@ func (tunnel *Tunnel) establish(ctx context.Context) ([]string, error) {
 
 	// Open the tunnel in a goroutine so that it is available in the background. Report errors to the main goroutine via
 	// a new channel.
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		errChan <- portforwarder.ForwardPorts()
 	}()


### PR DESCRIPTION
## Description

The `errChan` channel in `establish` was unbuffered. When `portforwarder.Ready` fires before `portforwarder.ForwardPorts()` returns, the `select` takes the `portforwarder.Ready` branch and the goroutine continues running in the background.

Later, when `tunnel.Close()` shuts the tunnel by closing `stopChan`, `portforwarder.ForwardPorts()` returns and the goroutine attempts to send its error on the unbuffered channel. Since `tunnel.Close()` never drains `errChan`, that send blocks forever, which then leaks the goroutine.

Make the channel buffered with capacity 1 so the goroutine's send always completes immediately, allowing it to exit regardless of whether anyone reads the error.

This is similar to the change made in [#3746](https://github.com/zarf-dev/zarf/pull/3746/changes#diff-8533e4e2439f63b3f10757f8f181a4083185ce0b77e3fe96d9e4d98554363921) to the `tunnel.Wrap` function.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
