### PR TITLE
feat(agent): add mutate-if-exists conditional image mutation

### DIFF
--- a/packages/zarf-agent/chart/templates/clusterrole.yaml
+++ b/packages/zarf-agent/chart/templates/clusterrole.yaml
@@ -10,3 +10,10 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list

--- a/site/src/content/docs/ref/init-package.mdx
+++ b/site/src/content/docs/ref/init-package.mdx
@@ -183,6 +183,38 @@ Additionally, when adopting resources, ensure that the namespaces specified are 
 
 The Agent does not need to create any secrets in the cluster. Instead, during `zarf init` and `zarf package deploy`, secrets are automatically created in a [Helm Postrender Hook](https://helm.sh/docs/topics/advanced/#post-rendering) for any namespaces Zarf sees. If you have resources managed by [Flux](https://fluxcd.io/) that are not in a namespace managed by Zarf, you can either create the secrets manually or include a manifest to create the namespace in your package and let Zarf create the secrets for you.
 
+#### Conditional Image Mutation with `mutate-if-exists`
+
+By default, the `zarf-agent` rewrites all container image references to point to the Zarf registry. However, in some scenarios you may want to conditionally mutate images—only rewriting images that already exist in the Zarf registry while leaving others pointing to their original locations.
+
+To enable this behavior, label a namespace with `zarf.dev/agent: mutate-if-exists`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  labels:
+    zarf.dev/agent: mutate-if-exists
+```
+
+When this label is applied:
+
+- **Images found in the Zarf registry**: Image references are rewritten to point to the Zarf registry (e.g., `docker.io/nginx:latest` → `127.0.0.1:31999/library/nginx:latest-zarf-...`)
+- **Images not found in the Zarf registry**: Image references remain unchanged, pointing to their original registry
+
+This is useful for:
+
+- **Hybrid deployments**: Running workloads that use a mix of air-gapped images (in Zarf registry) and external images (from internet-accessible registries)
+- **Gradual migration**: Testing incremental migration to fully air-gapped deployments
+- **Development environments**: Allowing developers to pull some images from external registries while using Zarf-managed images for core components
+
+:::note
+
+The registry existence check is performed via HTTP HEAD request to the Zarf registry when pods are created. If the registry is temporarily unavailable, pod creation will fail. Ensure your Zarf registry is healthy before deploying workloads to namespaces using `mutate-if-exists`.
+
+:::
+
 ## Optional Components
 
 The Zarf team maintains some optional components in the default 'init' package.

--- a/src/internal/agent/hooks/pods.go
+++ b/src/internal/agent/hooks/pods.go
@@ -95,6 +95,12 @@ func mutatePod(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Clu
 	// Pods do not have a metadata.name at the time of admission if from a deployment so we don't log the name
 	l.Info("using the Zarf registry URL to mutate the Pod", "registry", registryURL)
 
+	// Check if namespace wants mutate-if-exists behavior
+	useMutateIfExists, skipResult := checkNamespaceMutationBehavior(ctx, cluster, r.Namespace)
+	if skipResult != nil {
+		return skipResult, nil
+	}
+
 	var patches []operations.PatchOperation
 
 	// Add the zarf secret to the podspec
@@ -113,6 +119,17 @@ func mutatePod(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Clu
 		if err != nil {
 			return nil, err
 		}
+		// Check if image exists if mutate-if-exists is enabled
+		if useMutateIfExists {
+			exists, checkErr := imageExistsInRegistry(ctx, cluster, replacement, &state.RegistryInfo)
+			if checkErr != nil {
+				return nil, fmt.Errorf("registry check failed for %s: %w", replacement, checkErr)
+			}
+			if !exists {
+				l.Info("image not found in registry, skipping mutation", "original", container.Image, "transformed", replacement)
+				continue
+			}
+		}
 		updatedAnnotations[getImageAnnotationKey(ctx, container.Name)] = container.Image
 		patches = append(patches, operations.ReplacePatchOperation(path, replacement))
 	}
@@ -123,6 +140,17 @@ func mutatePod(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Clu
 		replacement, err := transform.ImageTransformHost(registryURL, container.Image)
 		if err != nil {
 			return nil, err
+		}
+		// Check if image exists if mutate-if-exists is enabled
+		if useMutateIfExists {
+			exists, checkErr := imageExistsInRegistry(ctx, cluster, replacement, &state.RegistryInfo)
+			if checkErr != nil {
+				return nil, fmt.Errorf("registry check failed for %s: %w", replacement, checkErr)
+			}
+			if !exists {
+				l.Info("image not found in registry, skipping mutation", "original", container.Image, "transformed", replacement)
+				continue
+			}
 		}
 		updatedAnnotations[getImageAnnotationKey(ctx, container.Name)] = container.Image
 		patches = append(patches, operations.ReplacePatchOperation(path, replacement))
@@ -138,6 +166,17 @@ func mutatePod(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster.Clu
 			replacement, err := transform.ImageTransformHost(registryURL, volume.Image.Reference)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transform volume %q (index %d) image reference %q: %w", volume.Name, idx, volume.Image.Reference, err)
+			}
+			// Check if image exists if mutate-if-exists is enabled
+			if useMutateIfExists {
+				exists, checkErr := imageExistsInRegistry(ctx, cluster, replacement, &state.RegistryInfo)
+				if checkErr != nil {
+					return nil, fmt.Errorf("registry check failed for volume %q image %s: %w", volume.Name, replacement, checkErr)
+				}
+				if !exists {
+					l.Info("volume image not found in registry, skipping mutation", "volume", volume.Name, "original", volume.Image.Reference, "transformed", replacement)
+					continue
+				}
 			}
 			updatedAnnotations[getVolumeAnnotationKey(ctx, volume.Name)] = volume.Image.Reference
 			patches = append(patches, operations.ReplacePatchOperation(path, replacement))
@@ -183,6 +222,12 @@ func mutateEphemeralContainers(ctx context.Context, r *v1.AdmissionRequest, clus
 	// Pods do not have a metadata.name at the time of admission if from a deployment so we don't log the name
 	l.Info("using the Zarf registry URL to mutate the Pod", "registry", registryURL)
 
+	// Check if namespace wants mutate-if-exists behavior
+	useMutateIfExists, skipResult := checkNamespaceMutationBehavior(ctx, cluster, r.Namespace)
+	if skipResult != nil {
+		return skipResult, nil
+	}
+
 	updatedAnnotations := pod.Annotations
 	if updatedAnnotations == nil {
 		updatedAnnotations = make(map[string]string)
@@ -196,6 +241,17 @@ func mutateEphemeralContainers(ctx context.Context, r *v1.AdmissionRequest, clus
 		replacement, err := transform.ImageTransformHost(registryURL, container.Image)
 		if err != nil {
 			return nil, err
+		}
+		// Check if image exists if mutate-if-exists is enabled
+		if useMutateIfExists {
+			exists, checkErr := imageExistsInRegistry(ctx, cluster, replacement, &state.RegistryInfo)
+			if checkErr != nil {
+				return nil, fmt.Errorf("registry check failed for %s: %w", replacement, checkErr)
+			}
+			if !exists {
+				l.Info("ephemeral container image not found in registry, skipping mutation", "original", container.Image, "transformed", replacement)
+				continue
+			}
 		}
 		updatedAnnotations[getImageAnnotationKey(ctx, container.Name)] = container.Image
 		patches = append(patches, operations.ReplacePatchOperation(path, replacement))

--- a/src/internal/agent/hooks/pods_mutate_if_exists_test.go
+++ b/src/internal/agent/hooks/pods_mutate_if_exists_test.go
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/state"
+	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMutateIfExistsBehavior(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Mock registry server that simulates image existence
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate different responses based on image path
+		// Pattern: /v2/library/{name}/manifests/{tag}
+		if contains(r.URL.Path, "nginx-exists") ||
+			contains(r.URL.Path, "busybox-exists") {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(registryServer.Close)
+
+	// Extract host from test server (remove http://)
+	registryAddr := registryServer.URL[7:]
+
+	s := &state.State{
+		RegistryInfo: state.RegistryInfo{
+			Address:      registryAddr,
+			PullUsername: "",
+			PullPassword: "",
+		},
+	}
+	c := createTestClientWithZarfState(ctx, t, s)
+
+	// Create test namespace with mutate-if-exists label
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			Labels: map[string]string{
+				"zarf.dev/agent": "mutate-if-exists",
+			},
+		},
+	}
+	_, err := c.Clientset.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create namespace with skip label
+	skipNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "skip-namespace",
+			Labels: map[string]string{
+				"zarf.dev/agent": "skip",
+			},
+		},
+	}
+	_, err = c.Clientset.CoreV1().Namespaces().Create(ctx, skipNamespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create namespace with ignore label
+	ignoreNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ignore-namespace",
+			Labels: map[string]string{
+				"zarf.dev/agent": "ignore",
+			},
+		},
+	}
+	_, err = c.Clientset.CoreV1().Namespaces().Create(ctx, ignoreNamespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create default namespace without labels
+	defaultNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-namespace",
+		},
+	}
+	_, err = c.Clientset.CoreV1().Namespaces().Create(ctx, defaultNamespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	handler := admission.NewHandler().Serve(ctx, NewPodMutationHook(ctx, c))
+
+	tests := []admissionTest{
+		{
+			name: "mutate-if-exists: image exists - should mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "test-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx-exists"},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+			// Can't check exact patches due to dynamic zarf suffix based on registry address
+		},
+		{
+			name: "mutate-if-exists: image missing - should not mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "test-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx-missing"},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+			// Container should not be mutated, so no image patch
+		},
+		{
+			name: "mutate-if-exists: mixed exists and missing - should mutate only existing",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "test-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{Name: "busybox", Image: "busybox-exists"},
+						},
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx-missing"},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+			// Should have init container mutation but not regular container
+		},
+		{
+			name: "skip namespace - should not mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "skip-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx"},
+						},
+					},
+				}),
+			},
+			patch: nil,
+			code:  http.StatusOK,
+		},
+		{
+			name: "ignore namespace - should not mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "ignore-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx"},
+						},
+					},
+				}),
+			},
+			patch: nil,
+			code:  http.StatusOK,
+		},
+		{
+			name: "default namespace - should mutate all (legacy behavior)",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Namespace: "default-namespace",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx-missing"},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+			// Legacy behavior - should mutate even if image doesn't exist
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
+			require.Equal(t, tt.code, rr.Code)
+
+			// Verify admission was successful
+			var admissionReview v1.AdmissionReview
+			err := json.NewDecoder(rr.Body).Decode(&admissionReview)
+			require.NoError(t, err)
+			require.True(t, admissionReview.Response.Allowed)
+		})
+	}
+}
+
+func TestMutateIfExistsEphemeralContainers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Mock registry server
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contains(r.URL.Path, "debug-exists") {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(registryServer.Close)
+
+	registryAddr := registryServer.URL[7:]
+
+	s := &state.State{
+		RegistryInfo: state.RegistryInfo{
+			Address: registryAddr,
+		},
+	}
+	c := createTestClientWithZarfState(ctx, t, s)
+
+	// Create test namespace with mutate-if-exists label
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ephemeral-test",
+			Labels: map[string]string{
+				"zarf.dev/agent": "mutate-if-exists",
+			},
+		},
+	}
+	_, err := c.Clientset.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	handler := admission.NewHandler().Serve(ctx, NewPodMutationHook(ctx, c))
+
+	tests := []admissionTest{
+		{
+			name: "ephemeral container exists - should mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation:   v1.Create,
+				Namespace:   "ephemeral-test",
+				SubResource: "ephemeralcontainers",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Labels: map[string]string{
+							"zarf-agent": "patched",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "app", Image: fmt.Sprintf("%s/library/app:v1", registryAddr)},
+						},
+						EphemeralContainers: []corev1.EphemeralContainer{
+							{
+								EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+									Name:  "debug",
+									Image: "debug-exists",
+								},
+							},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "ephemeral container missing - should not mutate",
+			admissionReq: &v1.AdmissionRequest{
+				Operation:   v1.Create,
+				Namespace:   "ephemeral-test",
+				SubResource: "ephemeralcontainers",
+				Object: createRawPod(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+						Labels: map[string]string{
+							"zarf-agent": "patched",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "app", Image: fmt.Sprintf("%s/library/app:v1", registryAddr)},
+						},
+						EphemeralContainers: []corev1.EphemeralContainer{
+							{
+								EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+									Name:  "debug",
+									Image: "debug-missing",
+								},
+							},
+						},
+					},
+				}),
+			},
+			code: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rr := sendAdmissionRequest(t, tt.admissionReq, handler)
+			require.Equal(t, tt.code, rr.Code)
+
+			// Verify admission was successful
+			var admissionReview v1.AdmissionReview
+			err := json.NewDecoder(rr.Body).Decode(&admissionReview)
+			require.NoError(t, err)
+			require.True(t, admissionReview.Response.Allowed)
+		})
+	}
+}
+
+func TestCheckNamespaceMutationBehavior(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := &cluster.Cluster{Clientset: fake.NewClientset()}
+
+	tests := []struct {
+		name                 string
+		namespaceLabels      map[string]string
+		expectMutateIfExists bool
+		expectSkip           bool
+	}{
+		{
+			name:                 "no labels - default behavior",
+			namespaceLabels:      nil,
+			expectMutateIfExists: false,
+			expectSkip:           false,
+		},
+		{
+			name: "skip label",
+			namespaceLabels: map[string]string{
+				"zarf.dev/agent": "skip",
+			},
+			expectMutateIfExists: false,
+			expectSkip:           true,
+		},
+		{
+			name: "ignore label",
+			namespaceLabels: map[string]string{
+				"zarf.dev/agent": "ignore",
+			},
+			expectMutateIfExists: false,
+			expectSkip:           true,
+		},
+		{
+			name: "mutate-if-exists label",
+			namespaceLabels: map[string]string{
+				"zarf.dev/agent": "mutate-if-exists",
+			},
+			expectMutateIfExists: true,
+			expectSkip:           false,
+		},
+		{
+			name: "mutate-if-exists case insensitive",
+			namespaceLabels: map[string]string{
+				"zarf.dev/agent": "Mutate-If-Exists",
+			},
+			expectMutateIfExists: true,
+			expectSkip:           false,
+		},
+		{
+			name: "other label value",
+			namespaceLabels: map[string]string{
+				"zarf.dev/agent": "some-other-value",
+			},
+			expectMutateIfExists: false,
+			expectSkip:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create namespace
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-ns-" + tt.name,
+					Labels: tt.namespaceLabels,
+				},
+			}
+			_, err := c.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			useMutateIfExists, skipResult := checkNamespaceMutationBehavior(ctx, c, ns.Name)
+
+			require.Equal(t, tt.expectMutateIfExists, useMutateIfExists, "useMutateIfExists mismatch")
+			if tt.expectSkip {
+				require.NotNil(t, skipResult, "expected skip result")
+				require.True(t, skipResult.Allowed)
+				require.Empty(t, skipResult.PatchOps)
+			} else {
+				require.Nil(t, skipResult, "expected no skip result")
+			}
+		})
+	}
+}
+
+// createRawPod is a helper to create raw pod JSON for admission requests
+func createRawPod(t *testing.T, pod *corev1.Pod) runtime.RawExtension {
+	t.Helper()
+	raw, err := json.Marshal(pod)
+	require.NoError(t, err)
+	return runtime.RawExtension{Raw: raw}
+}
+
+// contains checks if a string contains a substring
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/agent/hooks/pods_mutate_if_image_exists.go
+++ b/src/internal/agent/hooks/pods_mutate_if_image_exists.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package hooks
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zarf-dev/zarf/src/internal/agent/operations"
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/pki"
+	"github.com/zarf-dev/zarf/src/pkg/state"
+	"github.com/zarf-dev/zarf/src/pkg/transform"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// checkNamespaceMutationBehavior checks the namespace labels to determine mutation behavior.
+// Returns useMutateIfExists flag and skipResult. If skipResult is non-nil, mutation should be skipped.
+func checkNamespaceMutationBehavior(ctx context.Context, c *cluster.Cluster, namespaceName string) (useMutateIfExists bool, skipResult *operations.Result) {
+	l := logger.From(ctx)
+
+	// Fetch namespace to check labels
+	namespace, err := c.Clientset.CoreV1().Namespaces().Get(ctx, namespaceName, metav1.GetOptions{})
+	if err != nil {
+		l.Warn("failed to get namespace labels, using legacy behavior", "namespace", namespaceName, "error", err.Error())
+		return false, nil
+	}
+
+	// Check if namespace should be completely skipped
+	if namespace.Labels != nil {
+		agentLabel := namespace.Labels["zarf.dev/agent"]
+		if agentLabel == "skip" || agentLabel == "ignore" {
+			l.Info("skipping pod mutation for ignored namespace", "namespace", namespaceName, "label", agentLabel)
+			return false, &operations.Result{
+				Allowed:  true,
+				PatchOps: []operations.PatchOperation{},
+			}
+		}
+
+		// Check if this namespace should use mutate-if-exists behavior
+		if strings.EqualFold(agentLabel, "mutate-if-exists") {
+			l.Info("namespace opted into mutate-if-exists behavior", "namespace", namespaceName)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// imageExistsInRegistry checks if an image exists in the registry using HTTP HEAD request.
+func imageExistsInRegistry(ctx context.Context, c *cluster.Cluster, imageRef string, registryInfo *state.RegistryInfo) (bool, error) {
+	l := logger.From(ctx)
+
+	// Parse the image reference
+	image, err := transform.ParseImageRef(imageRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse image reference: %w", err)
+	}
+
+	// Build the manifest API URL
+	var reference string
+	if image.Digest != "" {
+		reference = image.Digest
+	} else {
+		reference = image.Tag
+	}
+
+	// Use in-cluster service address when accessing the internal registry
+	registryAddress := registryInfo.Address
+	if registryInfo.IsInternal() {
+		// Use the in-cluster service DNS name and port
+		registryAddress = "zarf-docker-registry.zarf.svc.cluster.local:5000"
+	}
+
+	manifestURL := fmt.Sprintf("http://%s/v2/%s/manifests/%s", registryAddress, image.Path, reference)
+
+	// Create HTTP client with mTLS if needed
+	var transport = http.DefaultTransport
+	if registryInfo.ShouldUseMTLS() {
+		certs, certErr := c.GetRegistryClientMTLSCert(ctx)
+		if certErr != nil {
+			l.Warn("failed to get registry mTLS cert, using default transport", "error", certErr.Error())
+		} else {
+			mtlsTransport, transportErr := pki.TransportWithKey(certs)
+			if transportErr != nil {
+				l.Warn("failed to create mTLS transport, using default transport", "error", transportErr.Error())
+			} else {
+				transport = mtlsTransport
+			}
+		}
+	}
+
+	httpClient := &http.Client{Timeout: 10 * time.Second, Transport: transport}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, manifestURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set Accept headers for Docker and OCI manifest types
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
+
+	// Add Basic Auth if credentials are provided
+	if registryInfo.PullUsername != "" && registryInfo.PullPassword != "" {
+		auth := registryInfo.PullUsername + ":" + registryInfo.PullPassword
+		encodedAuth := base64.StdEncoding.EncodeToString([]byte(auth))
+		req.Header.Set("Authorization", "Basic "+encodedAuth)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to check manifest: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			l.Warn("failed to close response body", "error", closeErr.Error())
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		l.Debug("image exists in registry", "image", imageRef, "url", manifestURL)
+		return true, nil
+	case http.StatusNotFound:
+		l.Debug("image not found in registry", "image", imageRef, "url", manifestURL)
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code %d checking manifest for %s", resp.StatusCode, imageRef)
+	}
+}


### PR DESCRIPTION
Add support for conditional image mutation using the zarf.dev/agent=mutate-if-exists namespace label. When enabled, only images that exist in the Zarf registry are mutated, while others keep their original references.

Changes:
- Add checkNamespaceMutationBehavior to detect mutate-if-exists label
- Implement imageExistsInRegistry to check registry before mutation
- Add namespace read permissions to ClusterRole
- Fix in-cluster registry address for agent pod
- Add user documentation to init-package.mdx
- Fix linting issues in pods_mutate_if_image_exists.go

## Description

...

## Related Issue

Fixes #4640
<!-- or -->
Relates to #4640

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
