### PR TITLE
feat: use legacy Helm wait + reconciliation Healthchecks

### DIFF
--- a/src/internal/packager/helm/chart.go
+++ b/src/internal/packager/helm/chart.go
@@ -5,6 +5,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -30,8 +31,10 @@ import (
 	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
 	"helm.sh/helm/v4/pkg/storage/driver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/zarf-dev/zarf/src/internal/healthchecks"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
 )
 
@@ -111,18 +114,19 @@ func InstallOrUpgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, ch
 
 	l.Debug("checking for existing helm deployment")
 
+	var newRelease release.Releaser
 	if errors.Is(histErr, driver.ErrReleaseNotFound) {
 		// No prior release, try to install it.
 		l.Info("performing Helm install", "chart", zarfChart.Name)
 
-		err = installChart(helmCtx, zarfChart, chart, values, opts, actionConfig, postRender)
+		newRelease, err = installChart(helmCtx, zarfChart, chart, values, opts, actionConfig, postRender)
 	} else if histErr == nil && len(releases) > 0 {
 		// Otherwise, there is a prior release so upgrade it.
 		l.Info("performing Helm upgrade", "chart", zarfChart.Name)
 
 		lastReleaser := releases[len(releases)-1]
 
-		err = upgradeChart(helmCtx, zarfChart, chart, values, opts, actionConfig, postRender, lastReleaser)
+		newRelease, err = upgradeChart(helmCtx, zarfChart, chart, values, opts, actionConfig, postRender, lastReleaser)
 	} else {
 		return nil, zarfChart.ReleaseName, fmt.Errorf("unable to verify the chart installation status: %w", histErr)
 	}
@@ -158,6 +162,29 @@ func InstallOrUpgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, ch
 			return nil, zarfChart.ReleaseName, fmt.Errorf("%w: unable to rollback: %w", installErr, err)
 		}
 		return nil, zarfChart.ReleaseName, installErr
+	}
+
+	newRel, err := release.NewAccessor(newRelease)
+	if err != nil {
+		return nil, zarfChart.ReleaseName, err
+	}
+
+	resourceList, err := actionConfig.KubeClient.Build(bytes.NewBufferString(newRel.Manifest()), true)
+	if err != nil {
+		return nil, zarfChart.ReleaseName, fmt.Errorf("unable to build the resource list: %w", err)
+	}
+
+	runtimeObjs := []runtime.Object{}
+	for _, resource := range resourceList {
+		runtimeObjs = append(runtimeObjs, resource.Object)
+	}
+
+	if !zarfChart.NoWait {
+		// Ensure we don't go past the timeout by using a context initialized with the helm timeout
+		l.Info("running health checks", "chart", zarfChart.Name)
+		if err := healthchecks.WaitForReadyRuntime(helmCtx, opts.Cluster.Watcher, runtimeObjs); err != nil {
+			return nil, zarfChart.ReleaseName, err
+		}
 	}
 
 	l.Debug("done processing Helm chart", "name", zarfChart.Name, "duration", time.Since(start))
@@ -226,7 +253,7 @@ func UpdateReleaseValues(ctx context.Context, zarfChart v1alpha1.ZarfChart, upda
 		client.ReuseValues = true
 
 		// Wait for the update operation to successfully complete
-		client.WaitStrategy = kube.StatusWatcherStrategy
+		client.WaitStrategy = kube.LegacyStrategy
 
 		client.ServerSideApply = zarfChart.GetServerSideApply()
 		client.ForceConflicts = shouldForceConflicts(zarfChart.GetServerSideApply(), lastRelease, opts.ForceConflicts)
@@ -244,7 +271,7 @@ func UpdateReleaseValues(ctx context.Context, zarfChart v1alpha1.ZarfChart, upda
 }
 
 func installChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *chartv2.Chart, chartValues common.Values,
-	opts InstallUpgradeOptions, actionConfig *action.Configuration, postRender *renderer) error {
+	opts InstallUpgradeOptions, actionConfig *action.Configuration, postRender *renderer) (release.Releaser, error) {
 	// Bind the helm action.
 	client := action.NewInstall(actionConfig)
 
@@ -255,7 +282,7 @@ func installChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *char
 	if zarfChart.NoWait {
 		client.WaitStrategy = kube.HookOnlyStrategy
 	} else {
-		client.WaitStrategy = kube.StatusWatcherStrategy
+		client.WaitStrategy = kube.LegacyStrategy
 	}
 
 	// We need to include CRDs or operator installations will fail spectacularly.
@@ -276,16 +303,15 @@ func installChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *char
 	client.ForceConflicts = shouldForceConflicts(zarfChart.GetServerSideApply(), nil, opts.ForceConflicts)
 
 	// Perform the loadedChart installation.
-	_, err := client.RunWithContext(ctx, chart, chartValues)
-	return err
+	return client.RunWithContext(ctx, chart, chartValues)
 }
 
 func upgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *chartv2.Chart, chartValues common.Values,
