### PR TITLE
feat(state): remove architecture field

### DIFF
--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -108,8 +108,6 @@ type State struct {
 	ZarfAppliance bool `json:"zarfAppliance"`
 	// K8s distribution of the cluster Zarf was deployed to
 	Distro string `json:"distro"`
-	// Machine architecture of the k8s node(s)
-	Architecture string `json:"architecture"`
 	// Default StorageClass value Zarf uses for variable templating
 	StorageClass string `json:"storageClass"`
 	// The IP family of the cluster, can be ipv4, ipv6, or dual


### PR DESCRIPTION
## Description

We have an architecture field in state that we never set. I don't think this field makes sense, given that we want to support multi architecture workloads

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
