### PR TITLE
fix!: remove 0.27.0 layout shim

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -628,12 +628,9 @@ func (d *deployer) installManifests(ctx context.Context, pkgLayout *layout.Packa
 	installedCharts := []state.InstalledChart{}
 	for _, manifest := range component.Manifests {
 		for idx := range manifest.Files {
+			manifest.Files[idx] = fmt.Sprintf("%s-%d.yaml", manifest.Name, idx)
 			if helpers.InvalidPath(filepath.Join(manifestDir, manifest.Files[idx])) {
-				// The path is likely invalid because of how we compose OCI components, add an index suffix to the filename
-				manifest.Files[idx] = fmt.Sprintf("%s-%d.yaml", manifest.Name, idx)
-				if helpers.InvalidPath(filepath.Join(manifestDir, manifest.Files[idx])) {
-					return installedCharts, fmt.Errorf("unable to find manifest file %s", manifest.Files[idx])
-				}
+				return installedCharts, fmt.Errorf("unable to find manifest file %s", manifest.Files[idx])
 			}
 			if manifest.IsTemplate() {
 				path := filepath.Join(manifestDir, manifest.Files[idx])


### PR DESCRIPTION
## Description

#1469 changed how manifests were loaded into a package, but kept a shim around in case old packages were deployed on newer versions of Zarf. This shim can cause a bug under specific circumstances, see #4819. 

Some consideration for adding a minimumVersionRequirement here, but given that this package layout change happened in v0.27.0 from May 2023, I deemed this not practically necessary. 

The breaking change here is that we will no longer deploy packages from <v0.27.0. I doubt this is relevant to anyone. 

## Related Issue

Fixes #4819

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
