### PR TITLE
fix: preserve error chains by using `%w` instead of `%s`

### DIFF
--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -608,7 +608,7 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 			Message: lang.CmdToolsGenKeyPrompt,
 		}
 		if err := survey.AskOne(prompt, &password); err != nil {
-			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
+			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
 		}
 
 		// perform the second prompt
@@ -617,7 +617,7 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 			Message: lang.CmdToolsGenKeyPromptAgain,
 		}
 		if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
-			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err.Error())
+			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
 		}
 
 		// check if the passwords match

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -18,13 +18,13 @@ import (
 // Include sprintf formatting directives in the string if needed.
 const (
 	ErrUnmarshal                    = "failed to unmarshal file: %w"
-	ErrWritingFile                  = "failed to write file %s: %s"
-	ErrDownloading                  = "failed to download %s: %s"
-	ErrCreatingDir                  = "failed to create directory %s: %s"
-	ErrRemoveFile                   = "failed to remove file %s: %s"
-	ErrUnarchive                    = "failed to unarchive %s: %s"
-	ErrFileExtract                  = "failed to extract filename %s from archive %s: %s"
-	ErrFileNameExtract              = "failed to extract filename from URL %s: %s"
+	ErrWritingFile                  = "failed to write file %s: %w"
+	ErrDownloading                  = "failed to download %s: %w"
+	ErrCreatingDir                  = "failed to create directory %s: %w"
+	ErrRemoveFile                   = "failed to remove file %s: %w"
+	ErrUnarchive                    = "failed to unarchive %s: %w"
+	ErrFileExtract                  = "failed to extract filename %s from archive %s: %w"
+	ErrFileNameExtract              = "failed to extract filename from URL %s: %w"
 	ErrUnableToGenerateRandomSecret = "unable to generate a random secret"
 )
 
@@ -597,7 +597,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsGenKeyPrompt               = "Private key password (empty for no password): "
 	CmdToolsGenKeyPromptAgain          = "Private key password again (empty for no password): "
 	CmdToolsGenKeyPromptExists         = "File %s already exists. Overwrite? "
-	CmdToolsGenKeyErrUnableGetPassword = "unable to get password for private key: %s"
+	CmdToolsGenKeyErrUnableGetPassword = "unable to get password for private key: %w"
 	CmdToolsGenKeyErrPasswordsNotMatch = "passwords do not match"
 
 	CmdToolsSbomShort = "Generates a Software Bill of Materials (SBOM) for the given package"

--- a/src/internal/git/repository.go
+++ b/src/internal/git/repository.go
@@ -237,9 +237,9 @@ func (r *Repository) Push(ctx context.Context, address, username, password strin
 	if errors.Is(err, git.NoErrAlreadyUpToDate) {
 		l.Debug("repo already up-to-date")
 	} else if errors.Is(err, plumbing.ErrObjectNotFound) {
-		return fmt.Errorf("unable to push repo due to likely shallow clone: %s", err.Error())
+		return fmt.Errorf("unable to push repo due to likely shallow clone: %w", err)
 	} else if err != nil {
-		return fmt.Errorf("unable to push repo to the gitops service: %s", err.Error())
+		return fmt.Errorf("unable to push repo to the gitops service: %w", err)
 	}
 
 	return nil

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -310,7 +310,7 @@ func packageValues(ctx context.Context, chart v1alpha1.ZarfChart, valuesPath str
 
 		if helpers.IsURL(path) {
 			if err := utils.DownloadToFile(ctx, path, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, path, err.Error())
+				return fmt.Errorf(lang.ErrDownloading, path, err)
 			}
 		} else {
 			if err := helpers.CreatePathAndCopy(path, dst); err != nil {

--- a/src/pkg/archive/archive.go
+++ b/src/pkg/archive/archive.go
@@ -298,10 +298,10 @@ func nestedUnarchive(ctx context.Context, extractor archives.Extractor, dst stri
 				outDir = strings.TrimSuffix(path, extensionTar)
 			}
 			if err := unarchive(ctx, extractor, path, outDir); err != nil {
-				return fmt.Errorf(lang.ErrUnarchive, path, err.Error())
+				return fmt.Errorf(lang.ErrUnarchive, path, err)
 			}
 			if err := os.Remove(path); err != nil {
-				return fmt.Errorf(lang.ErrRemoveFile, path, err.Error())
+				return fmt.Errorf(lang.ErrRemoveFile, path, err)
 			}
 		}
 		return nil

--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -107,7 +107,7 @@ func (c *Cluster) NewTargetTunnelInfo(ctx context.Context, target string) (Tunne
 		if target != "" {
 			ztNew, err := c.checkForZarfConnectLabel(ctx, target)
 			if err != nil {
-				return TunnelInfo{}, fmt.Errorf("problem looking for a zarf connect label in the cluster: %s", err.Error())
+				return TunnelInfo{}, fmt.Errorf("problem looking for a zarf connect label in the cluster: %w", err)
 			}
 			zt = ztNew
 			zt.ListenAddresses = []string{helpers.IPV4Localhost}

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -388,7 +388,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				// get the compressedFileName from the source
 				compressedFileName, err := helpers.ExtractBasePathFromURL(file.Source)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err)
 				}
 				tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 				if err != nil {
@@ -401,18 +401,18 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 				// If the file is an archive, download it to the componentPath.Temp
 				if err := utils.DownloadToFile(ctx, file.Source, compressedFile); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
 				}
 				decompressOpts := archive.DecompressOpts{
 					Files: []string{file.ExtractPath},
 				}
 				err = archive.Decompress(ctx, compressedFile, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err.Error())
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err)
 				}
 			} else {
 				if err := utils.DownloadToFile(ctx, file.Source, dst); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
 				}
 			}
 		} else {
@@ -426,7 +426,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				}
 				err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
 				}
 			} else {
 				if err := helpers.CreatePathAndCopy(src, dst); err != nil {
@@ -471,7 +471,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 		if helpers.IsURL(data.Source) {
 			if err := utils.DownloadToFile(ctx, data.Source, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, data.Source, err.Error())
+				return fmt.Errorf(lang.ErrDownloading, data.Source, err)
 			}
 		} else {
 			src := data.Source
@@ -479,7 +479,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				src = filepath.Join(packagePath, data.Source)
 			}
 			if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-				return fmt.Errorf("unable to copy data injection %s: %s", data.Source, err.Error())
+				return fmt.Errorf("unable to copy data injection %s: %w", data.Source, err)
 			}
 		}
 	}
