### PR TITLE
feat: add password flag for zarf tools gen-key “Relates to #4739”

### DIFF
--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -17,10 +17,11 @@ zarf tools gen-key [flags]
 ### Options
 
 ```
-  -h, --help              help for gen-key
-      --interactive       Interactively prompt for registry server, username, and password if not provided
-      --password string   Password
-  -p, --password-stdin    Take the password from stdin
+      --force                       Force overwrite of keyfiles -- undefined behavior when running interactive
+  -h, --help                        help for gen-key
+      --interactive                 Interactively prompt for password
+      --password string             Private key password -- undefined behavior when running interactive
+      --password-stdin --password   Take the password from stdin -- undefined behavior with --password
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -17,11 +17,11 @@ zarf tools gen-key [flags]
 ### Options
 
 ```
-      --force             Force overwrite of keyfiles -- cannot be used with --interactive
+      --force             Force overwrite of keyfiles
   -h, --help              help for gen-key
       --interactive       Interactively prompt for password
-      --password string   Private key password -- cannot be used with --password-stdin or --interactive
-      --password-stdin    Take the password from stdin -- cannot be used with --password or --interactive
+      --password string   Private key password
+      --password-stdin    Take the password from stdin
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -17,11 +17,11 @@ zarf tools gen-key [flags]
 ### Options
 
 ```
-      --force                       Force overwrite of keyfiles -- undefined behavior when running interactive
-  -h, --help                        help for gen-key
-      --interactive                 Interactively prompt for password
-      --password string             Private key password -- undefined behavior when running interactive
-      --password-stdin --password   Take the password from stdin -- undefined behavior with --password
+      --force             Force overwrite of keyfiles -- cannot be used with --interactive
+  -h, --help              help for gen-key
+      --interactive       Interactively prompt for password
+      --password string   Private key password -- cannot be used with --password-stdin or --interactive
+      --password-stdin    Take the password from stdin -- cannot be used with --password or --interactive
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -17,7 +17,10 @@ zarf tools gen-key [flags]
 ### Options
 
 ```
-  -h, --help   help for gen-key
+  -h, --help              help for gen-key
+      --interactive       Interactively prompt for registry server, username, and password if not provided
+      --password string   Password
+  -p, --password-stdin    Take the password from stdin
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -592,6 +592,7 @@ type genKeyOptions struct {
 	force         bool
 	password      string
 	passwordStdin bool
+	reader        io.Reader
 }
 
 func newGenKeyCommand() *cobra.Command {
@@ -616,6 +617,10 @@ func newGenKeyCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&o.force, "force", false, lang.CmdToolsGenKeyShortFlagForce)
 	cmd.Flags().StringVar(&o.password, "password", "", lang.CmdToolsGenKeyShortFlagPassword)
 	cmd.Flags().BoolVar(&o.passwordStdin, "password-stdin", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
+
+	if o.passwordStdin {
+		o.reader = os.Stdin
+	}
 
 	return cmd
 }
@@ -680,7 +685,10 @@ func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) err
 			return []byte(password), nil
 		}
 	} else if o.passwordStdin {
-		password, err := io.ReadAll(os.Stdin)
+		if o.reader == nil {
+			return fmt.Errorf("reader not set for genKeyOptions")
+		}
+		password, err := io.ReadAll(o.reader)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -684,6 +684,9 @@ func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) err
 		if err != nil {
 			return err
 		}
+		if string(password) == "" {
+			return fmt.Errorf("empty password disallowed when using --password-stdin")
+		}
 		passwordFunc = func(bool) ([]byte, error) {
 			return []byte(password), nil
 		}

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -609,6 +609,9 @@ func newGenKeyCommand() *cobra.Command {
 					return errors.New(lang.CmdToolsGenKeyErrNoPasswordProvided)
 				}
 			}
+			if o.passwordStdin {
+				o.reader = os.Stdin
+			}
 			return nil
 		},
 	}
@@ -620,10 +623,6 @@ func newGenKeyCommand() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("password", "password-stdin", "interactive")
 	cmd.MarkFlagsMutuallyExclusive("interactive", "force")
 
