### PR TITLE
fix: change scale down policy back to csa

### DIFF
--- a/src/pkg/cluster/zarf.go
+++ b/src/pkg/cluster/zarf.go
@@ -16,10 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	autoscalingv2ac "k8s.io/client-go/applyconfigurations/autoscaling/v2"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
-	"k8s.io/client-go/util/csaupgrade"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/config"
@@ -206,40 +203,22 @@ func (c *Cluster) RecordPackageDeployment(ctx context.Context, pkg v1alpha1.Zarf
 	return deployedPackage, nil
 }
 
-// setRegHPAScaleDownPolicy sets the HPA scale down policy for the Zarf Registry using Server-Side Apply.
+// setRegHPAScaleDownPolicy sets the HPA scale down policy for the Zarf Registry
 func (c *Cluster) setRegHPAScaleDownPolicy(ctx context.Context, policy autoscalingV2.ScalingPolicySelect) error {
 	hpa, err := c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(state.ZarfNamespaceName).Get(ctx, "zarf-docker-registry", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-
-	// If the hpa was deployed with client side apply then we need to update the fields to be managed by Zarf
-	// so the fields can be properly extracted
-	csaManagers := sets.New[string]()
-	for _, mf := range hpa.ManagedFields {
-		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
-			csaManagers.Insert(mf.Manager)
-		}
+	if hpa.Spec.Behavior == nil {
+		hpa.Spec.Behavior = &autoscalingV2.HorizontalPodAutoscalerBehavior{}
 	}
-	err = csaupgrade.UpgradeManagedFields(hpa, csaManagers, FieldManagerName)
-	if err != nil {
-		return fmt.Errorf("failed to upgrade managed fields: %w", err)
+	if hpa.Spec.Behavior.ScaleDown == nil {
+		hpa.Spec.Behavior.ScaleDown = &autoscalingV2.HPAScalingRules{}
 	}
-
-	hpaAc, err := autoscalingv2ac.ExtractHorizontalPodAutoscaler(hpa, FieldManagerName)
+	hpa.Spec.Behavior.ScaleDown.SelectPolicy = &policy
+	_, err = c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(state.ZarfNamespaceName).Update(ctx, hpa, metav1.UpdateOptions{})
 	if err != nil {
-		return err
-	}
-
-	hpaAc.Spec.Behavior.ScaleDown.WithSelectPolicy(policy)
-
-	_, err = c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(state.ZarfNamespaceName).Apply(
-		ctx,
-		hpaAc,
-		metav1.ApplyOptions{FieldManager: FieldManagerName, Force: true},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to apply hpa: %w", err)
+		return fmt.Errorf("failed to update hpa: %w", err)
 	}
 	return nil
 }

--- a/src/pkg/cluster/zarf_test.go
+++ b/src/pkg/cluster/zarf_test.go
@@ -70,36 +70,61 @@ func TestGetDeployedPackage(t *testing.T) {
 }
 
 func TestRegistryHPA(t *testing.T) {
-	ctx := context.Background()
-	cs := fake.NewClientset()
-	hpa := autoscalingv2.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "zarf-docker-registry",
-			Namespace: state.ZarfNamespaceName,
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec autoscalingv2.HorizontalPodAutoscalerSpec
+	}{
+		{
+			name: "behavior and scaleDown already set",
+			spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+					ScaleDown: &autoscalingv2.HPAScalingRules{},
+				},
+			},
 		},
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
-				ScaleDown: &autoscalingv2.HPAScalingRules{},
+		{
+			name: "nil behavior",
+			spec: autoscalingv2.HorizontalPodAutoscalerSpec{},
+		},
+		{
+			name: "nil scaleDown",
+			spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{},
 			},
 		},
 	}
-	_, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Create(ctx, &hpa, metav1.CreateOptions{})
-	require.NoError(t, err)
-	c := &Cluster{
-		Clientset: cs,
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			cs := fake.NewClientset()
+			hpa := autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zarf-docker-registry",
+					Namespace: state.ZarfNamespaceName,
+				},
+				Spec: tt.spec,
+			}
+			_, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Create(ctx, &hpa, metav1.CreateOptions{})
+			require.NoError(t, err)
+			c := &Cluster{Clientset: cs}
+
+			err = c.EnableRegHPAScaleDown(ctx)
+			require.NoError(t, err)
+			enableHpa, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, autoscalingv2.MinChangePolicySelect, *enableHpa.Spec.Behavior.ScaleDown.SelectPolicy)
+
+			err = c.DisableRegHPAScaleDown(ctx)
+			require.NoError(t, err)
+			disableHpa, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, autoscalingv2.DisabledPolicySelect, *disableHpa.Spec.Behavior.ScaleDown.SelectPolicy)
+		})
 	}
-
-	err = c.EnableRegHPAScaleDown(ctx)
-	require.NoError(t, err)
-	enableHpa, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Equal(t, autoscalingv2.MinChangePolicySelect, *enableHpa.Spec.Behavior.ScaleDown.SelectPolicy)
-
-	err = c.DisableRegHPAScaleDown(ctx)
-	require.NoError(t, err)
-	disableHpa, err := cs.AutoscalingV2().HorizontalPodAutoscalers(hpa.Namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Equal(t, autoscalingv2.DisabledPolicySelect, *disableHpa.Spec.Behavior.ScaleDown.SelectPolicy)
 }
 
 func TestInternalGitServerExists(t *testing.T) {


### PR DESCRIPTION
## Description

In #4437 we changed the scale down policy to ssa. Originally, the only option was to set the ssa field manager to Zarf, however since sdk users now have the ability to set the ssa manager to whatever they want, modifying the scale down policy using ssa will end in errors, as we either won't find the items on the resource, or we'll update it to a different field manager and the tool used to deploy the init package through the Zarf SDK would fail on their next deploy unless force conflicts was set.  

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