@@ -540,7 +540,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 		// Copy manifests without any processing.
 		if helpers.IsURL(path) {
 			if err := utils.DownloadToFile(ctx, path, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, path, err.Error())
+				return fmt.Errorf(lang.ErrDownloading, path, err)
 			}
 		} else {
 			src := path
@@ -656,7 +656,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			}
 			err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 			if err != nil {
-				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
+				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
 			}
 
 			// Make sure dst reflects the actual file or directory.
@@ -707,7 +707,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			src = filepath.Join(packagePath, src)
 		}
 		if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-			return fmt.Errorf("unable to copy data injection %s: %s", src, err.Error())
+			return fmt.Errorf("unable to copy data injection %s: %w", src, err)
 		}
 
 		component.DataInjections[dataIdx].Source = rel

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -90,7 +90,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 		var err error
 		depPkg, err = opts.Cluster.GetDeployedPackage(ctx, pkg.Metadata.Name, state.WithPackageNamespaceOverride(opts.NamespaceOverride))
 		if err != nil {
-			return fmt.Errorf("unable to load the secret for the package we are attempting to remove: %s", err.Error())
+			return fmt.Errorf("unable to load the secret for the package we are attempting to remove: %w", err)
 		}
 	} else {
 		// If we do not need the cluster, create a deployed components object based on the info we have

--- a/src/pkg/utils/network.go
+++ b/src/pkg/utils/network.go
@@ -51,13 +51,13 @@ func DownloadToFile(ctx context.Context, src, dst string) (err error) {
 
 	err = helpers.CreateDirectory(filepath.Dir(dst), helpers.ReadWriteExecuteUser)
 	if err != nil {
-		return fmt.Errorf(lang.ErrCreatingDir, filepath.Dir(dst), err.Error())
+		return fmt.Errorf(lang.ErrCreatingDir, filepath.Dir(dst), err)
 	}
 
 	// Create the file
 	file, err := os.Create(dst)
 	if err != nil {
-		return fmt.Errorf(lang.ErrWritingFile, dst, err.Error())
+		return fmt.Errorf(lang.ErrWritingFile, dst, err)
 	}
 	// Ensure our file closes and any error propagate out on error branches
 	defer func(file *os.File) {


### PR DESCRIPTION
## Description

Multiple `fmt.Errorf` call sites wrapped errors using `%s` with `err.Error()`, which converts the error to a plain string and severs the error chain. This means `errors.Is` and `errors.As` cannot match on any cause in the chain — callers lose the ability to programmatically inspect underlying errors.

The root cause is twofold: the `lang` package format constants (e.g., `ErrDownloading`, `ErrWritingFile`, `ErrCreatingDir`) were defined with a `%s` placeholder for the error argument, and every call site passed `err.Error()` to match. Several inline format strings outside `lang` had the same pattern.

Update all 8 affected `lang` constants in `english.go` to use `%w` as the error placeholder, and change every call site (20 occurrences across 8 files) from `err.Error()` to `err`. Also convert 4 inline format strings that used `%s` + `err.Error()` directly — in `repository.go`, `tunnel.go`, `remove.go`, and `assemble.go` — to use `%w` + `err`.

The `lang` constants that already used `%w` (e.g., `ErrUnmarshal`) and call sites that already wrapped correctly (e.g., `helpers.CreatePathAndCopy` callers using `%w`) are left unchanged.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
