### PR TITLE
fix(cache): sbom cachepath existence

### DIFF
--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -63,10 +63,6 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 	l := logger.From(ctx)
 	l.Info("assembling package", "path", packagePath)
 
-	if err := helpers.CreateDirectory(opts.CachePath, helpers.ReadExecuteAllWriteUser); err != nil {
-		return nil, fmt.Errorf("failed to create cache directory %s: %w", opts.CachePath, err)
-	}
-
 	if err := validateImageArchivesNoDuplicates(pkg.Components); err != nil {
 		return nil, err
 	}

--- a/src/pkg/packager/layout/sbom_test.go
+++ b/src/pkg/packager/layout/sbom_test.go
@@ -28,3 +28,17 @@ func TestCreateImageSBOM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fileContent, b)
 }
+
+func TestCreateImageSBOMNonExistentCachePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+
+	outputPath := t.TempDir()
+	// Cache path that doesn't exist yet
+	cachePath := filepath.Join(t.TempDir(), "non-existent-cache")
+	img := empty.Image
+	b, err := createImageSBOM(ctx, cachePath, outputPath, img, "docker.io/foo/bar:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, b)
+}


### PR DESCRIPTION
## Description

The {cache}/images directory is only created as a side effect of images.Pull(). When a package uses imageArchives instead of pulling from a registry, componentImages is empty, Pull() is never called, and nobody creates that directory. But `createImageSBOM` runs unconditionally (unless SBOM is skipped) and passes filepath.Join(cachePath, ImagesDir) to stereoscope, which assumes it exists and fails when it tries to write uncompressed layer data into it via os.Create.

This PR was specifically scoped to the identified issue. I think there is room for evaluating common entrypoints for library defaults.

## Related Issue

Fixes #4735
<!-- or -->
Relates to #

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
