### PR TITLE
docs: validate and update E2E test docs

### DIFF
--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -12,7 +12,9 @@ To run the end-to-end tests locally, you must meet the same prerequisites as tho
 
 1. GoLang version >= the version specified in the [go.mod](https://github.com/zarf-dev/zarf/blob/main/go.mod)
 2. Make
-3. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
+3. Docker
+4. Docker Buildx
+5. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
 
 ## Unit Tests
 
@@ -22,7 +24,7 @@ There are several ways to run tests depending on your specific situation, such a
 # The default way, from the root directory of the repo. Will run all of the unit tests that are currently defined.
 make test-unit
 
-# To get a single line readable summary of all the unit tests currently defined:
+# To get a single-line readable summary of all the unit tests currently defined:
 make test-unit 2>&1 | grep -E "^(ok|FAIL)\s"
 
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
@@ -56,10 +58,13 @@ There are several ways to run tests depending on your specific situation, such a
 # The default way, from the root directory of the repo. Will run all of the tests against your chosen k8s distro. Will automatically build any binary dependencies that don't already exist.
 make test-e2e ARCH="[amd64|arm64]"
 
+# To get a single-line readable summary of all the e2e tests currently defined:
+cd src/test/e2e && go test ./main_test.go ./[01]* -failfast -v -timeout 35m 2>&1 | grep -E "^(--- FAIL|--- PASS|FAIL|ok)"
+
 # To test against a Zarf-created cluster (on Linux with sudo)
 APPLIANCE_MODE=true make test-e2e ARCH="[amd64|arm64]"
 
-# If you already have everything build, you can run this inside this folder. This lets you customize the test run.
+# If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/test/... -v -failfast -count=1
 
 # Let's say you only want to run one test. You would run:

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -22,12 +22,17 @@ There are several ways to run tests depending on your specific situation, such a
 # The default way, from the root directory of the repo. Will run all of the unit tests that are currently defined.
 make test-unit
 
+# To get a single line readable summary of all the unit tests currently defined:
+make test-unit 2>&1 | grep -E "^(ok|FAIL)\s"
+
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/pkg/... -v
 
 # Let's say you only want to run one test. You would run:
 go test ./src/pkg/... -v -run TestFooBarBaz
 ```
+
+All unit tests should pass locally before submitting a PR.
 
 ### Adding New Unit Tests
 

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -6,6 +6,7 @@ Currently, we primarily test Zarf through a series of [end-to-end tests](https:/
 
 In addition, Zarf implements unit tests for specific functions where edge cases prove difficult to cover through end-to-end testing alone. Unit tests follow standard Go convention and are `*_test.go` files.
 
+# TODO: update any more dependencies
 ## Dependencies
 
 To run the end-to-end tests locally, you must meet the same prerequisites as those required for building and running Zarf, which include:
@@ -16,6 +17,7 @@ To run the end-to-end tests locally, you must meet the same prerequisites as tho
 4. Docker Buildx
 5. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
 
+# TODO: DONE these have been tested on mac and linux so this section is GTG
 ## Unit Tests
 
 There are several ways to run tests depending on your specific situation, such as:
@@ -30,10 +32,11 @@ make test-unit 2>&1 | grep -E "^(ok|FAIL)\s"
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/pkg/... -v
 
-# Let's say you only want to run one test. You would run:
+# To run a single test:
 go test ./src/pkg/... -v -run TestFooBarBaz
 ```
 
+# TODO: make new unit test and test instructions
 All unit tests should pass locally before submitting a PR.
 
 ### Adding New Unit Tests
@@ -61,8 +64,8 @@ make test-e2e ARCH="[amd64|arm64]"
 # To get a single-line readable summary of all the e2e tests currently defined:
 cd src/test/e2e && go test ./main_test.go ./[01]* -failfast -v -timeout 35m 2>&1 | grep -E "^(--- FAIL|--- PASS|FAIL|ok)"
 
-# To test against a Zarf-created cluster (on Linux with sudo)
-APPLIANCE_MODE=true make test-e2e ARCH="[amd64|arm64]"
+# To test against a Zarf-created cluster (Linux only with sudo, not compatible with macOS)
+APPLIANCE_MODE=true make test-e2e ARCH="amd64"
 
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/test/... -v -failfast -count=1
@@ -156,3 +159,23 @@ The end-to-end tests are run sequentially and the naming convention is set inten
 - 22 is reserved for tests required the git-server, which is removed at the end of the test.
 - 23-98 are for the remaining tests that only require a basic Zarf cluster without the git-server.
 - 99 is reserved for the `zarf destroy` and [YOLO Mode](/ref/examples/yolo/) test.
+
+### Troubleshooting ###
+
+Potential e2e testing errors and causes:
+Docker/Buildx:
+
+`unknown flag: --load` → Buildx not installed or broken symlink
+
+Cluster:
+
+dial tcp [::1]:8080: connect: connection refused → No cluster configured or kubeconfig not set
+error loading config file: duplicate name in list → Duplicate entries in ~/.kube/config
+
+Git/1Password:
+
+error: 1Password: Could not connect to socket → 1Password closed during rebase commit signing
+
+Architecture:
+
+no compatible component named k3s found → Either wrong ARCH value or trying to run Linux-only components on macOS

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -6,8 +6,7 @@ Currently, we primarily test Zarf through a series of [end-to-end tests](https:/
 
 In addition, Zarf implements unit tests for specific functions where edge cases prove difficult to cover through end-to-end testing alone. Unit tests follow standard Go convention and are `*_test.go` files.
 
-# TODO: update any more dependencies
-## Dependencies
+## Dependencies # TODO: update any more dependencies
 
 To run the end-to-end tests locally, you must meet the same prerequisites as those required for building and running Zarf, which include:
 
@@ -17,8 +16,7 @@ To run the end-to-end tests locally, you must meet the same prerequisites as tho
 4. Docker Buildx
 5. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
 
-# TODO: DONE these have been tested on mac and linux so this section is GTG
-## Unit Tests
+## Unit Tests # TODO: DONE these have been tested on mac and linux so this section is GTG
 
 There are several ways to run tests depending on your specific situation, such as:
 
@@ -36,10 +34,9 @@ go test ./src/pkg/... -v
 go test ./src/pkg/... -v -run TestFooBarBaz
 ```
 
-# TODO: make new unit test and test instructions
 All unit tests should pass locally before submitting a PR.
 
-### Adding New Unit Tests
+### Adding New Unit Tests # TODO: make new unit test and test instructions
 
 To create a unit test, search for or create a file that ends with `_test.go` in the package of the file that requires testing, such as `auth.go` -> `auth_test.go`. Import the testing library and create test functions as necessary. Generic unit test helper functions can be found in [src/test/testutil](https://github.com/zarf-dev/zarf/tree/main/src/test/testutil).
 

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -6,7 +6,7 @@ Currently, we primarily test Zarf through a series of [end-to-end tests](https:/
 
 In addition, Zarf implements unit tests for specific functions where edge cases prove difficult to cover through end-to-end testing alone. Unit tests follow standard Go convention and are `*_test.go` files.
 
-## Dependencies # TODO: update any more dependencies
+## Dependencies
 
 To run the end-to-end tests locally, you must meet the same prerequisites as those required for building and running Zarf, which include:
 
@@ -16,7 +16,7 @@ To run the end-to-end tests locally, you must meet the same prerequisites as tho
 4. Docker Buildx
 5. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
 
-## Unit Tests # TODO: DONE these have been tested on mac and linux so this section is GTG
+## Unit Tests
 
 There are several ways to run tests depending on your specific situation, such as:
 
@@ -77,8 +77,10 @@ make test-e2e ARCH="[amd64|arm64]"
 # To get a single-line readable summary of all the e2e tests currently defined:
 cd src/test/e2e && go test ./main_test.go ./[01]* -failfast -v -timeout 35m 2>&1 | grep -E "^(--- FAIL|--- PASS|FAIL|ok)"
 
+######### TODO: All of the above has been tested and is gtg #####################
+######### TODO: Working below this line #########################################
 # To test against a Zarf-created cluster (Linux only with sudo, not compatible with macOS)
-APPLIANCE_MODE=true make test-e2e ARCH="amd64"
+APPLIANCE_MODE=true make test-e2e ARCH="amd64" TODO: ✅ Confirmed this works on Linux
 
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/test/... -v -failfast -count=1

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -27,7 +27,7 @@ make test-unit
 # To get a single-line readable summary of all the unit tests currently defined:
 make test-unit 2>&1 | grep -E "^(ok|FAIL)\s"
 
-# If you already have everything built, you can run this inside this folder. This lets you customize the test run.
+# If you already have everything built, you can run the following command inside this folder. This lets you customize the test run.
 go test ./src/pkg/... -v
 
 # To run a single test:
@@ -36,17 +36,33 @@ go test ./src/pkg/... -v -run TestFooBarBaz
 
 All unit tests should pass locally before submitting a PR.
 
-### Adding New Unit Tests # TODO: make new unit test and test instructions
+### Adding New Unit Tests
 
 To create a unit test, search for or create a file that ends with `_test.go` in the package of the file that requires testing, such as `auth.go` -> `auth_test.go`. Import the testing library and create test functions as necessary. Generic unit test helper functions can be found in [src/test/testutil](https://github.com/zarf-dev/zarf/tree/main/src/test/testutil).
 
 There are two types of unit tests within Zarf:
 
 1. Standard unit tests on isolated functions or files.
-1. Tests in the [src/cmd](https://github.com/zarf-dev/zarf/tree/main/src/cmd) package, which test an entire command. These have similar properties to e2e tests, but faster iteration loops.
+2. Tests in the [src/cmd](https://github.com/zarf-dev/zarf/tree/main/src/cmd) package, which test an entire command. These have similar properties to e2e tests, but faster iteration loops.
 
 Unit tests should always take less than one second. Unit tests should run using `t.Parallel()` unless a specific constraint blocks this.
 
+## Verify Local Environment
+If not running tests in APPLIANCE_MODE, it's a good idea to run a minimal test to verify that all dependencies are functioning and your Kubernetes cluster is properly configured prior to performing a full end-to-end test run.
+
+Because early cluster connectivity checks in the test suite can fail silently and cause confusing errors later, manually verifying your cluster and running a single test is highly recommended.
+
+```
+# Verify cluster connectivity and ensure KUBECONFIG is pointing to a live, clean cluster
+kubectl cluster-info
+
+# Compile the CLI and basic dependencies to verify Go, Make, Docker, and Buildx
+make build
+make init-package
+
+# Run a single E2E test
+go test ./src/test/e2e/... -v -failfast -run TestUseCLI -count=1
+```
 
 ## CLI End-to-End Tests
 

--- a/site/src/content/docs/contribute/testing.mdx
+++ b/site/src/content/docs/contribute/testing.mdx
@@ -6,6 +6,7 @@ Currently, we primarily test Zarf through a series of [end-to-end tests](https:/
 
 In addition, Zarf implements unit tests for specific functions where edge cases prove difficult to cover through end-to-end testing alone. Unit tests follow standard Go convention and are `*_test.go` files.
 
+# TODO: update any more dependencies
 ## Dependencies
 
 To run the end-to-end tests locally, you must meet the same prerequisites as those required for building and running Zarf, which include:
@@ -16,6 +17,7 @@ To run the end-to-end tests locally, you must meet the same prerequisites as tho
 4. Docker Buildx
 5. Any clean K8s cluster (local or remote) or Linux with `root` if you want to use the Zarf-installed K3s cluster
 
+# TODO: DONE these have been tested on mac and linux so this section is GTG
 ## Unit Tests
 
 There are several ways to run tests depending on your specific situation, such as:
@@ -30,10 +32,11 @@ make test-unit 2>&1 | grep -E "^(ok|FAIL)\s"
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/pkg/... -v
 
-# Let's say you only want to run one test. You would run:
+# To run a single test:
 go test ./src/pkg/... -v -run TestFooBarBaz
 ```
 
+# TODO: make new unit test and test instructions
 All unit tests should pass locally before submitting a PR.
 
 ### Adding New Unit Tests
@@ -61,8 +64,8 @@ make test-e2e ARCH="[amd64|arm64]"
 # To get a single-line readable summary of all the e2e tests currently defined:
 cd src/test/e2e && go test ./main_test.go ./[01]* -failfast -v -timeout 35m 2>&1 | grep -E "^(--- FAIL|--- PASS|FAIL|ok)"
 
-# To test against a Zarf-created cluster (on Linux with sudo)
-APPLIANCE_MODE=true make test-e2e ARCH="[amd64|arm64]"
+# To test against a Zarf-created cluster (Linux only with sudo, not compatible with macOS)
+APPLIANCE_MODE=true make test-e2e ARCH="amd64"
 
 # If you already have everything built, you can run this inside this folder. This lets you customize the test run.
 go test ./src/test/... -v -failfast -count=1
@@ -155,4 +158,24 @@ The end-to-end tests are run sequentially and the naming convention is set inten
 - 20 is reserved for `zarf init`.
 - 22 is reserved for tests required the git-server, which is removed at the end of the test.
 - 23-98 are for the remaining tests that only require a basic Zarf cluster without the git-server.
-- 99 is reserved for the `zarf destroy` and Connected mode test.
+- 99 is reserved for the `zarf destroy` and [YOLO Mode](/ref/examples/yolo/) test.
+
+### Troubleshooting ###
+
+Potential e2e testing errors and causes:
+Docker/Buildx:
+
+`unknown flag: --load` → Buildx not installed or broken symlink
+
+Cluster:
+
+dial tcp [::1]:8080: connect: connection refused → No cluster configured or kubeconfig not set
+error loading config file: duplicate name in list → Duplicate entries in ~/.kube/config
+
+Git/1Password:
+
+error: 1Password: Could not connect to socket → 1Password closed during rebase commit signing
+
+Architecture:
+
+no compatible component named k3s found → Either wrong ARCH value or trying to run Linux-only components on macOS

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -19,6 +19,12 @@ import (
 func TestZarfInit(t *testing.T) {
 	t.Log("E2E: Zarf init")
 
+	// Verify cluster connectivity before running with-cluster tests
+	if !e2e.ApplianceMode {
+		_, _, err := e2e.Kubectl(t, "cluster-info")
+		require.NoError(t, err, "No cluster found. Ensure a valid kubeconfig is available and cluster is running.")
+	}
+
 	initComponents := "git-server"
 	if e2e.ApplianceMode {
 		initComponents = "k3s,git-server"

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -19,11 +19,11 @@ import (
 func TestZarfInit(t *testing.T) {
 	t.Log("E2E: Zarf init")
 
-	// Verify cluster connectivity before running with-cluster tests
-	if !e2e.ApplianceMode {
-		_, _, err := e2e.Kubectl(t, "cluster-info")
-		require.NoError(t, err, "No cluster found. Ensure a valid kubeconfig is available and cluster is running.")
-	}
+	// // Verify cluster connectivity before running with-cluster tests
+	// if !e2e.ApplianceMode {
+	// 	_, _, err := e2e.Kubectl(t, "cluster-info")
+	// 	require.NoError(t, err, "No cluster found. Ensure a valid kubeconfig is available and cluster is running.")
+	// }
 
 	initComponents := "git-server"
 	if e2e.ApplianceMode {

--- a/src/test/e2e/20_zarf_init_test.go
+++ b/src/test/e2e/20_zarf_init_test.go
@@ -19,12 +19,6 @@ import (
 func TestZarfInit(t *testing.T) {
 	t.Log("E2E: Zarf init")
 
-	// // Verify cluster connectivity before running with-cluster tests
-	// if !e2e.ApplianceMode {
-	// 	_, _, err := e2e.Kubectl(t, "cluster-info")
-	// 	require.NoError(t, err, "No cluster found. Ensure a valid kubeconfig is available and cluster is running.")
-	// }
-
 	initComponents := "git-server"
 	if e2e.ApplianceMode {
 		initComponents = "k3s,git-server"

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	// "context"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/test"
+	// "github.com/zarf-dev/zarf/src/pkg/utils/exec"
 )
 
 var (
@@ -45,5 +47,13 @@ func TestMain(m *testing.M) {
 	if _, err := os.Stat(e2e.ZarfBinPath); err != nil {
 		log.Fatalf("zarf binary %s not found: %v", e2e.ZarfBinPath, err)
 	}
+
+	// // If running with-cluster tests validate cluster connectivity early
+	// if os.Getenv(skipK8sEnvVar) != "true" && !e2e.ApplianceMode {
+	// 	_, _, err := exec.CmdWithContext(context.Background(), exec.Config{}, e2e.ZarfBinPath, "tools", "kubectl", "cluster-info")
+	// 	if err != nil {
+	// 		log.Fatalf("No cluster found. Ensure a valid kubeconfig is available and cluster is running: %v", err)
+	// 	}
+	// }
 	os.Exit(m.Run())
 }

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -5,13 +5,16 @@
 package test
 
 import (
-	// "context"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 	"github.com/zarf-dev/zarf/src/test"
 	// "github.com/zarf-dev/zarf/src/pkg/utils/exec"
 )
@@ -48,12 +51,44 @@ func TestMain(m *testing.M) {
 		log.Fatalf("zarf binary %s not found: %v", e2e.ZarfBinPath, err)
 	}
 
-	// // If running with-cluster tests validate cluster connectivity early
-	// if os.Getenv(skipK8sEnvVar) != "true" && !e2e.ApplianceMode {
-	// 	_, _, err := exec.CmdWithContext(context.Background(), exec.Config{}, e2e.ZarfBinPath, "tools", "kubectl", "cluster-info")
-	// 	if err != nil {
-	// 		log.Fatalf("No cluster found. Ensure a valid kubeconfig is available and cluster is running: %v", err)
-	// 	}
-	// }
+	// If APPLIANCE_MODE set to true, warn Mac user and run only non-cluster tests
+	if e2e.ApplianceMode && runtime.GOOS != "linux" {
+		cfg := logger.Config{
+			Level:       logger.Info,
+			Format:      logger.FormatConsole,
+			Destination: logger.DestinationDefault,
+			Color:       true,
+		}
+		l, err := logger.New(cfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		l.Warn("APPLIANCE_MODE=true is only fully supported on Linux. " +
+			"On macOS, only tests that do not require a cluster will run. " +
+			"To run with-cluster tests on macOS, create a local cluster first " +
+			"and run make test-e2e-with-cluster ARCH=arm64 instead.")
+	}
+
+	// If not in appliance mode, check for cluster connectivity
+	// If no cluster is found, warn that only without-cluster tests will run
+	if !e2e.ApplianceMode {
+		_, _, err := exec.CmdWithContext(context.Background(), exec.Config{}, e2e.ZarfBinPath, "tools", "kubectl", "cluster-info")
+		if err != nil {
+			cfg := logger.Config{
+				Level:       logger.Warn,
+				Format:      logger.FormatConsole,
+				Destination: logger.DestinationDefault,
+				Color:       true,
+			}
+			l, logErr := logger.New(cfg)
+			if logErr != nil {
+				log.Fatal(logErr)
+			}
+			l.Warn("No cluster found - with-cluster tests will fail. " +
+				"To run only tests that do not require a cluster use: make test-e2e-without-cluster. " +
+				"To run with-cluster tests, ensure a valid cluster is running.")
+		}
+	}
+
 	os.Exit(m.Run())
 }

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/zarf-dev/zarf/src/config"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 	"github.com/zarf-dev/zarf/src/test"
 	// "github.com/zarf-dev/zarf/src/pkg/utils/exec"
@@ -53,17 +52,7 @@ func TestMain(m *testing.M) {
 
 	// If APPLIANCE_MODE set to true, warn Mac user and run only non-cluster tests
 	if e2e.ApplianceMode && runtime.GOOS != "linux" {
-		cfg := logger.Config{
-			Level:       logger.Info,
-			Format:      logger.FormatConsole,
-			Destination: logger.DestinationDefault,
-			Color:       true,
-		}
-		l, err := logger.New(cfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-		l.Warn("APPLIANCE_MODE=true is only fully supported on Linux. " +
+		log.Println("WARNING: APPLIANCE_MODE=true is only fully supported on Linux. " +
 			"On macOS, only tests that do not require a cluster will run. " +
 			"To run with-cluster tests on macOS, create a local cluster first " +
 			"and run make test-e2e-with-cluster ARCH=arm64 instead.")
@@ -74,17 +63,7 @@ func TestMain(m *testing.M) {
 	if !e2e.ApplianceMode {
 		_, _, err := exec.CmdWithContext(context.Background(), exec.Config{}, e2e.ZarfBinPath, "tools", "kubectl", "cluster-info")
 		if err != nil {
-			cfg := logger.Config{
-				Level:       logger.Warn,
-				Format:      logger.FormatConsole,
-				Destination: logger.DestinationDefault,
-				Color:       true,
-			}
-			l, logErr := logger.New(cfg)
-			if logErr != nil {
-				log.Fatal(logErr)
-			}
-			l.Warn("No cluster found - with-cluster tests will fail. " +
+			log.Println("WARNING: No cluster found - with-cluster tests will fail. " +
 				"To run only tests that do not require a cluster use: make test-e2e-without-cluster. " +
 				"To run with-cluster tests, ensure a valid cluster is running.")
 		}


### PR DESCRIPTION
## Description

This PR aims to:
- Update dependencies required in E2E testing docs
- Clarify Kubernetes cluster configuration needed for E2E testing
- Reduce tribal knowledge by validating the testing E2E testing docs are correct and identify/correct any knowledge gaps in the documentation

## Related Issue

Relates to #2477 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
