### PR TITLE
fix: set field manager once during pre-run to avoid data race

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,13 +12,9 @@ import (
 
 	"github.com/zarf-dev/zarf/src/cmd"
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"helm.sh/helm/v4/pkg/kube"
 )
 
 func main() {
-	// This ensures the field manager is set to Zarf during any Helm SDK actions
-	kube.ManagedFieldsManager = cluster.FieldManagerName
 	// This ensures `./zarf` actions call the current Zarf binary over the system Zarf binary
 	config.ActionsUseSystemZarf = false
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -16,9 +16,11 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"helm.sh/helm/v4/pkg/kube"
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
 	"github.com/zarf-dev/zarf/src/pkg/feature"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 )
@@ -69,6 +71,8 @@ func (o *outputFormat) Type() string {
 var rootCmd = NewZarfCommand()
 
 func preRun(cmd *cobra.Command, _ []string) error {
+	// This ensures the field manager is set to Zarf during any Helm SDK actions
+	kube.ManagedFieldsManager = cluster.FieldManagerName
 	// Configure user defined Features
 	err := setupFeatures(features)
 	if err != nil {

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -146,6 +146,11 @@ func testHelmServerSideApply(t *testing.T) {
 	require.NoError(t, err, "unable to get helm metadata for configmap-without-ssa")
 	require.Contains(t, stdOut, "APPLY_METHOD: client-side apply")
 
+	// Verify the field manager is "zarf" for SSA-deployed resources
+	kubectlOut, _, err := e2e.Kubectl(t, "get", "configmap", "configmap-with-ssa-config", "-n", "configmap-with-ssa", "-o", "jsonpath={.metadata.managedFields[*].manager}")
+	require.NoError(t, err, "unable to get managedFields for configmap-with-ssa-config")
+	require.Contains(t, kubectlOut, "zarf")
+
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "helm-charts-ssa", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 }


### PR DESCRIPTION
## Description

We are setting the managed fields manager within a function that's called multiple times. When tests run in parallel they run into a race condition of both setting it. See https://github.com/zarf-dev/zarf/actions/runs/23006049045/job/66803088360?pr=4704

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