-	opts InstallUpgradeOptions, actionConfig *action.Configuration, postRender *renderer, lastRelease release.Releaser) error {
+	opts InstallUpgradeOptions, actionConfig *action.Configuration, postRender *renderer, lastRelease release.Releaser) (release.Releaser, error) {
 	// Migrate any deprecated APIs (if applicable)
 	err := migrateDeprecatedAPIs(ctx, opts.Cluster, actionConfig, lastRelease)
 	if err != nil {
-		return fmt.Errorf("unable to check for API deprecations: %w", err)
+		return nil, fmt.Errorf("unable to check for API deprecations: %w", err)
 	}
 
 	// Setup a new upgrade action
@@ -298,13 +324,13 @@ func upgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *char
 	if zarfChart.NoWait {
 		client.WaitStrategy = kube.HookOnlyStrategy
 	} else {
-		client.WaitStrategy = kube.StatusWatcherStrategy
+		client.WaitStrategy = kube.LegacyStrategy
 	}
 
 	client.ServerSideApply = zarfChart.GetServerSideApply()
 	rel, err := release.NewAccessor(lastRelease)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	client.ForceConflicts = shouldForceConflicts(zarfChart.GetServerSideApply(), rel, opts.ForceConflicts)
 
@@ -321,8 +347,7 @@ func upgradeChart(ctx context.Context, zarfChart v1alpha1.ZarfChart, chart *char
 	client.MaxHistory = maxHelmHistory
 
 	// Perform the loadedChart upgrade.
-	_, err = client.RunWithContext(ctx, zarfChart.ReleaseName, chart, chartValues)
-	return err
+	return client.RunWithContext(ctx, zarfChart.ReleaseName, chart, chartValues)
 }
 
 func rollbackChart(zarfChart v1alpha1.ZarfChart, rel release.Accessor, actionConfig *action.Configuration, timeout time.Duration, forceConflicts bool) error {
@@ -330,7 +355,7 @@ func rollbackChart(zarfChart v1alpha1.ZarfChart, rel release.Accessor, actionCon
 	client.CleanupOnFail = true
 	client.ServerSideApply = zarfChart.GetServerSideApply()
 	client.ForceConflicts = shouldForceConflicts(zarfChart.GetServerSideApply(), rel, forceConflicts)
-	client.WaitStrategy = kube.StatusWatcherStrategy
+	client.WaitStrategy = kube.LegacyStrategy
 	client.Timeout = timeout
 	client.Version = rel.Version()
 	client.MaxHistory = maxHelmHistory
@@ -340,7 +365,7 @@ func rollbackChart(zarfChart v1alpha1.ZarfChart, rel release.Accessor, actionCon
 func uninstallChart(name string, actionConfig *action.Configuration, timeout time.Duration) (*release.UninstallReleaseResponse, error) {
 	client := action.NewUninstall(actionConfig)
 	client.KeepHistory = false
-	client.WaitStrategy = kube.StatusWatcherStrategy
+	client.WaitStrategy = kube.LegacyStrategy
 	client.Timeout = timeout
 	return client.Run(name)
 }


### PR DESCRIPTION
## Description

In #4350 we upgraded to Helm 4 and used the newest Helm wait logic, which mirror'd the logic we use in Zarf. However we keep running into flakes in CI as seen by #4716. I believe it's possible that the system is getting overloaded with events and flaking because of that. Whereas in this system we only run healthchecks after most items are already ready, limiting events to process. In any case, until we have a clear idea of the solution, this will revert us to the same waiting behavior we had in Helm 3

## Related Issue

Fixes #4716

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
