### PR TITLE
feat: enable plugin support for vender-ed kubectl

### DIFF
--- a/src/cmd/kubectl.go
+++ b/src/cmd/kubectl.go
@@ -58,7 +58,7 @@ func patchPluginListSubcommand(kubectlCmd *cobra.Command) {
 	cmdutil.CheckErr(err)
 
 	originalRun := cmd.Run
-	cmd.Run = func(cmd *cobra.Command, args []string) {
+	cmd.Run = func(_ *cobra.Command, args []string) {
 		root := kubecmd.NewKubectlCommand(kubecmd.KubectlOptions{})
 		root.Use = strings.ReplaceAll(kubectlCmd.CommandPath(), " ", "-")
 		originalRun(root, args)


### PR DESCRIPTION
## Description

This update enables `zarf tools kubectl` to use `kubectl` plugins, tested with the following:

[`kubectl-cnpg`](https://github.com/cloudnative-pg/cloudnative-pg/tree/main/cmd/kubectl-cnpg)
[`kubectl-get_all`](https://github.com/stackitcloud/kubectl-get-all)

## Related Issue

Relates to #4681

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