-	if o.passwordStdin {
-		o.reader = os.Stdin
-	}
-
 	return cmd
 }
 
@@ -634,7 +633,6 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 	err := o.genKey(prvKeyFileName, pubKeyFileName)
 
 	if err != nil {
-		logger.From(cmd.Context()).Error("Failed to generate key pair")
 		return err
 	}
 

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -589,6 +589,7 @@ func (o *genPKIOptions) run(cmd *cobra.Command, args []string) error {
 
 type genKeyOptions struct {
 	interactive   bool
+	force         bool
 	password      string
 	passwordStdin bool
 }
@@ -603,7 +604,8 @@ func newGenKeyCommand() *cobra.Command {
 		RunE:    o.run,
 	}
 
-	cmd.Flags().BoolVar(&o.interactive, "interactive", true, lang.CmdToolsGenKeyShortFlagInteractive)
+	cmd.Flags().BoolVar(&o.interactive, "interactive", false, lang.CmdToolsGenKeyShortFlagInteractive)
+	cmd.Flags().BoolVar(&o.force, "force", false, lang.CmdToolsGenKeyShortFlagForce)
 	cmd.Flags().StringVar(&o.password, "password", "", lang.CmdToolsGenKeyShortFlagPassword)
 	cmd.Flags().BoolVar(&o.passwordStdin, "password-stdin", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
 
@@ -611,6 +613,24 @@ func newGenKeyCommand() *cobra.Command {
 }
 
 func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
+	prvKeyFileName := "cosign.key"
+	pubKeyFileName := "cosign.pub"
+
+	err := o.genKey(prvKeyFileName, pubKeyFileName)
+
+	if err != nil {
+		logger.From(cmd.Context()).Error("Failed to generate key pair")
+		return err
+	}
+
+	logger.From(cmd.Context()).Info("Successfully generated key pair",
+		"private-key-path", prvKeyFileName,
+		"public-key-path", pubKeyFileName)
+
+	return nil
+}
+
+func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) error {
 	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
 	if o.interactive {
@@ -660,13 +680,15 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to generate key pair: %w", err)
 	}
 
-	prvKeyFileName := "cosign.key"
-	pubKeyFileName := "cosign.pub"
-
 	// Check if we are about to overwrite existing key files
 	_, prvKeyExistsErr := os.Stat(prvKeyFileName)
 	_, pubKeyExistsErr := os.Stat(pubKeyFileName)
-	if (prvKeyExistsErr == nil || pubKeyExistsErr == nil) && o.interactive {
+	var keyfilesExist bool
+	if prvKeyExistsErr == nil || pubKeyExistsErr == nil {
+		keyfilesExist = true
+	}
+
+	if keyfilesExist && o.interactive {
 		var confirm bool
 		confirmOverwritePrompt := &survey.Confirm{
 			Message: fmt.Sprintf(lang.CmdToolsGenKeyPromptExists, prvKeyFileName),
@@ -678,19 +700,14 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 		if !confirm {
 			return errors.New("did not receive confirmation for overwriting key file(s)")
 		}
+	} else if keyfilesExist && !o.force {
+		return errors.New("cosign key file(s) already exist: pass --force to overwrite")
 	}
 
 	// Write the key file contents to disk
 	if err := os.WriteFile(prvKeyFileName, keyBytes.PrivateBytes, helpers.ReadWriteUser); err != nil {
 		return err
 	}
-	if err := os.WriteFile(pubKeyFileName, keyBytes.PublicBytes, helpers.ReadAllWriteUser); err != nil {
-		return err
-	}
 
-	logger.From(cmd.Context()).Info("Successfully generated key pair",
-		"private-key-path", prvKeyFileName,
-		"public-key-path", pubKeyFileName)
-
-	return nil
+	return os.WriteFile(pubKeyFileName, keyBytes.PublicBytes, helpers.ReadAllWriteUser)
 }

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -602,6 +602,14 @@ func newGenKeyCommand() *cobra.Command {
 		Aliases: []string{"key"},
 		Short:   lang.CmdToolsGenKeyShort,
 		RunE:    o.run,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if !o.interactive {
+				if !cmd.Flags().Changed("password") && !o.passwordStdin {
+					return errors.New(lang.CmdToolsGenKeyErrNoPasswordProvided)
+				}
+			}
+			return nil
+		},
 	}
 
 	cmd.Flags().BoolVar(&o.interactive, "interactive", false, lang.CmdToolsGenKeyShortFlagInteractive)

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -626,6 +626,15 @@ func newGenKeyCommand() *cobra.Command {
 	return cmd
 }
 
+func (o *genKeyOptions) validatePassword(s string) error {
+	for _, c := range s {
+		if c < 32 || c > 126 {
+			return fmt.Errorf("invalid character (ascii code 0x%02X) in password", c)
+		}
+	}
+	return nil
+}
+
 func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 	prvKeyFileName := "cosign.key"
 	pubKeyFileName := "cosign.pub"
@@ -644,54 +653,54 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 }
 
 func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) error {
+	var password string
+	var err error
 	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
 
 	if o.interactive {
-		passwordFunc = func(bool) ([]byte, error) {
-			// perform the first prompt
-			var password string
-			prompt := &survey.Password{
-				Message: lang.CmdToolsGenKeyPrompt,
-			}
-			if err := survey.AskOne(prompt, &password); err != nil {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
-			}
+		prompt := &survey.Password{
+			Message: lang.CmdToolsGenKeyPrompt,
+		}
+		if err := survey.AskOne(prompt, &password); err != nil {
+			return fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
+		}
 
-			// perform the second prompt
-			var doubleCheck string
-			rePrompt := &survey.Password{
-				Message: lang.CmdToolsGenKeyPromptAgain,
-			}
-			if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
-			}
+		// perform the second prompt
+		var doubleCheck string
+		rePrompt := &survey.Password{
+			Message: lang.CmdToolsGenKeyPromptAgain,
+		}
+		if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
+			return fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
+		}
 
-			// check if the passwords match
-			if password != doubleCheck {
-				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
-			}
-
-			return []byte(password), nil
+		// check if the passwords match
+		if password != doubleCheck {
+			return fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
 		}
 	} else if o.passwordStdin {
 		if o.reader == nil {
 			return fmt.Errorf("reader not set for genKeyOptions")
 		}
-		password, err := io.ReadAll(o.reader)
+		passwordBytes, err := io.ReadAll(o.reader)
 		if err != nil {
 			return err
 		}
-		if string(password) == "" {
+		password = string(passwordBytes)
+		if password == "" {
 			return fmt.Errorf("empty password disallowed when using --password-stdin")
 		}
-		passwordFunc = func(bool) ([]byte, error) {
-			return []byte(password), nil
-		}
 	} else {
-		passwordFunc = func(bool) ([]byte, error) {
-			return []byte(o.password), nil
+		password = o.password
+	}
+
+	passwordFunc = func(bool) ([]byte, error) {
+		err = o.validatePassword(password)
+		if err != nil {
+			return nil, err
 		}
+		return []byte(password), nil
 	}
 
 	// Use cosign to generate the keypair

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -617,6 +617,8 @@ func newGenKeyCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&o.force, "force", false, lang.CmdToolsGenKeyShortFlagForce)
 	cmd.Flags().StringVar(&o.password, "password", "", lang.CmdToolsGenKeyShortFlagPassword)
 	cmd.Flags().BoolVar(&o.passwordStdin, "password-stdin", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
+	cmd.MarkFlagsMutuallyExclusive("password", "password-stdin", "interactive")
+	cmd.MarkFlagsMutuallyExclusive("interactive", "force")
 
 	if o.passwordStdin {
 		o.reader = os.Stdin
@@ -647,17 +649,7 @@ func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) err
 	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
 
-	if len(o.password) > 0 && o.passwordStdin {
-		return fmt.Errorf("cannot use --password with --password-stdin")
-	}
-
 	if o.interactive {
-		if len(o.password) > 0 || o.passwordStdin {
-			return fmt.Errorf("cannot use --password or --password-stdin with --interactive")
-		}
-		if o.force {
-			return fmt.Errorf("cannot use --force with --interactive")
-		}
 		passwordFunc = func(bool) ([]byte, error) {
 			// perform the first prompt
 			var password string

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -587,7 +587,11 @@ func (o *genPKIOptions) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type genKeyOptions struct{}
+type genKeyOptions struct {
+	interactive   bool
+	password      string
+	passwordStdin bool
+}
 
 func newGenKeyCommand() *cobra.Command {
 	o := &genKeyOptions{}
@@ -599,36 +603,55 @@ func newGenKeyCommand() *cobra.Command {
 		RunE:    o.run,
 	}
 
+	cmd.Flags().BoolVar(&o.interactive, "interactive", true, lang.CmdToolsGenKeyShortFlagInteractive)
+	cmd.Flags().StringVar(&o.password, "password", "", lang.CmdToolsGenKeyShortFlagPassword)
+	cmd.Flags().BoolVarP(&o.passwordStdin, "password-stdin", "", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
+
 	return cmd
 }
 
 func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
+	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
-	passwordFunc := func(bool) ([]byte, error) {
-		// perform the first prompt
-		var password string
-		prompt := &survey.Password{
-			Message: lang.CmdToolsGenKeyPrompt,
-		}
-		if err := survey.AskOne(prompt, &password); err != nil {
-			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
-		}
+	if o.interactive {
+		passwordFunc = func(bool) ([]byte, error) {
+			// perform the first prompt
+			var password string
+			prompt := &survey.Password{
+				Message: lang.CmdToolsGenKeyPrompt,
+			}
+			if err := survey.AskOne(prompt, &password); err != nil {
+				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
+			}
 
-		// perform the second prompt
-		var doubleCheck string
-		rePrompt := &survey.Password{
-			Message: lang.CmdToolsGenKeyPromptAgain,
-		}
-		if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
-			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
-		}
+			// perform the second prompt
+			var doubleCheck string
+			rePrompt := &survey.Password{
+				Message: lang.CmdToolsGenKeyPromptAgain,
+			}
+			if err := survey.AskOne(rePrompt, &doubleCheck); err != nil {
+				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
+			}
 
-		// check if the passwords match
-		if password != doubleCheck {
-			return nil, fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
-		}
+			// check if the passwords match
+			if password != doubleCheck {
+				return nil, fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
+			}
 
-		return []byte(password), nil
+			return []byte(password), nil
+		}
+	} else if o.passwordStdin {
+		password, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		passwordFunc = func(bool) ([]byte, error) {
+			return []byte(password), nil
+		}
+	} else {
+		passwordFunc = func(bool) ([]byte, error) {
+			return []byte(o.password), nil
+		}
 	}
 
 	// Use cosign to generate the keypair
@@ -643,7 +666,7 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 	// Check if we are about to overwrite existing key files
 	_, prvKeyExistsErr := os.Stat(prvKeyFileName)
 	_, pubKeyExistsErr := os.Stat(pubKeyFileName)
-	if prvKeyExistsErr == nil || pubKeyExistsErr == nil {
+	if (prvKeyExistsErr == nil || pubKeyExistsErr == nil) && o.interactive {
 		var confirm bool
 		confirmOverwritePrompt := &survey.Confirm{
 			Message: fmt.Sprintf(lang.CmdToolsGenKeyPromptExists, prvKeyFileName),

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -605,7 +605,7 @@ func newGenKeyCommand() *cobra.Command {
 
 	cmd.Flags().BoolVar(&o.interactive, "interactive", true, lang.CmdToolsGenKeyShortFlagInteractive)
 	cmd.Flags().StringVar(&o.password, "password", "", lang.CmdToolsGenKeyShortFlagPassword)
-	cmd.Flags().BoolVarP(&o.passwordStdin, "password-stdin", "", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
+	cmd.Flags().BoolVar(&o.passwordStdin, "password-stdin", false, lang.CmdToolsGenKeyShortFlagPasswordStdin)
 
 	return cmd
 }

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -633,7 +633,18 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) error {
 	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
+
+	if len(o.password) > 0 && o.passwordStdin {
+		return fmt.Errorf("cannot use --password with --password-stdin")
+	}
+
 	if o.interactive {
+		if len(o.password) > 0 || o.passwordStdin {
+			return fmt.Errorf("cannot use --password or --password-stdin with --interactive")
+		}
+		if o.force {
+			return fmt.Errorf("cannot use --force with --interactive")
+		}
 		passwordFunc = func(bool) ([]byte, error) {
 			// perform the first prompt
 			var password string

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -626,7 +626,7 @@ func newGenKeyCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *genKeyOptions) validatePassword(bs []byte) error {
+func validatePassword(bs []byte) error {
 	for _, b := range bs {
 		if b < 32 || b > 126 {
 			return fmt.Errorf("invalid character (ascii code 0x%02X) in password", b)
@@ -640,7 +640,6 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 	pubKeyFileName := "cosign.pub"
 
 	err := o.genKey(prvKeyFileName, pubKeyFileName)
-
 	if err != nil {
 		return err
 	}
@@ -655,8 +654,6 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 func (o *genKeyOptions) genKey(prvKeyFileName, pubKeyFileName string) error {
 	var password []byte
 	var err error
-	var passwordFunc func(bool) ([]byte, error)
-	// Utility function to prompt the user for the password to the private key
 
 	if o.interactive {
 		var tmpPassword string
@@ -696,18 +693,9 @@ func (o *genKeyOptions) genKey(prvKeyFileName, pubKeyFileName string) error {
 		password = []byte(o.password)
 	}
 
-	passwordFunc = func(bool) ([]byte, error) {
-		err = o.validatePassword(password)
-		if err != nil {
-			return nil, err
-		}
-		return password, nil
-	}
-
-	// Use cosign to generate the keypair
-	keyBytes, err := cosign.GenerateKeyPair(passwordFunc)
+	err = validatePassword(password)
 	if err != nil {
-		return fmt.Errorf("unable to generate key pair: %w", err)
+		return err
 	}
 
 	// Check if we are about to overwrite existing key files
@@ -732,6 +720,14 @@ func (o *genKeyOptions) genKey(prvKeyFileName, pubKeyFileName string) error {
 		}
 	} else if keyfilesExist && !o.force {
 		return errors.New("cosign key file(s) already exist: pass --force to overwrite")
+	}
+
+	// Use cosign to generate the keypair
+	keyBytes, err := cosign.GenerateKeyPair(func(bool) ([]byte, error) {
+		return password, nil
+	})
+	if err != nil {
+		return fmt.Errorf("unable to generate key pair: %w", err)
 	}
 
 	// Write the key file contents to disk

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -626,10 +626,10 @@ func newGenKeyCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *genKeyOptions) validatePassword(s string) error {
-	for _, c := range s {
-		if c < 32 || c > 126 {
-			return fmt.Errorf("invalid character (ascii code 0x%02X) in password", c)
+func (o *genKeyOptions) validatePassword(bs []byte) error {
+	for _, b := range bs {
+		if b < 32 || b > 126 {
+			return fmt.Errorf("invalid character (ascii code 0x%02X) in password", b)
 		}
 	}
 	return nil
@@ -653,16 +653,17 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 }
 
 func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) error {
-	var password string
+	var password []byte
 	var err error
 	var passwordFunc func(bool) ([]byte, error)
 	// Utility function to prompt the user for the password to the private key
 
 	if o.interactive {
+		var tmpPassword string
 		prompt := &survey.Password{
 			Message: lang.CmdToolsGenKeyPrompt,
 		}
-		if err := survey.AskOne(prompt, &password); err != nil {
+		if err := survey.AskOne(prompt, &tmpPassword); err != nil {
 			return fmt.Errorf(lang.CmdToolsGenKeyErrUnableGetPassword, err)
 		}
 
@@ -676,23 +677,23 @@ func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) err
 		}
 
 		// check if the passwords match
-		if password != doubleCheck {
+		if tmpPassword != doubleCheck {
 			return fmt.Errorf(lang.CmdToolsGenKeyErrPasswordsNotMatch)
 		}
+		password = []byte(tmpPassword)
 	} else if o.passwordStdin {
 		if o.reader == nil {
 			return fmt.Errorf("reader not set for genKeyOptions")
 		}
-		passwordBytes, err := io.ReadAll(o.reader)
+		password, err = io.ReadAll(o.reader)
 		if err != nil {
 			return err
 		}
-		password = string(passwordBytes)
-		if password == "" {
+		if len(password) == 0 {
 			return fmt.Errorf("empty password disallowed when using --password-stdin")
 		}
 	} else {
-		password = o.password
+		password = []byte(o.password)
 	}
 
 	passwordFunc = func(bool) ([]byte, error) {
@@ -700,7 +701,7 @@ func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) err
 		if err != nil {
 			return nil, err
 		}
-		return []byte(password), nil
+		return password, nil
 	}
 
 	// Use cosign to generate the keypair

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -652,7 +652,7 @@ func (o *genKeyOptions) run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (o *genKeyOptions) genKey(prvKeyFileName string, pubKeyFileName string) error {
+func (o *genKeyOptions) genKey(prvKeyFileName, pubKeyFileName string) error {
 	var password []byte
 	var err error
 	var passwordFunc func(bool) ([]byte, error)

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -130,6 +130,14 @@ func TestGenKey(t *testing.T) {
 			},
 		},
 		{
+			name: "gen key password-stdin empty-string",
+			options: genKeyOptions{
+				passwordStdin: true,
+				reader:        bytes.NewBufferString(""),
+			},
+			shouldFail: true,
+		},
+		{
 			name:       "gen key (key exists)",
 			options:    genKeyOptions{},
 			keysExist:  true,

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -103,3 +103,72 @@ func TestGetCreds(t *testing.T) {
 		})
 	}
 }
+
+func TestGenKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		options    genKeyOptions
+		keysExist  bool
+		shouldFail bool
+	}{
+		{
+			name:    "gen key",
+			options: genKeyOptions{},
+		},
+		{
+			name: "gen key password",
+			options: genKeyOptions{
+				password: "test-password",
+			},
+		},
+		{
+			name: "gen key password-stdin",
+			options: genKeyOptions{
+				passwordStdin: true,
+			},
+		},
+		{
+			name:       "gen key (key exists)",
+			options:    genKeyOptions{},
+			keysExist:  true,
+			shouldFail: true,
+		},
+		{
+			name: "gen key force (key exists)",
+			options: genKeyOptions{
+				force: true,
+			},
+			keysExist: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+
+			prvKeyName := filepath.Join(tempDir, "test.key")
+			pubKeyName := filepath.Join(tempDir, "test.pub")
+
+			if tt.keysExist {
+				_, err := os.Create(prvKeyName)
+				require.NoError(t, err, "Could not test existing keys or force because a file could not be created in the private key's place")
+				_, err = os.Create(pubKeyName)
+				require.NoError(t, err, "Could not test existing keys or force because a file could not be created in the public key's place")
+			}
+
+			err := tt.options.genKey(prvKeyName, pubKeyName)
+
+			if tt.shouldFail {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.FileExists(t, prvKeyName, "private key did not generate")
+			require.FileExists(t, pubKeyName, "public key did not generate")
+		})
+	}
+}

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -138,6 +138,21 @@ func TestGenKey(t *testing.T) {
 			shouldFail: true,
 		},
 		{
+			name: "gen key password-stdin badBytes",
+			options: genKeyOptions{
+				passwordStdin: true,
+				reader:        bytes.NewBuffer([]byte{9, 10}),
+			},
+			shouldFail: true,
+		},
+		{
+			name: "gen key password bad chars",
+			options: genKeyOptions{
+				password: "\n\t",
+			},
+			shouldFail: true,
+		},
+		{
 			name:       "gen key (key exists)",
 			options:    genKeyOptions{},
 			keysExist:  true,

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -142,30 +142,6 @@ func TestGenKey(t *testing.T) {
 			},
 			keysExist: true,
 		},
-		{
-			name: "gen key interactive with password",
-			options: genKeyOptions{
-				interactive: true,
-				password:    "test-password",
-			},
-			shouldFail: true,
-		},
-		{
-			name: "gen key interactive with password-stdin",
-			options: genKeyOptions{
-				interactive:   true,
-				passwordStdin: true,
-			},
-			shouldFail: true,
-		},
-		{
-			name: "gen key password with password-stdin",
-			options: genKeyOptions{
-				password:      "test-password",
-				passwordStdin: true,
-			},
-			shouldFail: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -141,6 +141,30 @@ func TestGenKey(t *testing.T) {
 			},
 			keysExist: true,
 		},
+		{
+			name: "gen key interactive with password",
+			options: genKeyOptions{
+				interactive: true,
+				password:    "test-password",
+			},
+			shouldFail: true,
+		},
+		{
+			name: "gen key interactive with password-stdin",
+			options: genKeyOptions{
+				interactive:   true,
+				passwordStdin: true,
+			},
+			shouldFail: true,
+		},
+		{
+			name: "gen key password with password-stdin",
+			options: genKeyOptions{
+				password:      "test-password",
+				passwordStdin: true,
+			},
+			shouldFail: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -126,6 +126,7 @@ func TestGenKey(t *testing.T) {
 			name: "gen key password-stdin",
 			options: genKeyOptions{
 				passwordStdin: true,
+				reader:        bytes.NewBufferString("test-password"),
 			},
 		},
 		{

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -113,7 +113,7 @@ func TestGenKey(t *testing.T) {
 		shouldFail bool
 	}{
 		{
-			name:    "gen key",
+			name:    "gen key empty password",
 			options: genKeyOptions{},
 		},
 		{

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -611,9 +611,10 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsGenPkiFlagAltName = "Specify Subject Alternative Names for the certificate"
 
 	CmdToolsGenKeyShort                  = "Generates a cosign public/private keypair that can be used to sign packages"
-	CmdToolsGenKeyShortFlagInteractive   = "WILL OVERWRITE KEY FILES!!! -- Interactively prompt for password if not provided (default true)"
-	CmdToolsGenKeyShortFlagPassword      = "Private key password (default \"\")"
-	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- overrides `--password`"
+	CmdToolsGenKeyShortFlagInteractive   = "Interactively prompt for password"
+	CmdToolsGenKeyShortFlagForce         = "Force overwrite of keyfiles -- undefined behavior when running interactive"
+	CmdToolsGenKeyShortFlagPassword      = "Private key password -- undefined behavior when running interactive"
+	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- undefined behavior with `--password`"
 	CmdToolsGenKeyPrompt                 = "Private key password (empty for no password): "
 	CmdToolsGenKeyPromptAgain            = "Private key password again (empty for no password): "
 	CmdToolsGenKeyPromptExists           = "File %s already exists. Overwrite? "

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -610,12 +610,15 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsGenPkiSuccess     = "Successfully created a chain of trust for %s"
 	CmdToolsGenPkiFlagAltName = "Specify Subject Alternative Names for the certificate"
 
-	CmdToolsGenKeyShort                = "Generates a cosign public/private keypair that can be used to sign packages"
-	CmdToolsGenKeyPrompt               = "Private key password (empty for no password): "
-	CmdToolsGenKeyPromptAgain          = "Private key password again (empty for no password): "
-	CmdToolsGenKeyPromptExists         = "File %s already exists. Overwrite? "
-	CmdToolsGenKeyErrUnableGetPassword = "unable to get password for private key: %w"
-	CmdToolsGenKeyErrPasswordsNotMatch = "passwords do not match"
+	CmdToolsGenKeyShort                  = "Generates a cosign public/private keypair that can be used to sign packages"
+	CmdToolsGenKeyShortFlagInteractive   = "WILL OVERWRITE KEY FILES!!! -- Interactively prompt for password if not provided (default true)"
+	CmdToolsGenKeyShortFlagPassword      = "Private key password (default \"\")"
+	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- overrides `--password`"
+	CmdToolsGenKeyPrompt                 = "Private key password (empty for no password): "
+	CmdToolsGenKeyPromptAgain            = "Private key password again (empty for no password): "
+	CmdToolsGenKeyPromptExists           = "File %s already exists. Overwrite? "
+	CmdToolsGenKeyErrUnableGetPassword   = "unable to get password for private key: %w"
+	CmdToolsGenKeyErrPasswordsNotMatch   = "passwords do not match"
 
 	CmdToolsSbomShort = "Generates a Software Bill of Materials (SBOM) for the given package"
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -618,6 +618,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 	CmdToolsGenKeyPrompt                 = "Private key password (empty for no password): "
 	CmdToolsGenKeyPromptAgain            = "Private key password again (empty for no password): "
 	CmdToolsGenKeyPromptExists           = "File %s already exists. Overwrite? "
+	CmdToolsGenKeyErrNoPasswordProvided  = "must explicitly pass --password=\"\" for empty password"
 	CmdToolsGenKeyErrUnableGetPassword   = "unable to get password for private key: %w"
 	CmdToolsGenKeyErrPasswordsNotMatch   = "passwords do not match"
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -612,9 +612,9 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 
 	CmdToolsGenKeyShort                  = "Generates a cosign public/private keypair that can be used to sign packages"
 	CmdToolsGenKeyShortFlagInteractive   = "Interactively prompt for password"
-	CmdToolsGenKeyShortFlagForce         = "Force overwrite of keyfiles -- undefined behavior when running interactive"
-	CmdToolsGenKeyShortFlagPassword      = "Private key password -- undefined behavior when running interactive"
-	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- undefined behavior with `--password`"
+	CmdToolsGenKeyShortFlagForce         = "Force overwrite of keyfiles -- cannot be used with --interactive"
+	CmdToolsGenKeyShortFlagPassword      = "Private key password -- cannot be used with --password-stdin or --interactive"
+	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- cannot be used with --password or --interactive"
 	CmdToolsGenKeyPrompt                 = "Private key password (empty for no password): "
 	CmdToolsGenKeyPromptAgain            = "Private key password again (empty for no password): "
 	CmdToolsGenKeyPromptExists           = "File %s already exists. Overwrite? "

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -612,9 +612,9 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 
 	CmdToolsGenKeyShort                  = "Generates a cosign public/private keypair that can be used to sign packages"
 	CmdToolsGenKeyShortFlagInteractive   = "Interactively prompt for password"
-	CmdToolsGenKeyShortFlagForce         = "Force overwrite of keyfiles -- cannot be used with --interactive"
-	CmdToolsGenKeyShortFlagPassword      = "Private key password -- cannot be used with --password-stdin or --interactive"
-	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin -- cannot be used with --password or --interactive"
+	CmdToolsGenKeyShortFlagForce         = "Force overwrite of keyfiles"
+	CmdToolsGenKeyShortFlagPassword      = "Private key password"
+	CmdToolsGenKeyShortFlagPasswordStdin = "Take the password from stdin"
 	CmdToolsGenKeyPrompt                 = "Private key password (empty for no password): "
 	CmdToolsGenKeyPromptAgain            = "Private key password again (empty for no password): "
 	CmdToolsGenKeyPromptExists           = "File %s already exists. Overwrite? "


### PR DESCRIPTION
## Description

Adds password command line flags, and an interactive flag to allow easier scripting for `zarf tools gen-key`.

As suggested in #4739, I tried to mimic the behavior as close as possible to `zarf registry login`. However, by default, the registry login command runs interactively. So as to not change the current behavior and api, the tools gen-key command runs as interactive by default unless you pass `--interactive=false`. This behavior can be modified if it is desired to change the behavior. Just let me know.

## Related Issue

Relates to #4739

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed

P.S. Let me know if you want me to fill out this checklist. I ran the pre-commit hooks, but obviously the ci in the actions is authoritative, so I don't want to check things before they're done. I also read and tried best to follow the Contributor guide. Let me know if anything is unsatisfactory, and I will do what I can to fix it.