### PR TITLE
fix(cache): support for default sdk cache path

### DIFF
--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -49,7 +49,7 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 		return "", fmt.Errorf("cannot skip SBOM creation and specify an SBOM output directory")
 	}
 
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -62,7 +62,7 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 		opts.Timeout = config.ZarfDefaultTimeout
 	}
 
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -86,7 +86,7 @@ type ComponentImageScan struct {
 func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions) (_ []ComponentImageScan, err error) {
 	l := logger.From(ctx)
 
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -194,7 +194,7 @@ type InspectDefinitionResourcesOptions struct {
 
 // InspectDefinitionResources templates and returns the manifests and Helm chart manifests found in the definition at the given path
 func InspectDefinitionResources(ctx context.Context, packagePath string, opts InspectDefinitionResourcesOptions) (_ []Resource, err error) {
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/packager/lint.go
+++ b/src/pkg/packager/lint.go
@@ -28,7 +28,7 @@ func Lint(ctx context.Context, packagePath string, opts LintOptions) error {
 	}
 
 	var err error
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -59,7 +59,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 		opts.LayersSelector = zoci.AllLayers
 	}
 
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/packager/load/load.go
+++ b/src/pkg/packager/load/load.go
@@ -66,7 +66,7 @@ func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionO
 		return v1alpha1.ZarfPackage{}, err
 	}
 	pkg.Metadata.Architecture = config.GetArch(pkg.Metadata.Architecture)
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return v1alpha1.ZarfPackage{}, err
 	}

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -205,7 +205,7 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 		opts.Retries = defaultPublishRetries
 	}
 
-	cachePath, err := utils.GetCachePath(opts.CachePath)
+	cachePath, err := utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return registry.Reference{}, err
 	}

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -55,7 +55,7 @@ func Pull(ctx context.Context, source, destination string, opts PullOptions) (_ 
 	// ensure architecture is set
 	arch := config.GetArch(opts.Architecture)
 
-	opts.CachePath, err = utils.GetCachePath(opts.CachePath)
+	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/utils/io.go
+++ b/src/pkg/utils/io.go
@@ -17,9 +17,9 @@ const (
 	tmpPathPrefix = "zarf-"
 )
 
-// GetCachePath returns cachePath if non-empty, otherwise falls back to
+// ResolveCachePath returns cachePath if non-empty, otherwise falls back to
 // filepath.Join(os.UserCacheDir(), "zarf") which respects XDG_CACHE_HOME on Linux.
-func GetCachePath(cachePath string) (string, error) {
+func ResolveCachePath(cachePath string) (string, error) {
 	if cachePath != "" {
 		return cachePath, nil
 	}

--- a/src/pkg/utils/io_test.go
+++ b/src/pkg/utils/io_test.go
@@ -14,19 +14,19 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 )
 
-func TestGetCachePath(t *testing.T) {
+func TestResolveCachePath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("non-empty input returns input unchanged", func(t *testing.T) {
 		t.Parallel()
-		result, err := GetCachePath("/custom/cache/path")
+		result, err := ResolveCachePath("/custom/cache/path")
 		require.NoError(t, err)
 		require.Equal(t, "/custom/cache/path", result)
 	})
 
 	t.Run("empty input returns UserCacheDir/zarf", func(t *testing.T) {
 		t.Parallel()
-		result, err := GetCachePath("")
+		result, err := ResolveCachePath("")
 		require.NoError(t, err)
 		expected, err := os.UserCacheDir()
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Zarf's public `src/pkg/packager/` functions all accept a `CachePath` string in their options. The CLI always sets this via `getCachePath()`, but SDK consumers who omit it get an empty string that causes failures deep in the call stack (`zoci.GetOCICacheModifier`, `images.Pull`, `createImageSBOM`, helm operations). This change adds a `GetCachePath` utility and applies it at every public entry point so SDK consumers get a working default (`os.UserCacheDir()/zarf`) without needing CLI knowledge. 

CLI behavior is unchanged — the CLI always passes an explicit path but worth acknowledging optionality here to change the CLI to support #3828 .

There is some redundancy across some transient load operations where this is called multiple times. Given the cases all are subsequently public functions and the operation is idempotent I think this is reasonable. 

## Related Issue

Fixes #4764

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
