### PR TITLE
feat: stop adding Zarf service default values to state when the service does not exist

### DIFF
--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -42,7 +42,6 @@ const (
 	gitKey          = "git"
 	gitReadKey      = "git-readonly"
 	artifactKey     = "artifact"
-	agentKey        = "agent"
 )
 
 type getCredsOptions struct {
@@ -281,19 +280,14 @@ func newUpdateCredsCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
-	validKeys := []string{
-		state.RegistryKey,
-		state.GitKey,
-		state.ArtifactKey,
-		state.AgentKey,
-	}
-	if len(args) == 0 {
-		args = validKeys
-	} else {
-		if !slices.Contains(validKeys, args[0]) {
+	services := state.AllServiceKeys
+	if len(args) > 0 {
+		parsed, err := state.ParseServiceKey(args[0])
+		if err != nil {
 			cmd.Help()
-			return fmt.Errorf("invalid service key specified, valid key choices are: %v", validKeys)
+			return err
 		}
+		services = []state.ServiceKey{parsed}
 	}
 
 	ctx := cmd.Context()
@@ -318,10 +312,10 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 		GitServer:      o.gitServer,
 		RegistryInfo:   o.registryInfo,
 		ArtifactServer: o.artifactServer,
-		Services:       args,
+		Services:       services,
 	}
 
-	if slices.Contains(args, state.AgentKey) {
+	if slices.Contains(services, state.AgentKey) {
 		if oldState.AgentTLSUserProvided && o.agentTLSCAPath == "" {
 			return fmt.Errorf("current agent TLS certificates are user-provided; provide --agent-tls-ca, --agent-tls-cert, and --agent-tls-key to update them, or explicitly define service list without `agent`")
 		}
@@ -339,7 +333,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to update Zarf credentials: %w", err)
 	}
 
-	printCredentialUpdates(ctx, oldState, newState, args)
+	printCredentialUpdates(ctx, oldState, newState, services)
 
 	confirm := o.confirm
 
@@ -357,7 +351,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update registry and git pull secrets
-	if slices.Contains(args, state.RegistryKey) {
+	if slices.Contains(services, state.RegistryKey) {
 		err := c.UpdateZarfManagedImageSecrets(ctx, newState)
 		if err != nil {
 			return err
@@ -370,7 +364,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	if slices.Contains(args, state.GitKey) {
+	if slices.Contains(services, state.GitKey) {
 		err := c.UpdateZarfManagedGitSecrets(ctx, newState)
 		if err != nil {
 			return err
@@ -384,7 +378,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update artifact token (if internal)
-	if slices.Contains(args, state.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
+	if slices.Contains(services, state.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
 		newState.ArtifactServer.PushToken, err = c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
 		if err != nil {
 			return fmt.Errorf("unable to create the new Gitea artifact token: %w", err)
@@ -407,20 +401,20 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update Zarf 'init' component Helm releases if present
-	if slices.Contains(args, state.RegistryKey) && newState.RegistryInfo.IsInternal() {
+	if slices.Contains(services, state.RegistryKey) && newState.RegistryInfo.IsInternal() {
 		err = helm.UpdateZarfRegistryValues(ctx, helmOpts)
 		if err != nil {
 			// Warn if we couldn't actually update the registry (it might not be installed and we should try to continue)
 			l.Warn("unable to update Zarf Registry values", "error", err.Error())
 		}
 	}
-	if slices.Contains(args, state.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
+	if slices.Contains(services, state.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
 		err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
 		if err != nil {
 			return fmt.Errorf("unable to update Zarf Git Server values: %w", err)
 		}
 	}
-	if slices.Contains(args, state.AgentKey) {
+	if slices.Contains(services, state.AgentKey) {
 		err = helm.UpdateZarfAgentValues(ctx, helmOpts)
 		if err != nil {
 			// Warn if we couldn't actually update the agent (it might not be installed and we should try to continue)
@@ -431,13 +425,13 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printCredentialUpdates(ctx context.Context, oldState *state.State, newState *state.State, services []string) {
+func printCredentialUpdates(ctx context.Context, oldState *state.State, newState *state.State, services []state.ServiceKey) {
 	// Pause the logfile's output to avoid credentials being printed to the log file
 	l := logger.From(ctx)
 	l.Info("--- printing credential updates. Sensitive values will be redacted ---")
 	for _, service := range services {
 		switch service {
-		case registryKey:
+		case state.RegistryKey:
 			oR := oldState.RegistryInfo
 			nR := newState.RegistryInfo
 			l.Info("registry URL address", "existing", oR.Address, "replacement", nR.Address)
@@ -450,7 +444,7 @@ func printCredentialUpdates(ctx context.Context, oldState *state.State, newState
 				l.Info("registry mTLS public certificate", "changed", "true")
 				l.Info("registry mTLS private key", "changed", "true")
 			}
-		case gitKey:
+		case state.GitKey:
 			oG := oldState.GitServer
 			nG := newState.GitServer
 			l.Info("Git server URL address", "existing", oG.Address, "replacement", nG.Address)
@@ -458,13 +452,13 @@ func printCredentialUpdates(ctx context.Context, oldState *state.State, newState
 			l.Info("Git server push password", "changed", oG.PushPassword != nG.PushPassword)
 			l.Info("Git server pull username", "existing", oG.PullUsername, "replacement", nG.PullUsername)
 			l.Info("Git server pull password", "changed", oG.PullPassword != nG.PullPassword)
-		case artifactKey:
+		case state.ArtifactKey:
 			oA := oldState.ArtifactServer
 			nA := newState.ArtifactServer
 			l.Info("artifact server URL address", "existing", oA.Address, "replacement", nA.Address)
 			l.Info("artifact server push username", "existing", oA.PushUsername, "replacement", nA.PushUsername)
 			l.Info("artifact server push token", "changed", oA.PushToken != nA.PushToken)
-		case agentKey:
+		case state.AgentKey:
 			oT := oldState.AgentTLS
 			nT := newState.AgentTLS
 			l.Info("agent TLS source", "user-provided", newState.AgentTLSUserProvided)

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -280,7 +280,7 @@ func newUpdateCredsCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
-	services := state.AllServiceKeys
+	services := state.AllServiceKeys()
 	if len(args) > 0 {
 		parsed, err := state.ParseServiceKey(args[0])
 		if err != nil {

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
@@ -280,14 +279,14 @@ func newUpdateCredsCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
-	services := state.AllServiceKeys()
+	services := state.NewServiceSet(state.AllServiceKeys()...)
 	if len(args) > 0 {
 		parsed, err := state.ParseServiceKey(args[0])
 		if err != nil {
 			cmd.Help()
 			return err
 		}
-		services = []state.ServiceKey{parsed}
+		services = state.NewServiceSet(parsed)
 	}
 
 	ctx := cmd.Context()
@@ -315,7 +314,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 		Services:       services,
 	}
 
-	if slices.Contains(services, state.AgentKey) {
+	if services.Has(state.AgentKey) {
 		if oldState.AgentTLSUserProvided && o.agentTLSCAPath == "" {
 			return fmt.Errorf("current agent TLS certificates are user-provided; provide --agent-tls-ca, --agent-tls-cert, and --agent-tls-key to update them, or explicitly define service list without `agent`")
 		}
@@ -351,7 +350,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update registry and git pull secrets
-	if slices.Contains(services, state.RegistryKey) {
+	if services.Has(state.RegistryKey) {
 		err := c.UpdateZarfManagedImageSecrets(ctx, newState)
 		if err != nil {
 			return err
@@ -364,7 +363,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	if slices.Contains(services, state.GitKey) {
+	if services.Has(state.GitKey) {
 		err := c.UpdateZarfManagedGitSecrets(ctx, newState)
 		if err != nil {
 			return err
@@ -379,7 +378,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update artifact token (if internal)
-	if slices.Contains(services, state.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
+	if services.Has(state.ArtifactKey) && newState.ArtifactServer.PushToken == "" && newState.ArtifactServer.IsInternal() && internalGitServerExists {
 		newState.ArtifactServer.PushToken, err = c.UpdateInternalArtifactServerToken(ctx, oldState.GitServer)
 		if err != nil {
 			return fmt.Errorf("unable to create the new Gitea artifact token: %w", err)
@@ -402,20 +401,20 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Update Zarf 'init' component Helm releases if present
-	if slices.Contains(services, state.RegistryKey) && newState.RegistryInfo.IsInternal() {
+	if services.Has(state.RegistryKey) && newState.RegistryInfo.IsInternal() {
 		err = helm.UpdateZarfRegistryValues(ctx, helmOpts)
 		if err != nil {
 			// Warn if we couldn't actually update the registry (it might not be installed and we should try to continue)
 			l.Warn("unable to update Zarf Registry values", "error", err.Error())
 		}
 	}
-	if slices.Contains(services, state.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
+	if services.Has(state.GitKey) && newState.GitServer.IsInternal() && internalGitServerExists {
 		err := c.UpdateInternalGitServerSecret(cmd.Context(), oldState.GitServer, newState.GitServer)
 		if err != nil {
 			return fmt.Errorf("unable to update Zarf Git Server values: %w", err)
 		}
 	}
-	if slices.Contains(services, state.AgentKey) {
+	if services.Has(state.AgentKey) {
 		err = helm.UpdateZarfAgentValues(ctx, helmOpts)
 		if err != nil {
 			// Warn if we couldn't actually update the agent (it might not be installed and we should try to continue)
@@ -426,47 +425,47 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printCredentialUpdates(ctx context.Context, oldState *state.State, newState *state.State, services []state.ServiceKey) {
+func printCredentialUpdates(ctx context.Context, oldState *state.State, newState *state.State, services state.ServiceSet) {
 	// Pause the logfile's output to avoid credentials being printed to the log file
 	l := logger.From(ctx)
 	l.Info("--- printing credential updates. Sensitive values will be redacted ---")
-	for _, service := range services {
-		switch service {
-		case state.RegistryKey:
-			oR := oldState.RegistryInfo
-			nR := newState.RegistryInfo
-			l.Info("registry URL address", "existing", oR.Address, "replacement", nR.Address)
-			l.Info("registry push username", "existing", oR.PushUsername, "replacement", nR.PushUsername)
-			l.Info("registry push password", "changed", oR.PushPassword != nR.PushPassword)
-			l.Info("registry pull username", "existing", oR.PullUsername, "replacement", nR.PullUsername)
-			l.Info("registry pull password", "changed", oR.PullPassword != nR.PullPassword)
-			if newState.RegistryInfo.MTLSStrategy == state.MTLSStrategyZarfManaged {
-				l.Info("registry mTLS certificate authority", "changed", "true")
-				l.Info("registry mTLS public certificate", "changed", "true")
-				l.Info("registry mTLS private key", "changed", "true")
-			}
-		case state.GitKey:
-			oG := oldState.GitServer
-			nG := newState.GitServer
-			l.Info("Git server URL address", "existing", oG.Address, "replacement", nG.Address)
-			l.Info("Git server push username", "existing", oG.PushUsername, "replacement", nG.PushUsername)
-			l.Info("Git server push password", "changed", oG.PushPassword != nG.PushPassword)
-			l.Info("Git server pull username", "existing", oG.PullUsername, "replacement", nG.PullUsername)
-			l.Info("Git server pull password", "changed", oG.PullPassword != nG.PullPassword)
-		case state.ArtifactKey:
-			oA := oldState.ArtifactServer
-			nA := newState.ArtifactServer
-			l.Info("artifact server URL address", "existing", oA.Address, "replacement", nA.Address)
-			l.Info("artifact server push username", "existing", oA.PushUsername, "replacement", nA.PushUsername)
-			l.Info("artifact server push token", "changed", oA.PushToken != nA.PushToken)
-		case state.AgentKey:
-			oT := oldState.AgentTLS
-			nT := newState.AgentTLS
-			l.Info("agent TLS source", "user-provided", newState.AgentTLSUserProvided)
-			l.Info("agent certificate authority", "changed", string(oT.CA) != string(nT.CA))
-			l.Info("agent public certificate", "changed", string(oT.Cert) != string(nT.Cert))
-			l.Info("agent private key", "changed", string(oT.Key) != string(nT.Key))
+	if services.Has(state.RegistryKey) {
+		oR := oldState.RegistryInfo
+		nR := newState.RegistryInfo
+		l.Info("registry URL address", "existing", oR.Address, "replacement", nR.Address)
+		l.Info("registry push username", "existing", oR.PushUsername, "replacement", nR.PushUsername)
+		l.Info("registry push password", "changed", oR.PushPassword != nR.PushPassword)
+		l.Info("registry pull username", "existing", oR.PullUsername, "replacement", nR.PullUsername)
+		l.Info("registry pull password", "changed", oR.PullPassword != nR.PullPassword)
+		if newState.RegistryInfo.MTLSStrategy == state.MTLSStrategyZarfManaged {
+			l.Info("registry mTLS certificate authority", "changed", "true")
+			l.Info("registry mTLS public certificate", "changed", "true")
+			l.Info("registry mTLS private key", "changed", "true")
 		}
+	}
+	if services.Has(state.GitKey) {
+		oG := oldState.GitServer
+		nG := newState.GitServer
+		l.Info("Git server URL address", "existing", oG.Address, "replacement", nG.Address)
+		l.Info("Git server push username", "existing", oG.PushUsername, "replacement", nG.PushUsername)
+		l.Info("Git server push password", "changed", oG.PushPassword != nG.PushPassword)
+		l.Info("Git server pull username", "existing", oG.PullUsername, "replacement", nG.PullUsername)
+		l.Info("Git server pull password", "changed", oG.PullPassword != nG.PullPassword)
+	}
+	if services.Has(state.ArtifactKey) {
+		oA := oldState.ArtifactServer
+		nA := newState.ArtifactServer
+		l.Info("artifact server URL address", "existing", oA.Address, "replacement", nA.Address)
+		l.Info("artifact server push username", "existing", oA.PushUsername, "replacement", nA.PushUsername)
+		l.Info("artifact server push token", "changed", oA.PushToken != nA.PushToken)
+	}
+	if services.Has(state.AgentKey) {
+		oT := oldState.AgentTLS
+		nT := newState.AgentTLS
+		l.Info("agent TLS source", "user-provided", newState.AgentTLSUserProvided)
+		l.Info("agent certificate authority", "changed", string(oT.CA) != string(nT.CA))
+		l.Info("agent public certificate", "changed", string(oT.Cert) != string(nT.Cert))
+		l.Info("agent private key", "changed", string(oT.Key) != string(nT.Key))
 	}
 }
 

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -370,8 +370,9 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	// TODO once Zarf is changed so the default state is empty for a service when it is not deployed
-	// and sufficient time has passed for users state to get updated we can remove this check
+
+	// Zarf now only configures state with a Git server if a git server is deployed
+	// since there is still old state, we continue to check the cluster if the Git server exists
 	internalGitServerExists, err := c.InternalGitServerExists(cmd.Context())
 	if err != nil {
 		return err

--- a/src/internal/agent/hooks/argocd-application.go
+++ b/src/internal/agent/hooks/argocd-application.go
@@ -65,6 +65,10 @@ func mutateApplication(ctx context.Context, r *v1.AdmissionRequest, cluster *clu
 	if err != nil {
 		return nil, err
 	}
+	if !s.GitServer.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping ArgoCD Application mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	app := Application{}
 	if err = json.Unmarshal(r.Object.Raw, &app); err != nil {

--- a/src/internal/agent/hooks/argocd-applicationset.go
+++ b/src/internal/agent/hooks/argocd-applicationset.go
@@ -64,6 +64,10 @@ func mutateApplicationSet(ctx context.Context, r *v1.AdmissionRequest, cluster *
 	if err != nil {
 		return nil, err
 	}
+	if !s.GitServer.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping ArgoCD ApplicationSet mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	appSet := ApplicationSet{}
 	if err = json.Unmarshal(r.Object.Raw, &appSet); err != nil {

--- a/src/internal/agent/hooks/argocd-appproject.go
+++ b/src/internal/agent/hooks/argocd-appproject.go
@@ -53,6 +53,10 @@ func mutateAppProject(ctx context.Context, r *v1.AdmissionRequest, cluster *clus
 	if err != nil {
 		return nil, err
 	}
+	if !s.GitServer.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping ArgoCD AppProject mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	proj := AppProject{}
 	if err = json.Unmarshal(r.Object.Raw, &proj); err != nil {

--- a/src/internal/agent/hooks/argocd-repository.go
+++ b/src/internal/agent/hooks/argocd-repository.go
@@ -57,6 +57,10 @@ func mutateRepositorySecret(ctx context.Context, r *v1.AdmissionRequest, cluster
 	if err != nil {
 		return nil, err
 	}
+	if !s.GitServer.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping ArgoCD repository secret mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	secret := corev1.Secret{}
 	if err = json.Unmarshal(r.Object.Raw, &secret); err != nil {

--- a/src/internal/agent/hooks/flux-gitrepo.go
+++ b/src/internal/agent/hooks/flux-gitrepo.go
@@ -45,6 +45,10 @@ func mutateGitRepo(ctx context.Context, r *v1.AdmissionRequest, cluster *cluster
 	if err != nil {
 		return nil, err
 	}
+	if !s.GitServer.IsConfigured() {
+		l.Debug("no Zarf git server configured, skipping Flux GitRepository mutation")
+		return &operations.Result{Allowed: true}, nil
+	}
 
 	repo := flux.GitRepository{}
 	if err = json.Unmarshal(r.Object.Raw, &repo); err != nil {

--- a/src/internal/agent/hooks/git_mutation_guard_test.go
+++ b/src/internal/agent/hooks/git_mutation_guard_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/internal/agent/http/admission"
+	"github.com/zarf-dev/zarf/src/pkg/state"
+	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// When state has no git server address (cluster was initialized without gitea
+// and without an external --git-url), the agent must not mutate any git resource.
+func TestGitMutationHooksSkipWhenUnConfigured(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := &state.State{} // empty GitServer → IsConfigured() == false
+	c := createTestClientWithZarfState(ctx, t, s)
+
+	mustRaw := func(v any) runtime.RawExtension {
+		t.Helper()
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		return runtime.RawExtension{Raw: b}
+	}
+
+	cases := []admissionTest{
+		{
+			name: "argocd Application",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Object: mustRaw(&Application{
+					Spec: ApplicationSpec{Source: &ApplicationSource{RepoURL: "https://example.com/org/repo"}},
+				}),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "argocd ApplicationSet",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Object: mustRaw(&ApplicationSet{
+					Spec: ApplicationSetSpec{Generators: []ApplicationSetGenerator{
+						{Git: &GitGenerator{RepoURL: "https://example.com/org/repo"}},
+					}},
+				}),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "argocd AppProject",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Object: mustRaw(&AppProject{
+					Spec: AppProjectSpec{SourceRepos: []string{"https://example.com/org/repo"}},
+				}),
+			},
+			code: http.StatusOK,
+		},
+		{
+			name: "argocd repository secret",
+			admissionReq: &v1.AdmissionRequest{
+				Operation: v1.Create,
+				Object: mustRaw(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-creds"},
+					Data:       map[string][]byte{"url": []byte("https://example.com/org/repo")},
+				}),
+			},
+			code: http.StatusOK,
+		},
+	}
+
+	hooks := map[string]http.HandlerFunc{
+		"argocd Application":       admission.NewHandler().Serve(ctx, NewApplicationMutationHook(ctx, c)),
+		"argocd ApplicationSet":    admission.NewHandler().Serve(ctx, NewApplicationSetMutationHook(ctx, c)),
+		"argocd AppProject":        admission.NewHandler().Serve(ctx, NewAppProjectMutationHook(ctx, c)),
+		"argocd repository secret": admission.NewHandler().Serve(ctx, NewRepositorySecretMutationHook(ctx, c)),
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rr := sendAdmissionRequest(t, tc.admissionReq, hooks[tc.name])
+			verifyAdmission(t, rr, tc)
+		})
+	}
+
+	// Flux GitRepository uses a separate unstructured type; exercise it inline.
+	t.Run("flux GitRepository", func(t *testing.T) {
+		t.Parallel()
+		raw := runtime.RawExtension{Raw: []byte(`{"spec":{"url":"https://example.com/org/repo"}}`)}
+		req := &v1.AdmissionRequest{Operation: v1.Create, Object: raw}
+		handler := admission.NewHandler().Serve(ctx, NewGitRepositoryMutationHook(ctx, c))
+		rr := sendAdmissionRequest(t, req, handler)
+		verifyAdmission(t, rr, admissionTest{code: http.StatusOK})
+	})
+}

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -327,19 +327,20 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 
 	s.IPFamily = ipFamily
 
-	// Registry-mode reconciliation only applies to internally deployed registries.
+	previousMode := s.RegistryInfo.RegistryMode
+	if opts.RegistryInfo.RegistryMode != "" {
+		s.RegistryInfo.RegistryMode = opts.RegistryInfo.RegistryMode
+	}
+	modeChanged := opts.RegistryInfo.RegistryMode != "" && opts.RegistryInfo.RegistryMode != previousMode
+
+	// If the registry mode is changing the injector will be re-made so the port should be reset
+	if modeChanged {
+		s.InjectorInfo.Port = 0
+	}
+
+	// Internal-registry topology (port defaults, localhost address, mTLS certs)
+	// is only reconciled when Zarf is deploying the registry.
 	if slices.Contains(opts.InternalServices, state.RegistryKey) {
-		previousMode := s.RegistryInfo.RegistryMode
-		if opts.RegistryInfo.RegistryMode != "" {
-			s.RegistryInfo.RegistryMode = opts.RegistryInfo.RegistryMode
-		}
-		modeChanged := opts.RegistryInfo.RegistryMode != "" && opts.RegistryInfo.RegistryMode != previousMode
-
-		// If the registry mode is changing the injector will be re-made so the port should be reset
-		if modeChanged {
-			s.InjectorInfo.Port = 0
-		}
-
 		switch s.RegistryInfo.RegistryMode {
 		case state.RegistryModeNodePort:
 			switch {

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -176,7 +176,7 @@ type InitStateOptions struct {
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
 	// InternalServices lists the state services that Zarf is deploying in this init run.
-	InternalServices []state.ServiceKey
+	InternalServices state.ServiceSet
 }
 
 // InitState takes initOptions and hydrates a cluster's state from InitStateOptions.
@@ -233,7 +233,7 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 		}
 
 		// Setup zarf agent PKI when the agent is being deployed
-		if slices.Contains(opts.InternalServices, state.AgentKey) {
+		if opts.InternalServices.Has(state.AgentKey) {
 			if opts.AgentTLS != nil {
 				s.AgentTLS = *opts.AgentTLS
 				s.AgentTLSUserProvided = true
@@ -288,37 +288,34 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 
 		// Populate git/registry/artifact state for each service that is either
 		// deployed by Zarf (InternalServices) or pointed at an external endpoint.
-		gitInternal := slices.Contains(opts.InternalServices, state.GitKey)
-		if gitInternal || opts.GitServer.Address != "" {
+		if opts.InternalServices.Has(state.GitKey) || opts.GitServer.Address != "" {
 			if err := opts.GitServer.FillInEmptyValues(); err != nil {
 				return nil, err
 			}
 			s.GitServer = opts.GitServer
 		}
-		registryInternal := slices.Contains(opts.InternalServices, state.RegistryKey)
-		if registryInternal || opts.RegistryInfo.Address != "" {
+		if opts.InternalServices.Has(state.RegistryKey) || opts.RegistryInfo.Address != "" {
 			if err := opts.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
 				return nil, err
 			}
 			s.RegistryInfo = opts.RegistryInfo
 		}
-		artifactInternal := slices.Contains(opts.InternalServices, state.ArtifactKey)
-		if artifactInternal || opts.ArtifactServer.Address != "" {
+		if opts.InternalServices.Has(state.ArtifactKey) || opts.ArtifactServer.Address != "" {
 			opts.ArtifactServer.FillInEmptyValues()
 			s.ArtifactServer = opts.ArtifactServer
 		}
 	} else {
 		// Re-init: fill defaults only for internal services that weren't configured
 		// on a prior init. External services are managed via `zarf tools update-creds`.
-		if slices.Contains(opts.InternalServices, state.GitKey) && !s.GitServer.IsConfigured() {
+		if opts.InternalServices.Has(state.GitKey) && !s.GitServer.IsConfigured() {
 			if err := s.GitServer.FillInEmptyValues(); err != nil {
 				return nil, err
 			}
 		}
-		if slices.Contains(opts.InternalServices, state.ArtifactKey) && !s.ArtifactServer.IsConfigured() {
+		if opts.InternalServices.Has(state.ArtifactKey) && !s.ArtifactServer.IsConfigured() {
 			s.ArtifactServer.FillInEmptyValues()
 		}
-		if slices.Contains(opts.InternalServices, state.RegistryKey) && !s.RegistryInfo.IsConfigured() {
+		if opts.InternalServices.Has(state.RegistryKey) && !s.RegistryInfo.IsConfigured() {
 			if err := s.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
 				return nil, err
 			}

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -175,11 +175,8 @@ type InitStateOptions struct {
 	InjectorPort int
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
-	// InternalServices lists the state keys (state.RegistryKey, GitKey, ArtifactKey, AgentKey)
-	// that Zarf is deploying in this init run. External endpoints supplied through
-	// GitServer/RegistryInfo/ArtifactServer addresses are detected separately and
-	// do not belong in this list.
-	InternalServices []string
+	// InternalServices lists the state services that Zarf is deploying in this init run.
+	InternalServices []state.ServiceKey
 }
 
 // InitState takes initOptions and hydrates a cluster's state from InitStateOptions.

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -338,36 +338,32 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 		s.InjectorInfo.Port = 0
 	}
 
-	// Internal-registry topology (port defaults, localhost address, mTLS certs)
-	// is only reconciled when Zarf is deploying the registry.
-	if slices.Contains(opts.InternalServices, state.RegistryKey) {
-		switch s.RegistryInfo.RegistryMode {
-		case state.RegistryModeNodePort:
-			switch {
-			case opts.RegistryInfo.Port != 0:
-				s.RegistryInfo.Port = opts.RegistryInfo.Port
-			case modeChanged:
-				s.RegistryInfo.Port = state.ZarfInClusterContainerRegistryNodePort
-			}
-			s.RegistryInfo.MTLSStrategy = state.MTLSStrategyNone
-			s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
-		case state.RegistryModeProxy:
-			switch {
-			case opts.RegistryInfo.Port != 0:
-				s.RegistryInfo.Port = opts.RegistryInfo.Port
-			case modeChanged:
-				s.RegistryInfo.Port = state.ZarfRegistryHostPort
-			}
-			s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
+	switch s.RegistryInfo.RegistryMode {
+	case state.RegistryModeNodePort:
+		switch {
+		case opts.RegistryInfo.Port != 0:
+			s.RegistryInfo.Port = opts.RegistryInfo.Port
+		case modeChanged:
+			s.RegistryInfo.Port = state.ZarfInClusterContainerRegistryNodePort
 		}
+		s.RegistryInfo.MTLSStrategy = state.MTLSStrategyNone
+		s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
+	case state.RegistryModeProxy:
+		switch {
+		case opts.RegistryInfo.Port != 0:
+			s.RegistryInfo.Port = opts.RegistryInfo.Port
+		case modeChanged:
+			s.RegistryInfo.Port = state.ZarfRegistryHostPort
+		}
+		s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
+	}
 
-		if opts.RegistryInfo.RegistryMode == state.RegistryModeProxy {
-			err = c.InitRegistryCerts(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to generate certs: %w", err)
-			}
-			s.RegistryInfo.MTLSStrategy = state.MTLSStrategyZarfManaged
+	if opts.RegistryInfo.RegistryMode == state.RegistryModeProxy {
+		err = c.InitRegistryCerts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate certs: %w", err)
 		}
+		s.RegistryInfo.MTLSStrategy = state.MTLSStrategyZarfManaged
 	}
 
 	switch s.Distro {

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -175,10 +175,11 @@ type InitStateOptions struct {
 	InjectorPort int
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
-	// Services lists the state keys (state.RegistryKey, GitKey, ArtifactKey, AgentKey)
-	// that this init run is responsible for populating. Services not listed keep
-	// their zero values so state.IsConfigured checks reflect reality.
-	Services []string
+	// InternalServices lists the state keys (state.RegistryKey, GitKey, ArtifactKey, AgentKey)
+	// that Zarf is deploying in this init run. External endpoints supplied through
+	// GitServer/RegistryInfo/ArtifactServer addresses are detected separately and
+	// do not belong in this list.
+	InternalServices []string
 }
 
 // InitState takes initOptions and hydrates a cluster's state from InitStateOptions.
@@ -235,7 +236,7 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 		}
 
 		// Setup zarf agent PKI when the agent is being deployed
-		if slices.Contains(opts.Services, state.AgentKey) {
+		if slices.Contains(opts.InternalServices, state.AgentKey) {
 			if opts.AgentTLS != nil {
 				s.AgentTLS = *opts.AgentTLS
 				s.AgentTLSUserProvided = true
@@ -288,58 +289,49 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 			return nil, fmt.Errorf("unable get default Zarf service account: %w", err)
 		}
 
-		if slices.Contains(opts.Services, state.GitKey) {
+		// Populate git/registry/artifact state for each service that is either
+		// deployed by Zarf (InternalServices) or pointed at an external endpoint.
+		gitInternal := slices.Contains(opts.InternalServices, state.GitKey)
+		if gitInternal || opts.GitServer.Address != "" {
 			if err := opts.GitServer.FillInEmptyValues(); err != nil {
 				return nil, err
 			}
 			s.GitServer = opts.GitServer
 		}
-		if slices.Contains(opts.Services, state.RegistryKey) {
+		registryInternal := slices.Contains(opts.InternalServices, state.RegistryKey)
+		if registryInternal || opts.RegistryInfo.Address != "" {
 			if err := opts.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
 				return nil, err
 			}
 			s.RegistryInfo = opts.RegistryInfo
 		}
-		if slices.Contains(opts.Services, state.ArtifactKey) {
+		artifactInternal := slices.Contains(opts.InternalServices, state.ArtifactKey)
+		if artifactInternal || opts.ArtifactServer.Address != "" {
 			opts.ArtifactServer.FillInEmptyValues()
 			s.ArtifactServer = opts.ArtifactServer
 		}
 	} else {
-		// Re-init: fill defaults for services that are now being added but were absent before.
-		if slices.Contains(opts.Services, state.GitKey) && s.GitServer.Address == "" {
-			merged := s.GitServer
-			if opts.GitServer.Address != "" {
-				merged = opts.GitServer
-			}
-			if err := merged.FillInEmptyValues(); err != nil {
+		// Re-init: fill defaults only for internal services that weren't configured
+		// on a prior init. External services are managed via `zarf tools update-creds`.
+		if slices.Contains(opts.InternalServices, state.GitKey) && s.GitServer.Address == "" {
+			if err := s.GitServer.FillInEmptyValues(); err != nil {
 				return nil, err
 			}
-			s.GitServer = merged
 		}
-		if slices.Contains(opts.Services, state.ArtifactKey) && s.ArtifactServer.Address == "" {
-			merged := s.ArtifactServer
-			if opts.ArtifactServer.Address != "" {
-				merged = opts.ArtifactServer
-			}
-			merged.FillInEmptyValues()
-			s.ArtifactServer = merged
+		if slices.Contains(opts.InternalServices, state.ArtifactKey) && s.ArtifactServer.Address == "" {
+			s.ArtifactServer.FillInEmptyValues()
 		}
-		if slices.Contains(opts.Services, state.RegistryKey) && s.RegistryInfo.Address == "" {
-			merged := s.RegistryInfo
-			if opts.RegistryInfo.Address != "" {
-				merged = opts.RegistryInfo
-			}
-			if err := merged.FillInEmptyValues(ipFamily); err != nil {
+		if slices.Contains(opts.InternalServices, state.RegistryKey) && s.RegistryInfo.Address == "" {
+			if err := s.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
 				return nil, err
 			}
-			s.RegistryInfo = merged
 		}
 	}
 
 	s.IPFamily = ipFamily
 
-	// Registry-mode reconciliation only applies when the registry service is being managed.
-	if slices.Contains(opts.Services, state.RegistryKey) {
+	// Registry-mode reconciliation only applies to internally deployed registries.
+	if slices.Contains(opts.InternalServices, state.RegistryKey) {
 		previousMode := s.RegistryInfo.RegistryMode
 		if opts.RegistryInfo.RegistryMode != "" {
 			s.RegistryInfo.RegistryMode = opts.RegistryInfo.RegistryMode

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -175,6 +175,10 @@ type InitStateOptions struct {
 	InjectorPort int
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
+	// Services lists the state keys (state.RegistryKey, GitKey, ArtifactKey, AgentKey)
+	// that this init run is responsible for populating. Services not listed keep
+	// their zero values so state.IsConfigured checks reflect reality.
+	Services []string
 }
 
 // InitState takes initOptions and hydrates a cluster's state from InitStateOptions.
@@ -230,16 +234,18 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 			l.Debug("Detected K8s distro", "name", s.Distro)
 		}
 
-		// Setup zarf agent PKI
-		if opts.AgentTLS != nil {
-			s.AgentTLS = *opts.AgentTLS
-			s.AgentTLSUserProvided = true
-		} else {
-			agentTLS, err := pki.GeneratePKI(state.ZarfAgentHost)
-			if err != nil {
-				return nil, err
+		// Setup zarf agent PKI when the agent is being deployed
+		if slices.Contains(opts.Services, state.AgentKey) {
+			if opts.AgentTLS != nil {
+				s.AgentTLS = *opts.AgentTLS
+				s.AgentTLSUserProvided = true
+			} else {
+				agentTLS, err := pki.GeneratePKI(state.ZarfAgentHost)
+				if err != nil {
+					return nil, err
+				}
+				s.AgentTLS = agentTLS
 			}
-			s.AgentTLS = agentTLS
 		}
 
 		namespaceList, err := c.Clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
@@ -282,59 +288,96 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 			return nil, fmt.Errorf("unable get default Zarf service account: %w", err)
 		}
 
-		err = opts.GitServer.FillInEmptyValues()
-		if err != nil {
-			return nil, err
+		if slices.Contains(opts.Services, state.GitKey) {
+			if err := opts.GitServer.FillInEmptyValues(); err != nil {
+				return nil, err
+			}
+			s.GitServer = opts.GitServer
 		}
-		s.GitServer = opts.GitServer
-		err = opts.RegistryInfo.FillInEmptyValues(ipFamily)
-		if err != nil {
-			return nil, err
+		if slices.Contains(opts.Services, state.RegistryKey) {
+			if err := opts.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
+				return nil, err
+			}
+			s.RegistryInfo = opts.RegistryInfo
 		}
-		s.RegistryInfo = opts.RegistryInfo
-		opts.ArtifactServer.FillInEmptyValues()
-		s.ArtifactServer = opts.ArtifactServer
+		if slices.Contains(opts.Services, state.ArtifactKey) {
+			opts.ArtifactServer.FillInEmptyValues()
+			s.ArtifactServer = opts.ArtifactServer
+		}
+	} else {
+		// Re-init: fill defaults for services that are now being added but were absent before.
+		if slices.Contains(opts.Services, state.GitKey) && s.GitServer.Address == "" {
+			merged := s.GitServer
+			if opts.GitServer.Address != "" {
+				merged = opts.GitServer
+			}
+			if err := merged.FillInEmptyValues(); err != nil {
+				return nil, err
+			}
+			s.GitServer = merged
+		}
+		if slices.Contains(opts.Services, state.ArtifactKey) && s.ArtifactServer.Address == "" {
+			merged := s.ArtifactServer
+			if opts.ArtifactServer.Address != "" {
+				merged = opts.ArtifactServer
+			}
+			merged.FillInEmptyValues()
+			s.ArtifactServer = merged
+		}
+		if slices.Contains(opts.Services, state.RegistryKey) && s.RegistryInfo.Address == "" {
+			merged := s.RegistryInfo
+			if opts.RegistryInfo.Address != "" {
+				merged = opts.RegistryInfo
+			}
+			if err := merged.FillInEmptyValues(ipFamily); err != nil {
+				return nil, err
+			}
+			s.RegistryInfo = merged
+		}
 	}
 
 	s.IPFamily = ipFamily
 
-	previousMode := s.RegistryInfo.RegistryMode
-	if opts.RegistryInfo.RegistryMode != "" {
-		s.RegistryInfo.RegistryMode = opts.RegistryInfo.RegistryMode
-	}
-	modeChanged := opts.RegistryInfo.RegistryMode != "" && opts.RegistryInfo.RegistryMode != previousMode
-
-	// If the registry mode is changing the injector will be re-made so the port should be reset
-	if modeChanged {
-		s.InjectorInfo.Port = 0
-	}
-
-	switch s.RegistryInfo.RegistryMode {
-	case state.RegistryModeNodePort:
-		switch {
-		case opts.RegistryInfo.Port != 0:
-			s.RegistryInfo.Port = opts.RegistryInfo.Port
-		case modeChanged:
-			s.RegistryInfo.Port = state.ZarfInClusterContainerRegistryNodePort
+	// Registry-mode reconciliation only applies when the registry service is being managed.
+	if slices.Contains(opts.Services, state.RegistryKey) {
+		previousMode := s.RegistryInfo.RegistryMode
+		if opts.RegistryInfo.RegistryMode != "" {
+			s.RegistryInfo.RegistryMode = opts.RegistryInfo.RegistryMode
 		}
-		s.RegistryInfo.MTLSStrategy = state.MTLSStrategyNone
-		s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
-	case state.RegistryModeProxy:
-		switch {
-		case opts.RegistryInfo.Port != 0:
-			s.RegistryInfo.Port = opts.RegistryInfo.Port
-		case modeChanged:
-			s.RegistryInfo.Port = state.ZarfRegistryHostPort
-		}
-		s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
-	}
+		modeChanged := opts.RegistryInfo.RegistryMode != "" && opts.RegistryInfo.RegistryMode != previousMode
 
-	if opts.RegistryInfo.RegistryMode == state.RegistryModeProxy {
-		err = c.InitRegistryCerts(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate certs: %w", err)
+		// If the registry mode is changing the injector will be re-made so the port should be reset
+		if modeChanged {
+			s.InjectorInfo.Port = 0
 		}
-		s.RegistryInfo.MTLSStrategy = state.MTLSStrategyZarfManaged
+
+		switch s.RegistryInfo.RegistryMode {
+		case state.RegistryModeNodePort:
+			switch {
+			case opts.RegistryInfo.Port != 0:
+				s.RegistryInfo.Port = opts.RegistryInfo.Port
+			case modeChanged:
+				s.RegistryInfo.Port = state.ZarfInClusterContainerRegistryNodePort
+			}
+			s.RegistryInfo.MTLSStrategy = state.MTLSStrategyNone
+			s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
+		case state.RegistryModeProxy:
+			switch {
+			case opts.RegistryInfo.Port != 0:
+				s.RegistryInfo.Port = opts.RegistryInfo.Port
+			case modeChanged:
+				s.RegistryInfo.Port = state.ZarfRegistryHostPort
+			}
+			s.RegistryInfo.Address = state.LocalhostRegistryAddress(ipFamily, s.RegistryInfo.Port)
+		}
+
+		if opts.RegistryInfo.RegistryMode == state.RegistryModeProxy {
+			err = c.InitRegistryCerts(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate certs: %w", err)
+			}
+			s.RegistryInfo.MTLSStrategy = state.MTLSStrategyZarfManaged
+		}
 	}
 
 	switch s.Distro {

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -310,15 +310,15 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 	} else {
 		// Re-init: fill defaults only for internal services that weren't configured
 		// on a prior init. External services are managed via `zarf tools update-creds`.
-		if slices.Contains(opts.InternalServices, state.GitKey) && s.GitServer.Address == "" {
+		if slices.Contains(opts.InternalServices, state.GitKey) && !s.GitServer.IsConfigured() {
 			if err := s.GitServer.FillInEmptyValues(); err != nil {
 				return nil, err
 			}
 		}
-		if slices.Contains(opts.InternalServices, state.ArtifactKey) && s.ArtifactServer.Address == "" {
+		if slices.Contains(opts.InternalServices, state.ArtifactKey) && !s.ArtifactServer.IsConfigured() {
 			s.ArtifactServer.FillInEmptyValues()
 		}
-		if slices.Contains(opts.InternalServices, state.RegistryKey) && s.RegistryInfo.Address == "" {
+		if slices.Contains(opts.InternalServices, state.RegistryKey) && !s.RegistryInfo.IsConfigured() {
 			if err := s.RegistryInfo.FillInEmptyValues(ipFamily); err != nil {
 				return nil, err
 			}

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -654,4 +654,31 @@ func TestInitStateServicesGating(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "keep-me", s.GitServer.PushPassword)
 	})
+
+	t.Run("re-init propagates RegistryMode when registry is not in InternalServices", func(t *testing.T) {
+		ctx := context.Background()
+		existing := &state.State{
+			Distro: DistroIsK3d,
+			RegistryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:31999",
+				Port:         31999,
+				RegistryMode: state.RegistryModeNodePort,
+				PushUsername: "push-user",
+				PullUsername: "pull-user",
+				Secret:       "secret",
+			},
+			InjectorInfo: state.InjectorInfo{Port: 31999},
+		}
+		c := newFakeInitStateCluster(ctx, t, existing)
+		s, err := c.InitState(ctx, InitStateOptions{
+			InternalServices: []state.ServiceKey{state.AgentKey},
+			RegistryInfo: state.RegistryInfo{
+				RegistryMode: state.RegistryModeExternal,
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, state.RegistryModeExternal, s.RegistryInfo.RegistryMode)
+		require.False(t, s.RegistryInfo.IsInternal())
+		require.Equal(t, 0, s.InjectorInfo.Port, "injector port must reset when mode changes")
+	})
 }

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -497,7 +497,7 @@ func TestInitStateRegistryModeSwitch(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			tt.opts.InternalServices = []state.ServiceKey{state.RegistryKey}
+			tt.opts.InternalServices = state.NewServiceSet(state.RegistryKey)
 			result, err := c.InitState(ctx, tt.opts)
 			require.NoError(t, err)
 
@@ -555,7 +555,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.RegistryKey, state.AgentKey},
+			InternalServices: state.NewServiceSet(state.RegistryKey, state.AgentKey),
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.GitServer.Address)
@@ -570,7 +570,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.RegistryKey},
+			InternalServices: state.NewServiceSet(state.RegistryKey),
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.AgentTLS.Cert)
@@ -581,7 +581,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
+			InternalServices: state.NewServiceSet(state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey),
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
@@ -605,7 +605,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.GitKey, state.ArtifactKey},
+			InternalServices: state.NewServiceSet(state.GitKey, state.ArtifactKey),
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
@@ -617,7 +617,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.RegistryKey, state.AgentKey},
+			InternalServices: state.NewServiceSet(state.RegistryKey, state.AgentKey),
 			GitServer: state.GitServerInfo{
 				Address:      "https://git.example.com",
 				PushUsername: "pusher",
@@ -649,7 +649,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.RegistryKey},
+			InternalServices: state.NewServiceSet(state.RegistryKey),
 		})
 		require.NoError(t, err)
 		require.Equal(t, "keep-me", s.GitServer.PushPassword)
@@ -671,7 +671,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []state.ServiceKey{state.AgentKey},
+			InternalServices: state.NewServiceSet(state.AgentKey),
 			RegistryInfo: state.RegistryInfo{
 				RegistryMode: state.RegistryModeExternal,
 			},

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -497,7 +497,7 @@ func TestInitStateRegistryModeSwitch(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			tt.opts.Services = []string{state.RegistryKey}
+			tt.opts.InternalServices = []string{state.RegistryKey}
 			result, err := c.InitState(ctx, tt.opts)
 			require.NoError(t, err)
 
@@ -555,7 +555,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			Services: []string{state.RegistryKey, state.AgentKey},
+			InternalServices: []string{state.RegistryKey, state.AgentKey},
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.GitServer.Address)
@@ -570,7 +570,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			Services: []string{state.RegistryKey},
+			InternalServices: []string{state.RegistryKey},
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.AgentTLS.Cert)
@@ -581,7 +581,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			Services: []string{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
+			InternalServices: []string{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
@@ -605,12 +605,28 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			Services: []string{state.GitKey, state.ArtifactKey},
+			InternalServices: []string{state.GitKey, state.ArtifactKey},
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
 		require.Equal(t, "127.0.0.1:31999", s.RegistryInfo.Address)
 		require.NotEmpty(t, s.ArtifactServer.Address)
+	})
+
+	t.Run("new cluster with external git URL persists without being in InternalServices", func(t *testing.T) {
+		ctx := context.Background()
+		c := newFakeInitStateCluster(ctx, t, nil)
+		s, err := c.InitState(ctx, InitStateOptions{
+			InternalServices: []string{state.RegistryKey, state.AgentKey},
+			GitServer: state.GitServerInfo{
+				Address:      "https://git.example.com",
+				PushUsername: "pusher",
+				PushPassword: "pass",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "https://git.example.com", s.GitServer.Address)
+		require.False(t, s.GitServer.IsInternal())
 	})
 
 	t.Run("re-init does not wipe services not listed", func(t *testing.T) {
@@ -633,7 +649,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			Services: []string{state.RegistryKey},
+			InternalServices: []string{state.RegistryKey},
 		})
 		require.NoError(t, err)
 		require.Equal(t, "keep-me", s.GitServer.PushPassword)

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -497,7 +497,7 @@ func TestInitStateRegistryModeSwitch(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			tt.opts.InternalServices = []string{state.RegistryKey}
+			tt.opts.InternalServices = []state.ServiceKey{state.RegistryKey}
 			result, err := c.InitState(ctx, tt.opts)
 			require.NoError(t, err)
 
@@ -555,7 +555,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.RegistryKey, state.AgentKey},
+			InternalServices: []state.ServiceKey{state.RegistryKey, state.AgentKey},
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.GitServer.Address)
@@ -570,7 +570,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.RegistryKey},
+			InternalServices: []state.ServiceKey{state.RegistryKey},
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.AgentTLS.Cert)
@@ -581,7 +581,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
+			InternalServices: []state.ServiceKey{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
@@ -605,7 +605,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.GitKey, state.ArtifactKey},
+			InternalServices: []state.ServiceKey{state.GitKey, state.ArtifactKey},
 		})
 		require.NoError(t, err)
 		require.True(t, s.GitServer.IsConfigured())
@@ -617,7 +617,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.RegistryKey, state.AgentKey},
+			InternalServices: []state.ServiceKey{state.RegistryKey, state.AgentKey},
 			GitServer: state.GitServerInfo{
 				Address:      "https://git.example.com",
 				PushUsername: "pusher",
@@ -649,7 +649,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		}
 		c := newFakeInitStateCluster(ctx, t, existing)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: []string{state.RegistryKey},
+			InternalServices: []state.ServiceKey{state.RegistryKey},
 		})
 		require.NoError(t, err)
 		require.Equal(t, "keep-me", s.GitServer.PushPassword)

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -497,6 +497,7 @@ func TestInitStateRegistryModeSwitch(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
+			tt.opts.Services = []string{state.RegistryKey}
 			result, err := c.InitState(ctx, tt.opts)
 			require.NoError(t, err)
 
@@ -509,4 +510,132 @@ func TestInitStateRegistryModeSwitch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newFakeInitStateCluster(ctx context.Context, t *testing.T, existing *state.State) *Cluster {
+	t.Helper()
+	cs := fake.NewClientset()
+	c := &Cluster{
+		Clientset: cs,
+		Watcher:   healthchecks.NewImmediateWatcher(status.CurrentStatus),
+	}
+
+	_, err := cs.CoreV1().Nodes().Create(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}},
+		metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: state.ZarfNamespaceName}},
+		metav1.CreateOptions{})
+	require.NoError(t, err)
+	if existing != nil {
+		data, err := json.Marshal(existing)
+		require.NoError(t, err)
+		_, err = cs.CoreV1().Secrets(state.ZarfNamespaceName).Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: state.ZarfNamespaceName, Name: state.ZarfStateSecretName},
+			Data:       map[string][]byte{state.ZarfStateDataKey: data},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	_, err = cs.CoreV1().Services(state.ZarfNamespaceName).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "zarf-ip-family-test", Namespace: state.ZarfNamespaceName},
+		Spec:       corev1.ServiceSpec{IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	if existing == nil {
+		_, err = cs.CoreV1().ServiceAccounts(state.ZarfNamespaceName).Create(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Namespace: state.ZarfNamespaceName, Name: "default"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	return c
+}
+
+func TestInitStateServicesGating(t *testing.T) {
+	t.Run("new cluster without git service leaves git and artifact empty", func(t *testing.T) {
+		ctx := context.Background()
+		c := newFakeInitStateCluster(ctx, t, nil)
+		s, err := c.InitState(ctx, InitStateOptions{
+			Services: []string{state.RegistryKey, state.AgentKey},
+		})
+		require.NoError(t, err)
+		require.Empty(t, s.GitServer.Address)
+		require.Empty(t, s.GitServer.PushPassword)
+		require.Empty(t, s.ArtifactServer.Address)
+		require.False(t, s.GitServer.IsConfigured())
+		require.NotEmpty(t, s.RegistryInfo.Address)
+		require.NotEmpty(t, s.AgentTLS.Cert)
+	})
+
+	t.Run("new cluster without agent service leaves agent TLS empty", func(t *testing.T) {
+		ctx := context.Background()
+		c := newFakeInitStateCluster(ctx, t, nil)
+		s, err := c.InitState(ctx, InitStateOptions{
+			Services: []string{state.RegistryKey},
+		})
+		require.NoError(t, err)
+		require.Empty(t, s.AgentTLS.Cert)
+		require.False(t, s.AgentTLSUserProvided)
+	})
+
+	t.Run("new cluster with all services populates everything", func(t *testing.T) {
+		ctx := context.Background()
+		c := newFakeInitStateCluster(ctx, t, nil)
+		s, err := c.InitState(ctx, InitStateOptions{
+			Services: []string{state.RegistryKey, state.GitKey, state.ArtifactKey, state.AgentKey},
+		})
+		require.NoError(t, err)
+		require.True(t, s.GitServer.IsConfigured())
+		require.True(t, s.ArtifactServer.IsInternal())
+		require.NotEmpty(t, s.RegistryInfo.Address)
+		require.NotEmpty(t, s.AgentTLS.Cert)
+	})
+
+	t.Run("re-init adds a missing git service without overwriting existing registry", func(t *testing.T) {
+		ctx := context.Background()
+		existing := &state.State{
+			Distro: DistroIsK3d,
+			RegistryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:31999",
+				Port:         31999,
+				RegistryMode: state.RegistryModeNodePort,
+				PushUsername: "push-user",
+				PullUsername: "pull-user",
+				Secret:       "secret",
+			},
+		}
+		c := newFakeInitStateCluster(ctx, t, existing)
+		s, err := c.InitState(ctx, InitStateOptions{
+			Services: []string{state.GitKey, state.ArtifactKey},
+		})
+		require.NoError(t, err)
+		require.True(t, s.GitServer.IsConfigured())
+		require.Equal(t, "127.0.0.1:31999", s.RegistryInfo.Address)
+		require.NotEmpty(t, s.ArtifactServer.Address)
+	})
+
+	t.Run("re-init does not wipe services not listed", func(t *testing.T) {
+		ctx := context.Background()
+		existing := &state.State{
+			Distro: DistroIsK3d,
+			GitServer: state.GitServerInfo{
+				Address:      state.ZarfInClusterGitServiceURL,
+				PushUsername: "zarf-git-user",
+				PushPassword: "keep-me",
+			},
+			RegistryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:31999",
+				Port:         31999,
+				RegistryMode: state.RegistryModeNodePort,
+				PushUsername: "push-user",
+				PullUsername: "pull-user",
+				Secret:       "secret",
+			},
+		}
+		c := newFakeInitStateCluster(ctx, t, existing)
+		s, err := c.InitState(ctx, InitStateOptions{
+			Services: []string{state.RegistryKey},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "keep-me", s.GitServer.PushPassword)
+	})
 }

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -321,25 +321,20 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 }
 
 // internalServicesFor returns the state services Zarf will deploy internally in this init run.
-func internalServicesFor(components []v1alpha1.ZarfComponent, opts DeployOptions) []state.ServiceKey {
-	var services []state.ServiceKey
-	add := func(k state.ServiceKey) {
-		if !slices.Contains(services, k) {
-			services = append(services, k)
-		}
-	}
+func internalServicesFor(components []v1alpha1.ZarfComponent, opts DeployOptions) state.ServiceSet {
+	services := state.NewServiceSet()
 	registryExternal := opts.RegistryInfo.Address != ""
 	for _, c := range components {
 		switch c.Name {
 		case "git-server":
-			add(state.GitKey)
-			add(state.ArtifactKey)
+			services.Add(state.GitKey)
+			services.Add(state.ArtifactKey)
 		case "zarf-registry", "zarf-seed-registry", "zarf-injector":
 			if !registryExternal {
-				add(state.RegistryKey)
+				services.Add(state.RegistryKey)
 			}
 		case "zarf-agent":
-			add(state.AgentKey)
+			services.Add(state.AgentKey)
 		}
 	}
 	return services

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -335,6 +335,17 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 				applianceMode = true
 			}
 		}
+		services := state.ServicesForInitComponents(pkgLayout.Pkg.Components)
+		// Externally-supplied endpoints imply the service is in use even without the matching component.
+		if opts.GitServer.Address != "" && !slices.Contains(services, state.GitKey) {
+			services = append(services, state.GitKey)
+		}
+		if opts.RegistryInfo.Address != "" && !slices.Contains(services, state.RegistryKey) {
+			services = append(services, state.RegistryKey)
+		}
+		if opts.ArtifactServer.Address != "" && !slices.Contains(services, state.ArtifactKey) {
+			services = append(services, state.ArtifactKey)
+		}
 		var err error
 		d.s, err = d.c.InitState(ctx, cluster.InitStateOptions{
 			GitServer:      opts.GitServer,
@@ -344,6 +355,7 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 			StorageClass:   opts.StorageClass,
 			InjectorPort:   opts.InjectorPort,
 			AgentTLS:       opts.AgentTLS,
+			Services:       services,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize Zarf state: %w", err)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -335,27 +335,16 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 				applianceMode = true
 			}
 		}
-		services := state.ServicesForInitComponents(pkgLayout.Pkg.Components)
-		// Externally-supplied endpoints imply the service is in use even without the matching component.
-		if opts.GitServer.Address != "" && !slices.Contains(services, state.GitKey) {
-			services = append(services, state.GitKey)
-		}
-		if opts.RegistryInfo.Address != "" && !slices.Contains(services, state.RegistryKey) {
-			services = append(services, state.RegistryKey)
-		}
-		if opts.ArtifactServer.Address != "" && !slices.Contains(services, state.ArtifactKey) {
-			services = append(services, state.ArtifactKey)
-		}
 		var err error
 		d.s, err = d.c.InitState(ctx, cluster.InitStateOptions{
-			GitServer:      opts.GitServer,
-			RegistryInfo:   opts.RegistryInfo,
-			ArtifactServer: opts.ArtifactServer,
-			ApplianceMode:  applianceMode,
-			StorageClass:   opts.StorageClass,
-			InjectorPort:   opts.InjectorPort,
-			AgentTLS:       opts.AgentTLS,
-			Services:       services,
+			GitServer:        opts.GitServer,
+			RegistryInfo:     opts.RegistryInfo,
+			ArtifactServer:   opts.ArtifactServer,
+			ApplianceMode:    applianceMode,
+			StorageClass:     opts.StorageClass,
+			InjectorPort:     opts.InjectorPort,
+			AgentTLS:         opts.AgentTLS,
+			InternalServices: state.ServicesForInitComponents(pkgLayout.Pkg.Components),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize Zarf state: %w", err)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -320,6 +320,31 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 	return deployedComponents, nil
 }
 
+// internalServicesFor returns the state services Zarf will deploy internally in this init run.
+func internalServicesFor(components []v1alpha1.ZarfComponent, opts DeployOptions) []state.ServiceKey {
+	var services []state.ServiceKey
+	add := func(k state.ServiceKey) {
+		if !slices.Contains(services, k) {
+			services = append(services, k)
+		}
+	}
+	registryExternal := opts.RegistryInfo.Address != ""
+	for _, c := range components {
+		switch c.Name {
+		case "git-server":
+			add(state.GitKey)
+			add(state.ArtifactKey)
+		case "zarf-registry", "zarf-seed-registry", "zarf-injector":
+			if !registryExternal {
+				add(state.RegistryKey)
+			}
+		case "zarf-agent":
+			add(state.AgentKey)
+		}
+	}
+	return services
+}
+
 func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.PackageLayout, component v1alpha1.ZarfComponent, opts DeployOptions) ([]state.InstalledChart, error) {
 	l := logger.From(ctx)
 	isSeedRegistry := component.Name == "zarf-seed-registry"
@@ -344,7 +369,7 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 			StorageClass:     opts.StorageClass,
 			InjectorPort:     opts.InjectorPort,
 			AgentTLS:         opts.AgentTLS,
-			InternalServices: state.ServicesForInitComponents(pkgLayout.Pkg.Components),
+			InternalServices: internalServicesFor(pkgLayout.Pkg.Components, opts),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize Zarf state: %w", err)

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/state"
+)
+
+func TestInternalServicesFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		components []v1alpha1.ZarfComponent
+		opts       DeployOptions
+		expected   []state.ServiceKey
+	}{
+		{
+			name:       "no components",
+			components: nil,
+			expected:   nil,
+		},
+		{
+			name: "full init package with no external URLs populates all four",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "k3s"},
+				{Name: "zarf-injector"},
+				{Name: "zarf-seed-registry"},
+				{Name: "zarf-registry"},
+				{Name: "zarf-agent"},
+				{Name: "git-server"},
+			},
+			expected: []state.ServiceKey{state.RegistryKey, state.AgentKey, state.GitKey, state.ArtifactKey},
+		},
+		{
+			name: "external registry URL drops registry key even though registry components are present",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "zarf-injector"},
+				{Name: "zarf-seed-registry"},
+				{Name: "zarf-registry"},
+				{Name: "zarf-agent"},
+				{Name: "git-server"},
+			},
+			opts: DeployOptions{
+				RegistryInfo: state.RegistryInfo{Address: "https://registry.example.com"},
+			},
+			expected: []state.ServiceKey{state.AgentKey, state.GitKey, state.ArtifactKey},
+		},
+		{
+			name: "external git URL does not drop git or artifact keys — git-server deploys regardless",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "zarf-registry"},
+				{Name: "git-server"},
+			},
+			opts: DeployOptions{
+				GitServer:      state.GitServerInfo{Address: "https://git.example.com"},
+				ArtifactServer: state.ArtifactServerInfo{Address: "https://artifact.example.com"},
+			},
+			expected: []state.ServiceKey{state.RegistryKey, state.GitKey, state.ArtifactKey},
+		},
+		{
+			name: "registry components dedupe to registry key",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "zarf-injector"},
+				{Name: "zarf-seed-registry"},
+				{Name: "zarf-registry"},
+			},
+			expected: []state.ServiceKey{state.RegistryKey},
+		},
+		{
+			name: "unknown components ignored",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "k3s"},
+				{Name: "some-custom-component"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := internalServicesFor(tt.components, tt.opts)
+			require.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -18,12 +18,12 @@ func TestInternalServicesFor(t *testing.T) {
 		name       string
 		components []v1alpha1.ZarfComponent
 		opts       DeployOptions
-		expected   []state.ServiceKey
+		expected   state.ServiceSet
 	}{
 		{
 			name:       "no components",
 			components: nil,
-			expected:   nil,
+			expected:   state.NewServiceSet(),
 		},
 		{
 			name: "full init package with no external URLs populates all four",
@@ -35,7 +35,7 @@ func TestInternalServicesFor(t *testing.T) {
 				{Name: "zarf-agent"},
 				{Name: "git-server"},
 			},
-			expected: []state.ServiceKey{state.RegistryKey, state.AgentKey, state.GitKey, state.ArtifactKey},
+			expected: state.NewServiceSet(state.RegistryKey, state.AgentKey, state.GitKey, state.ArtifactKey),
 		},
 		{
 			name: "external registry URL drops registry key even though registry components are present",
@@ -49,7 +49,7 @@ func TestInternalServicesFor(t *testing.T) {
 			opts: DeployOptions{
 				RegistryInfo: state.RegistryInfo{Address: "https://registry.example.com"},
 			},
-			expected: []state.ServiceKey{state.AgentKey, state.GitKey, state.ArtifactKey},
+			expected: state.NewServiceSet(state.AgentKey, state.GitKey, state.ArtifactKey),
 		},
 		{
 			name: "external git URL does not drop git or artifact keys — git-server deploys regardless",
@@ -61,7 +61,7 @@ func TestInternalServicesFor(t *testing.T) {
 				GitServer:      state.GitServerInfo{Address: "https://git.example.com"},
 				ArtifactServer: state.ArtifactServerInfo{Address: "https://artifact.example.com"},
 			},
-			expected: []state.ServiceKey{state.RegistryKey, state.GitKey, state.ArtifactKey},
+			expected: state.NewServiceSet(state.RegistryKey, state.GitKey, state.ArtifactKey),
 		},
 		{
 			name: "registry components dedupe to registry key",
@@ -70,7 +70,7 @@ func TestInternalServicesFor(t *testing.T) {
 				{Name: "zarf-seed-registry"},
 				{Name: "zarf-registry"},
 			},
-			expected: []state.ServiceKey{state.RegistryKey},
+			expected: state.NewServiceSet(state.RegistryKey),
 		},
 		{
 			name: "unknown components ignored",
@@ -78,7 +78,7 @@ func TestInternalServicesFor(t *testing.T) {
 				{Name: "k3s"},
 				{Name: "some-custom-component"},
 			},
-			expected: nil,
+			expected: state.NewServiceSet(),
 		},
 	}
 
@@ -86,7 +86,7 @@ func TestInternalServicesFor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := internalServicesFor(tt.components, tt.opts)
-			require.ElementsMatch(t, tt.expected, got)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -40,16 +40,18 @@ const (
 )
 
 // AllServiceKeys is the canonical ordered list of every supported service key.
-var AllServiceKeys = []ServiceKey{RegistryKey, GitKey, ArtifactKey, AgentKey}
+func AllServiceKeys() []ServiceKey {
+	return []ServiceKey{RegistryKey, GitKey, ArtifactKey, AgentKey}
+}
 
 // ParseServiceKey returns the ServiceKey matching s, or an error if s is not recognized.
 func ParseServiceKey(s string) (ServiceKey, error) {
-	for _, k := range AllServiceKeys {
+	for _, k := range AllServiceKeys() {
 		if string(k) == s {
 			return k, nil
 		}
 	}
-	return "", fmt.Errorf("invalid service key %q, valid keys are: %v", s, AllServiceKeys)
+	return "", fmt.Errorf("invalid service key %q, valid keys are: %v", s, AllServiceKeys())
 }
 
 // ComponentStatus defines the deployment status of a Zarf component within a package.

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -171,9 +171,7 @@ func (gs GitServerInfo) IsInternal() bool {
 }
 
 // IsConfigured returns true if the git server address has been set.
-// New clusters only populate the address when the git-server component (or an
-// external --git-url) was supplied, so this reflects whether a git server is
-// actually in use. Legacy clusters initialized before services-gated state
+// clusters initialized before services-gated state https://github.com/zarf-dev/zarf/pull/4832
 // may report true even without a real git server.
 func (gs GitServerInfo) IsConfigured() bool {
 	return gs.Address != ""

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -234,6 +234,11 @@ func (as ArtifactServerInfo) IsInternal() bool {
 	return as.Address == ZarfInClusterArtifactServiceURL
 }
 
+// IsConfigured returns true if the artifact server address has been set.
+func (as ArtifactServerInfo) IsConfigured() bool {
+	return as.Address != ""
+}
+
 // FillInEmptyValues sets every necessary value that's currently empty to a reasonable default
 func (as *ArtifactServerInfo) FillInEmptyValues() {
 	// Set default svc url if an external registry was not provided

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -52,30 +52,6 @@ func ParseServiceKey(s string) (ServiceKey, error) {
 	return "", fmt.Errorf("invalid service key %q, valid keys are: %v", s, AllServiceKeys)
 }
 
-// ServicesForInitComponents returns the state service keys corresponding to the
-// selected init-package components. Callers should pass the deploy-filtered
-// component set so absent components stay absent from state.
-func ServicesForInitComponents(components []v1alpha1.ZarfComponent) []ServiceKey {
-	var services []ServiceKey
-	add := func(k ServiceKey) {
-		if !slices.Contains(services, k) {
-			services = append(services, k)
-		}
-	}
-	for _, c := range components {
-		switch c.Name {
-		case "git-server":
-			add(GitKey)
-			add(ArtifactKey)
-		case "zarf-registry", "zarf-seed-registry", "zarf-injector":
-			add(RegistryKey)
-		case "zarf-agent":
-			add(AgentKey)
-		}
-	}
-	return services
-}
-
 // ComponentStatus defines the deployment status of a Zarf component within a package.
 type ComponentStatus string
 

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"slices"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -42,6 +41,29 @@ const (
 // AllServiceKeys is the canonical ordered list of every supported service key.
 func AllServiceKeys() []ServiceKey {
 	return []ServiceKey{RegistryKey, GitKey, ArtifactKey, AgentKey}
+}
+
+// ServiceSet is an unordered set of ServiceKeys.
+type ServiceSet map[ServiceKey]struct{}
+
+// NewServiceSet returns a ServiceSet populated with the given keys.
+func NewServiceSet(keys ...ServiceKey) ServiceSet {
+	s := make(ServiceSet, len(keys))
+	for _, k := range keys {
+		s[k] = struct{}{}
+	}
+	return s
+}
+
+// Has reports whether k is in the set.
+func (s ServiceSet) Has(k ServiceKey) bool {
+	_, ok := s[k]
+	return ok
+}
+
+// Add inserts k into the set.
+func (s ServiceSet) Add(k ServiceKey) {
+	s[k] = struct{}{}
 }
 
 // ParseServiceKey returns the ServiceKey matching s, or an error if s is not recognized.
@@ -445,7 +467,7 @@ type MergeOptions struct {
 	GitServer      GitServerInfo
 	RegistryInfo   RegistryInfo
 	ArtifactServer ArtifactServerInfo
-	Services       []ServiceKey
+	Services       ServiceSet
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
 }
@@ -454,7 +476,7 @@ type MergeOptions struct {
 func Merge(oldState *State, opts MergeOptions) (*State, error) {
 	newState := *oldState
 	var err error
-	if slices.Contains(opts.Services, RegistryKey) {
+	if opts.Services.Has(RegistryKey) {
 		// TODO: Replace use of reflections with explicit setting
 		newState.RegistryInfo = helpers.MergeNonZero(newState.RegistryInfo, opts.RegistryInfo)
 
@@ -470,7 +492,7 @@ func Merge(oldState *State, opts MergeOptions) (*State, error) {
 			}
 		}
 	}
-	if slices.Contains(opts.Services, GitKey) {
+	if opts.Services.Has(GitKey) {
 		// TODO: Replace use of reflections with explicit setting
 		newState.GitServer = helpers.MergeNonZero(newState.GitServer, opts.GitServer)
 
@@ -486,7 +508,7 @@ func Merge(oldState *State, opts MergeOptions) (*State, error) {
 			}
 		}
 	}
-	if slices.Contains(opts.Services, ArtifactKey) {
+	if opts.Services.Has(ArtifactKey) {
 		// TODO: Replace use of reflections with explicit setting
 		newState.ArtifactServer = helpers.MergeNonZero(newState.ArtifactServer, opts.ArtifactServer)
 
@@ -495,7 +517,7 @@ func Merge(oldState *State, opts MergeOptions) (*State, error) {
 			newState.ArtifactServer.PushToken = ""
 		}
 	}
-	if slices.Contains(opts.Services, AgentKey) {
+	if opts.Services.Has(AgentKey) {
 		if opts.AgentTLS != nil {
 			newState.AgentTLS = *opts.AgentTLS
 			newState.AgentTLSUserProvided = true

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -28,21 +28,36 @@ const (
 	ZarfPackageInfoLabel = "package-deploy-info"
 )
 
+// ServiceKey identifies a Zarf-managed service in state (registry, git, artifact, agent).
+type ServiceKey string
+
 // Credential keys
-// TODO(mkcp): Provide semantic doccomments for how these are used.
 const (
-	RegistryKey = "registry"
-	GitKey      = "git"
-	ArtifactKey = "artifact"
-	AgentKey    = "agent"
+	RegistryKey ServiceKey = "registry"
+	GitKey      ServiceKey = "git"
+	ArtifactKey ServiceKey = "artifact"
+	AgentKey    ServiceKey = "agent"
 )
+
+// AllServiceKeys is the canonical ordered list of every supported service key.
+var AllServiceKeys = []ServiceKey{RegistryKey, GitKey, ArtifactKey, AgentKey}
+
+// ParseServiceKey returns the ServiceKey matching s, or an error if s is not recognized.
+func ParseServiceKey(s string) (ServiceKey, error) {
+	for _, k := range AllServiceKeys {
+		if string(k) == s {
+			return k, nil
+		}
+	}
+	return "", fmt.Errorf("invalid service key %q, valid keys are: %v", s, AllServiceKeys)
+}
 
 // ServicesForInitComponents returns the state service keys corresponding to the
 // selected init-package components. Callers should pass the deploy-filtered
 // component set so absent components stay absent from state.
-func ServicesForInitComponents(components []v1alpha1.ZarfComponent) []string {
-	var services []string
-	add := func(k string) {
+func ServicesForInitComponents(components []v1alpha1.ZarfComponent) []ServiceKey {
+	var services []ServiceKey
+	add := func(k ServiceKey) {
 		if !slices.Contains(services, k) {
 			services = append(services, k)
 		}
@@ -449,7 +464,7 @@ type MergeOptions struct {
 	GitServer      GitServerInfo
 	RegistryInfo   RegistryInfo
 	ArtifactServer ArtifactServerInfo
-	Services       []string
+	Services       []ServiceKey
 	// AgentTLS allows providing user-managed TLS certificates for the agent. When nil, certs are auto-generated.
 	AgentTLS *pki.GeneratedPKI
 }

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -31,13 +31,35 @@ const (
 // Credential keys
 // TODO(mkcp): Provide semantic doccomments for how these are used.
 const (
-	RegistryKey     = "registry"
-	RegistryReadKey = "registry-readonly"
-	GitKey          = "git"
-	GitReadKey      = "git-readonly"
-	ArtifactKey     = "artifact"
-	AgentKey        = "agent"
+	RegistryKey = "registry"
+	GitKey      = "git"
+	ArtifactKey = "artifact"
+	AgentKey    = "agent"
 )
+
+// ServicesForInitComponents returns the state service keys corresponding to the
+// selected init-package components. Callers should pass the deploy-filtered
+// component set so absent components stay absent from state.
+func ServicesForInitComponents(components []v1alpha1.ZarfComponent) []string {
+	var services []string
+	add := func(k string) {
+		if !slices.Contains(services, k) {
+			services = append(services, k)
+		}
+	}
+	for _, c := range components {
+		switch c.Name {
+		case "git-server":
+			add(GitKey)
+			add(ArtifactKey)
+		case "zarf-registry", "zarf-seed-registry", "zarf-injector":
+			add(RegistryKey)
+		case "zarf-agent":
+			add(AgentKey)
+		}
+	}
+	return services
+}
 
 // ComponentStatus defines the deployment status of a Zarf component within a package.
 type ComponentStatus string
@@ -157,9 +179,11 @@ func (gs GitServerInfo) IsInternal() bool {
 	return gs.Address == ZarfInClusterGitServiceURL
 }
 
-// IsConfigured returns true if the git server address has been set
-// Note that even when the Git server component is not used Zarf will set the address to a default value
-// TODO make this more accurate https://github.com/zarf-dev/zarf/issues/2947
+// IsConfigured returns true if the git server address has been set.
+// New clusters only populate the address when the git-server component (or an
+// external --git-url) was supplied, so this reflects whether a git server is
+// actually in use. Legacy clusters initialized before services-gated state
+// may report true even without a real git server.
 func (gs GitServerInfo) IsConfigured() bool {
 	return gs.Address != ""
 }

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -10,76 +10,8 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 )
-
-func TestServicesForInitComponents(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		components []v1alpha1.ZarfComponent
-		expected   []ServiceKey
-	}{
-		{
-			name:       "no components",
-			components: nil,
-			expected:   nil,
-		},
-		{
-			name: "git-server maps to git and artifact",
-			components: []v1alpha1.ZarfComponent{
-				{Name: "git-server"},
-			},
-			expected: []ServiceKey{GitKey, ArtifactKey},
-		},
-		{
-			name: "registry components dedupe to registry key",
-			components: []v1alpha1.ZarfComponent{
-				{Name: "zarf-injector"},
-				{Name: "zarf-seed-registry"},
-				{Name: "zarf-registry"},
-			},
-			expected: []ServiceKey{RegistryKey},
-		},
-		{
-			name: "zarf-agent maps to agent",
-			components: []v1alpha1.ZarfComponent{
-				{Name: "zarf-agent"},
-			},
-			expected: []ServiceKey{AgentKey},
-		},
-		{
-			name: "full init package maps to all four services",
-			components: []v1alpha1.ZarfComponent{
-				{Name: "k3s"},
-				{Name: "zarf-injector"},
-				{Name: "zarf-seed-registry"},
-				{Name: "zarf-registry"},
-				{Name: "zarf-agent"},
-				{Name: "git-server"},
-			},
-			expected: []ServiceKey{RegistryKey, AgentKey, GitKey, ArtifactKey},
-		},
-		{
-			name: "unknown components ignored",
-			components: []v1alpha1.ZarfComponent{
-				{Name: "k3s"},
-				{Name: "some-custom-component"},
-			},
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := ServicesForInitComponents(tt.components)
-			require.ElementsMatch(t, tt.expected, got)
-		})
-	}
-}
 
 // TODO: Change password gen method to make testing possible.
 func TestMergeStateRegistry(t *testing.T) {

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -20,7 +20,7 @@ func TestServicesForInitComponents(t *testing.T) {
 	tests := []struct {
 		name       string
 		components []v1alpha1.ZarfComponent
-		expected   []string
+		expected   []ServiceKey
 	}{
 		{
 			name:       "no components",
@@ -32,7 +32,7 @@ func TestServicesForInitComponents(t *testing.T) {
 			components: []v1alpha1.ZarfComponent{
 				{Name: "git-server"},
 			},
-			expected: []string{GitKey, ArtifactKey},
+			expected: []ServiceKey{GitKey, ArtifactKey},
 		},
 		{
 			name: "registry components dedupe to registry key",
@@ -41,14 +41,14 @@ func TestServicesForInitComponents(t *testing.T) {
 				{Name: "zarf-seed-registry"},
 				{Name: "zarf-registry"},
 			},
-			expected: []string{RegistryKey},
+			expected: []ServiceKey{RegistryKey},
 		},
 		{
 			name: "zarf-agent maps to agent",
 			components: []v1alpha1.ZarfComponent{
 				{Name: "zarf-agent"},
 			},
-			expected: []string{AgentKey},
+			expected: []ServiceKey{AgentKey},
 		},
 		{
 			name: "full init package maps to all four services",
@@ -60,7 +60,7 @@ func TestServicesForInitComponents(t *testing.T) {
 				{Name: "zarf-agent"},
 				{Name: "git-server"},
 			},
-			expected: []string{RegistryKey, AgentKey, GitKey, ArtifactKey},
+			expected: []ServiceKey{RegistryKey, AgentKey, GitKey, ArtifactKey},
 		},
 		{
 			name: "unknown components ignored",
@@ -182,7 +182,7 @@ func TestMergeStateRegistry(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				RegistryInfo: tt.initRegistry,
-				Services:     []string{RegistryKey},
+				Services:     []ServiceKey{RegistryKey},
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRegistry.PushUsername, newState.RegistryInfo.PushUsername)
@@ -287,7 +287,7 @@ func TestMergeStateGit(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				GitServer: tt.initGitServer,
-				Services:  []string{GitKey},
+				Services:  []ServiceKey{GitKey},
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedGitServer.PushUsername, newState.GitServer.PushUsername)
@@ -383,7 +383,7 @@ func TestMergeStateArtifact(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				ArtifactServer: tt.initArtifactServer,
-				Services:       []string{ArtifactKey},
+				Services:       []ServiceKey{ArtifactKey},
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedArtifactServer, newState.ArtifactServer)
@@ -402,7 +402,7 @@ func TestMergeStateAgent(t *testing.T) {
 			AgentTLS: agentTLS,
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []string{AgentKey},
+			Services: []ServiceKey{AgentKey},
 		})
 		require.NoError(t, err)
 		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)
@@ -418,7 +418,7 @@ func TestMergeStateAgent(t *testing.T) {
 			Key:  []byte("user-key"),
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []string{AgentKey},
+			Services: []ServiceKey{AgentKey},
 			AgentTLS: &userTLS,
 		})
 		require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestMergeStateAgent(t *testing.T) {
 			AgentTLSUserProvided: true,
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []string{AgentKey},
+			Services: []ServiceKey{AgentKey},
 		})
 		require.NoError(t, err)
 		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -10,8 +10,76 @@ import (
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 )
+
+func TestServicesForInitComponents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		components []v1alpha1.ZarfComponent
+		expected   []string
+	}{
+		{
+			name:       "no components",
+			components: nil,
+			expected:   nil,
+		},
+		{
+			name: "git-server maps to git and artifact",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "git-server"},
+			},
+			expected: []string{GitKey, ArtifactKey},
+		},
+		{
+			name: "registry components dedupe to registry key",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "zarf-injector"},
+				{Name: "zarf-seed-registry"},
+				{Name: "zarf-registry"},
+			},
+			expected: []string{RegistryKey},
+		},
+		{
+			name: "zarf-agent maps to agent",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "zarf-agent"},
+			},
+			expected: []string{AgentKey},
+		},
+		{
+			name: "full init package maps to all four services",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "k3s"},
+				{Name: "zarf-injector"},
+				{Name: "zarf-seed-registry"},
+				{Name: "zarf-registry"},
+				{Name: "zarf-agent"},
+				{Name: "git-server"},
+			},
+			expected: []string{RegistryKey, AgentKey, GitKey, ArtifactKey},
+		},
+		{
+			name: "unknown components ignored",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "k3s"},
+				{Name: "some-custom-component"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ServicesForInitComponents(tt.components)
+			require.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
 
 // TODO: Change password gen method to make testing possible.
 func TestMergeStateRegistry(t *testing.T) {

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -114,7 +114,7 @@ func TestMergeStateRegistry(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				RegistryInfo: tt.initRegistry,
-				Services:     []ServiceKey{RegistryKey},
+				Services:     NewServiceSet(RegistryKey),
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRegistry.PushUsername, newState.RegistryInfo.PushUsername)
@@ -219,7 +219,7 @@ func TestMergeStateGit(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				GitServer: tt.initGitServer,
-				Services:  []ServiceKey{GitKey},
+				Services:  NewServiceSet(GitKey),
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedGitServer.PushUsername, newState.GitServer.PushUsername)
@@ -315,7 +315,7 @@ func TestMergeStateArtifact(t *testing.T) {
 			}
 			newState, err := Merge(oldState, MergeOptions{
 				ArtifactServer: tt.initArtifactServer,
-				Services:       []ServiceKey{ArtifactKey},
+				Services:       NewServiceSet(ArtifactKey),
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedArtifactServer, newState.ArtifactServer)
@@ -334,7 +334,7 @@ func TestMergeStateAgent(t *testing.T) {
 			AgentTLS: agentTLS,
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []ServiceKey{AgentKey},
+			Services: NewServiceSet(AgentKey),
 		})
 		require.NoError(t, err)
 		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)
@@ -350,7 +350,7 @@ func TestMergeStateAgent(t *testing.T) {
 			Key:  []byte("user-key"),
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []ServiceKey{AgentKey},
+			Services: NewServiceSet(AgentKey),
 			AgentTLS: &userTLS,
 		})
 		require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestMergeStateAgent(t *testing.T) {
 			AgentTLSUserProvided: true,
 		}
 		newState, err := Merge(oldState, MergeOptions{
-			Services: []ServiceKey{AgentKey},
+			Services: NewServiceSet(AgentKey),
 		})
 		require.NoError(t, err)
 		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)


### PR DESCRIPTION
## Description

Zarf always adds default Git server values to state even when the Git server is not configured or deployed. This means anyone deploying GitOps resources has their resources configured to point at a non-existent Git server, guaranteeing failure. Additionally, we always add private-git-server secrets to every namespace even when their irrelevant.

## Related Issue

Fixes #2947
Fixes #2740


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
