### PR TITLE
chore(deps): bump go version to v1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarf-dev/zarf
 
-go 1.25.6
+go 1.25.7
 
 // TODO (@AABRO): Pending merge into github.com/gojsonschema/gojsonschema (https://github.com/gojsonschema/gojsonschema/pull/5)
 replace github.com/xeipuuv/gojsonschema => github.com/defenseunicorns/gojsonschema v0.0.0-20231116163348-e00f069122d6


### PR DESCRIPTION
## Description

bumps the go version to v1.25.7 to resolve the regression in go identified in the related issue.

1.26 brings a number of considerations that need to be evaluated further. Given proximity to release this feels appropriate. 

## Related Issue

Fixes #4671
<!-- or -->
Relates to #

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
