### PR TITLE
fix(cmd): honor --insecure-skip-tls-verify for registry tools

### DIFF
--- a/src/cmd/crane.go
+++ b/src/cmd/crane.go
@@ -35,6 +35,10 @@ type registryOptions struct {
 	platform string
 }
 
+func useInsecureRegistryTransport(commandFlagInsecure bool, globalFlagInsecureSkipTLSVerify bool) bool {
+	return commandFlagInsecure || globalFlagInsecureSkipTLSVerify
+}
+
 func newRegistryCommand() *cobra.Command {
 	o := &registryOptions{
 		verbose:  false,
@@ -62,7 +66,7 @@ func newRegistryCommand() *cobra.Command {
 			if o.verbose {
 				logs.Debug.SetOutput(os.Stderr)
 			}
-			if o.insecure {
+			if useInsecureRegistryTransport(o.insecure, insecureSkipTLSVerify) {
 				craneOptions = append(craneOptions, crane.Insecure)
 			}
 			if o.ndlayers {
@@ -329,7 +333,7 @@ func (o *registryPruneOptions) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	options := []crane.Option{}
-	if o.insecure {
+	if useInsecureRegistryTransport(o.insecure, insecureSkipTLSVerify) {
 		options = append(options, crane.Insecure)
 	}
 

--- a/src/cmd/crane_test.go
+++ b/src/cmd/crane_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package cmd contains the CLI commands for Zarf.
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseInsecureRegistryTransport(t *testing.T) {
+	tests := []struct {
+		name          string
+		commandFlag   bool
+		globalFlag    bool
+		expectedValue bool
+	}{
+		{
+			name:          "both flags false",
+			commandFlag:   false,
+			globalFlag:    false,
+			expectedValue: false,
+		},
+		{
+			name:          "command flag true",
+			commandFlag:   true,
+			globalFlag:    false,
+			expectedValue: true,
+		},
+		{
+			name:          "global flag true",
+			commandFlag:   false,
+			globalFlag:    true,
+			expectedValue: true,
+		},
+		{
+			name:          "both flags true",
+			commandFlag:   true,
+			globalFlag:    true,
+			expectedValue: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := useInsecureRegistryTransport(tc.commandFlag, tc.globalFlag)
+			require.Equal(t, tc.expectedValue, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`zarf tools registry` commands are wrapped around crane and previously only honored the local `--insecure` flag. The global root flag `--insecure-skip-tls-verify` was not being applied on that code path.

This change makes registry tools honor either flag by:
- adding a small helper to unify insecure flag behavior
- using that helper in `tools registry` pre-run (covers `pull`, `push`, etc.)
- using that helper in `tools registry prune`
- adding unit tests for all flag combinations

Validation:
- `GOCACHE=/tmp/go-build-cache go test ./src/cmd -run TestUseInsecureRegistryTransport -count=1`

## Related Issue

Relates to zarf-dev/zarf#4671

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
