### PR TITLE
fix(create): built package path separators

### DIFF
--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -27,14 +27,16 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/git"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
-	"github.com/zarf-dev/zarf/src/internal/packager/images"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
+	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
+	"github.com/zarf-dev/zarf/src/pkg/value"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 // AssembleOptions are the options for creating a package from a package object
@@ -49,16 +51,21 @@ type AssembleOptions struct {
 	// When DifferentialPackage is set the zarf package created only includes images and repos not in the differential package
 	DifferentialPackage v1alpha1.ZarfPackage
 	OCIConcurrency      int
-	// CachePath is the path to the Zarf cache, used to cache images
+	// CachePath is the path to the Zarf cache, used to cache images and charts
 	CachePath string
 	// WithBuildMachineInfo includes build machine information (hostname and username) in the package metadata
 	WithBuildMachineInfo bool
+	types.RemoteOptions
 }
 
 // AssemblePackage takes a package definition and returns a package layout with all the resources collected
 func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string, opts AssembleOptions) (*PackageLayout, error) {
 	l := logger.From(ctx)
 	l.Info("assembling package", "path", packagePath)
+
+	if err := validateImageArchivesNoDuplicates(pkg.Components); err != nil {
+		return nil, err
+	}
 
 	if opts.DifferentialPackage.Metadata.Name != "" {
 		l.Debug("creating differential package", "differential", opts.DifferentialPackage)
@@ -97,14 +104,26 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		return nil, err
 	}
 	for _, component := range pkg.Components {
-		err := assemblePackageComponent(ctx, component, packagePath, buildPath)
+		err := assemblePackageComponent(ctx, component, packagePath, buildPath, opts.CachePath, opts.RemoteOptions)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	componentImages := []transform.Image{}
+	manifests := []images.ImageWithManifest{}
 	for _, component := range pkg.Components {
+		for _, imageArchive := range component.ImageArchives {
+			if !filepath.IsAbs(imageArchive.Path) {
+				imageArchive.Path = filepath.Join(packagePath, imageArchive.Path)
+			}
+
+			archiveImageManifests, err := images.Unpack(ctx, imageArchive, filepath.Join(buildPath, ImagesDir), pkg.Metadata.Architecture)
+			if err != nil {
+				return nil, err
+			}
+			manifests = append(manifests, archiveImageManifests...)
+		}
 		for _, src := range component.Images {
 			refInfo, err := transform.ParseImageRef(src)
 			if err != nil {
@@ -118,25 +137,25 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 	}
 	sbomImageList := []transform.Image{}
 	if len(componentImages) > 0 {
-		pullCfg := images.PullConfig{
+		pullOpts := images.PullOptions{
 			OCIConcurrency:        opts.OCIConcurrency,
-			DestinationDirectory:  filepath.Join(buildPath, ImagesDir),
-			ImageList:             componentImages,
 			Arch:                  pkg.Metadata.Architecture,
 			RegistryOverrides:     opts.RegistryOverrides,
 			CacheDirectory:        filepath.Join(opts.CachePath, ImagesDir),
-			PlainHTTP:             config.CommonOptions.PlainHTTP,
-			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
+			PlainHTTP:             opts.RemoteOptions.PlainHTTP,
+			InsecureSkipTLSVerify: opts.RemoteOptions.InsecureSkipTLSVerify,
 		}
-		manifests, err := images.Pull(ctx, pullCfg)
+		imageManifests, err := images.Pull(ctx, componentImages, filepath.Join(buildPath, ImagesDir), pullOpts)
 		if err != nil {
 			return nil, err
 		}
-		for image, manifest := range manifests {
-			ok := images.OnlyHasImageLayers(manifest)
-			if ok {
-				sbomImageList = append(sbomImageList, image)
-			}
+		manifests = append(manifests, imageManifests...)
+	}
+
+	for _, manifest := range manifests {
+		ok := images.OnlyHasImageLayers(manifest.Manifest)
+		if ok {
+			sbomImageList = append(sbomImageList, manifest.Image)
 		}
 
 		// Sort images index to make build reproducible.
@@ -156,11 +175,20 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		}
 	}
 
-	l.Debug("copying values files to package", "files", pkg.Values.Files)
-	for _, file := range pkg.Values.Files {
-		if err = copyValuesFile(ctx, file, packagePath, buildPath); err != nil {
+	l.Debug("merging values files to package", "files", pkg.Values.Files)
+	if err = mergeAndWriteValuesFile(ctx, pkg.Values.Files, packagePath, buildPath); err != nil {
+		return nil, err
+	}
+
+	// Copy schema file if specified
+	if pkg.Values.Schema != "" {
+		if err = copyValuesSchema(ctx, pkg.Values.Schema, packagePath, buildPath); err != nil {
 			return nil, err
 		}
+	}
+
+	if err = createDocumentationTar(pkg, packagePath, buildPath); err != nil {
+		return nil, err
 	}
 
 	checksumContent, checksumSha, err := getChecksum(buildPath)
@@ -185,7 +213,8 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		return nil, err
 	}
 
-	pkgLayout, err := LoadFromDir(ctx, buildPath, PackageLayoutOptions{SkipSignatureValidation: true})
+	// skip verification on package creation
+	pkgLayout, err := LoadFromDir(ctx, buildPath, PackageLayoutOptions{VerificationStrategy: VerifyNever})
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +246,10 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 
 	buildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
+		return nil, err
+	}
+
+	if err = createDocumentationTar(pkg, packagePath, buildPath); err != nil {
 		return nil, err
 	}
 
@@ -255,8 +288,8 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 	}
 
 	layoutOpts := PackageLayoutOptions{
-		SkipSignatureValidation: true,
-		IsPartial:               false,
+		VerificationStrategy: VerifyNever,
+		IsPartial:            false,
 	}
 	pkgLayout, err := LoadFromDir(ctx, buildPath, layoutOpts)
 	if err != nil {
@@ -276,7 +309,47 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 	return pkgLayout, nil
 }
 
-func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfComponent, packagePath, buildPath string) (err error) {
+// validateImageArchivesNoDuplicates ensures no image appears in multiple image archives
+// and that images in image archives don't conflict with images in component.Images.
+func validateImageArchivesNoDuplicates(components []v1alpha1.ZarfComponent) error {
+	imageToArchive := make(map[string]string)
+
+	for _, comp := range components {
+		for _, archive := range comp.ImageArchives {
+			for _, image := range archive.Images {
+				refInfo, err := transform.ParseImageRef(image)
+				if err != nil {
+					return fmt.Errorf("failed to parse image ref %s in archive %s: %w", image, archive.Path, err)
+				}
+
+				if existingArchivePath, exists := imageToArchive[refInfo.Reference]; exists {
+					// A user may want to represent the same tar twice across components if both components need the same image
+					if existingArchivePath != archive.Path {
+						return fmt.Errorf("image %s appears in multiple image archives: %s and %s", refInfo.Reference, existingArchivePath, archive.Path)
+					}
+				} else {
+					imageToArchive[refInfo.Reference] = archive.Path
+				}
+			}
+		}
+	}
+
+	for _, comp := range components {
+		for _, image := range comp.Images {
+			refInfo, err := transform.ParseImageRef(image)
+			if err != nil {
+				return fmt.Errorf("failed to parse image ref %s in component %s: %w", image, comp.Name, err)
+			}
+			if archivePath, exists := imageToArchive[refInfo.Reference]; exists {
+				return fmt.Errorf("image %s from %s is also pulled by component %s", refInfo.Reference, archivePath, comp.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfComponent, packagePath, buildPath, cachePath string, remoteOpts types.RemoteOptions) (err error) {
 	tmpBuildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return err
@@ -299,7 +372,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 	for _, chart := range component.Charts {
 		chartPath := filepath.Join(compBuildPath, string(ChartsComponentDir))
 		valuesFilePath := filepath.Join(compBuildPath, string(ValuesComponentDir))
-		err := PackageChart(ctx, chart, packagePath, chartPath, valuesFilePath)
+		err := PackageChart(ctx, chart, packagePath, chartPath, valuesFilePath, cachePath, remoteOpts)
 		if err != nil {
 			return err
 		}
@@ -315,7 +388,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				// get the compressedFileName from the source
 				compressedFileName, err := helpers.ExtractBasePathFromURL(file.Source)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err)
 				}
 				tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 				if err != nil {
@@ -328,18 +401,18 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 				// If the file is an archive, download it to the componentPath.Temp
 				if err := utils.DownloadToFile(ctx, file.Source, compressedFile); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
 				}
 				decompressOpts := archive.DecompressOpts{
 					Files: []string{file.ExtractPath},
 				}
 				err = archive.Decompress(ctx, compressedFile, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err.Error())
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err)
 				}
 			} else {
 				if err := utils.DownloadToFile(ctx, file.Source, dst); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
 				}
 			}
 		} else {
@@ -353,7 +426,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				}
 				err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
 				}
 			} else {
 				if err := helpers.CreatePathAndCopy(src, dst); err != nil {
@@ -375,7 +448,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 		// Abort packaging on invalid shasum (if one is specified).
 		if file.Shasum != "" {
 			if err := helpers.SHAsMatch(dst, file.Shasum); err != nil {
-				return err
+				return fmt.Errorf("sha mismatch for %s: %w", file.Source, err)
 			}
 		}
 
@@ -398,7 +471,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 		if helpers.IsURL(data.Source) {
 			if err := utils.DownloadToFile(ctx, data.Source, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, data.Source, err.Error())
+				return fmt.Errorf(lang.ErrDownloading, data.Source, err)
 			}
 		} else {
 			src := data.Source
@@ -406,7 +479,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				src = filepath.Join(packagePath, data.Source)
 			}
 			if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-				return fmt.Errorf("unable to copy data injection %s: %s", data.Source, err.Error())
+				return fmt.Errorf("unable to copy data injection %s: %w", data.Source, err)
 			}
 		}
 	}
@@ -467,7 +540,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 		// Copy manifests without any processing.
 		if helpers.IsURL(path) {
 			if err := utils.DownloadToFile(ctx, path, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, path, err.Error())
+				return fmt.Errorf(lang.ErrDownloading, path, err)
 			}
 		} else {
 			src := path
@@ -497,7 +570,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 }
 
 // PackageChart takes a Zarf Chart definition and packs it into a package layout
-func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath string, chartPath string, valuesFilePath string) error {
+func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath, chartPath, valuesFilePath, cachePath string, remoteOpts types.RemoteOptions) error {
 	if chart.LocalPath != "" && !filepath.IsAbs(chart.LocalPath) {
 		chart.LocalPath = filepath.Join(packagePath, chart.LocalPath)
 	}
@@ -510,7 +583,7 @@ func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath str
 		valuesFiles = append(valuesFiles, v)
 	}
 	chart.ValuesFiles = valuesFiles
-	if err := helm.PackageChart(ctx, chart, chartPath, valuesFilePath); err != nil {
+	if err := helm.PackageChart(ctx, chart, chartPath, valuesFilePath, cachePath, remoteOpts); err != nil {
 		return err
 	}
 	chart.ValuesFiles = oldValuesFiles
@@ -583,7 +656,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			}
 			err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 			if err != nil {
-				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
+				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
 			}
 
 			// Make sure dst reflects the actual file or directory.
@@ -608,7 +681,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 		// Abort packaging on invalid shasum (if one is specified).
 		if file.Shasum != "" {
 			if err := helpers.SHAsMatch(dst, file.Shasum); err != nil {
-				return err
+				return fmt.Errorf("sha mismatch for %s: %w", file.Source, err)
 			}
 		}
 
@@ -634,7 +707,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			src = filepath.Join(packagePath, src)
 		}
 		if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-			return fmt.Errorf("unable to copy data injection %s: %s", src, err.Error())
+			return fmt.Errorf("unable to copy data injection %s: %w", src, err)
 		}
 
 		component.DataInjections[dataIdx].Source = rel
@@ -740,6 +813,18 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 	// Record the flavor of Zarf used to build this package (if any).
 	pkg.Build.Flavor = flavor
 
+	var versionRequirements []v1alpha1.VersionRequirement
+	for _, comp := range pkg.Components {
+		if len(comp.ImageArchives) > 0 {
+			versionRequirements = append(versionRequirements, v1alpha1.VersionRequirement{
+				Version: "v0.68.0",
+				Reason:  "This package contains image archives which will only be recognized on v0.68.0+",
+			})
+			break
+		}
+	}
+	pkg.Build.VersionRequirements = versionRequirements
+
 	// We lose the ordering for the user-provided registry overrides.
 	overrides := make(map[string]string, len(registryOverrides))
 	for i := range registryOverrides {
@@ -751,6 +836,10 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 	// set signed to false by default - this is updated if signing occurs.
 	signed := false
 	pkg.Build.Signed = &signed
+
+	// Record checksums.txt as a supplemental file — it cannot checksum itself.
+	// Signature files are appended by SignPackage() if signing occurs.
+	pkg.Build.ProvenanceFiles = []string{Checksums}
 
 	return pkg
 }
@@ -876,35 +965,113 @@ func createReproducibleTarballFromDir(dirPath, dirPrefix, tarballPath string, ov
 	})
 }
 
-func copyValuesFile(ctx context.Context, file, packagePath, buildPath string) error {
+func mergeAndWriteValuesFile(ctx context.Context, files []string, packagePath, buildPath string) error {
 	l := logger.From(ctx)
 
-	// Process local values file
-	src := file
-	if !filepath.IsAbs(src) {
-		src = filepath.Join(packagePath, ValuesDir, file)
-	}
-	// Validate src
-	if _, err := os.Stat(src); err != nil {
-		return fmt.Errorf("unable to access values file %s: %w", src, err)
+	if len(files) == 0 {
+		return nil
 	}
 
-	// Ensure relative paths don't munge the destination and write outside of the package tmpdir
-	cleanFile := filepath.Clean(file)
-	if strings.HasPrefix(cleanFile, "..") {
-		return fmt.Errorf("values file path %s escapes package directory", file)
+	// Build absolute paths for all values files
+	valueFilePaths := make([]string, len(files))
+	for i, file := range files {
+		src := file
+		if !filepath.IsAbs(src) {
+			src = filepath.Join(packagePath, file)
+		}
+		// Validate src exists
+		if _, err := os.Stat(src); err != nil {
+			return fmt.Errorf("unable to access values file %s: %w", src, err)
+		}
+		valueFilePaths[i] = src
 	}
 
-	//Copy file to pre-archive package - destination includes ValuesDir
-	dst := filepath.Join(buildPath, ValuesDir, cleanFile)
-	l.Debug("copying values file", "src", src, "dst", dst)
-	if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-		return fmt.Errorf("failed to copy values file %s: %w", src, err)
+	// Parse and merge all values files
+	vals, err := value.ParseFiles(ctx, valueFilePaths, value.ParseFilesOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to parse values files: %w", err)
+	}
+
+	// Write merged values to YAML
+	dst := filepath.Join(buildPath, ValuesYAML)
+	l.Debug("writing merged values file", "dst", dst, "fileCount", len(files))
+	if err := utils.WriteYaml(dst, vals, helpers.ReadWriteUser); err != nil {
+		return fmt.Errorf("failed to write merged values file: %w", err)
+	}
+
+	return nil
+}
+
+// copyValuesSchema validates and copies a values schema file to the build directory.
+// It validates the schema is valid JSON Schema, checks for path traversal, and copies
+// the file to the package root.
+func copyValuesSchema(ctx context.Context, schema, packagePath, buildPath string) error {
+	l := logger.From(ctx)
+	l.Debug("copying values schema file to package", "schema", schema)
+
+	// Resolve the schema source path from package root
+	schemaSrc := schema
+	if !filepath.IsAbs(schemaSrc) {
+		schemaSrc = filepath.Join(packagePath, schema)
+	}
+
+	// Validate the schema is valid JSON Schema
+	if err := value.ValidateSchemaFile(schemaSrc); err != nil {
+		return fmt.Errorf("values schema validation failed: %w", err)
+	}
+
+	// Copy schema file to package root
+	schemaDst := filepath.Join(buildPath, ValuesSchema)
+	l.Debug("copying values schema file", "src", schemaSrc, "dst", schemaDst)
+	if err := helpers.CreatePathAndCopy(schemaSrc, schemaDst); err != nil {
+		return fmt.Errorf("failed to copy values schema file %s: %w", schemaSrc, err)
 	}
 
 	// Set appropriate file permissions
-	if err := os.Chmod(dst, helpers.ReadWriteUser); err != nil {
-		return fmt.Errorf("failed to set permissions on values file %s: %w", dst, err)
+	if err := os.Chmod(schemaDst, helpers.ReadWriteUser); err != nil {
+		return fmt.Errorf("failed to set permissions on values schema file %s: %w", schemaDst, err)
+	}
+
+	return nil
+}
+
+func createDocumentationTar(pkg v1alpha1.ZarfPackage, packagePath, buildPath string) (err error) {
+	if len(pkg.Documentation) == 0 {
+		return nil
+	}
+
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory for documentation: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
+
+	// Get the mapping of keys to their final filenames (with deduplication logic)
+	fileNames := GetDocumentationFileNames(pkg.Documentation)
+
+	for key, file := range pkg.Documentation {
+		src := file
+		if !filepath.IsAbs(src) {
+			src = filepath.Join(packagePath, file)
+		}
+
+		docFilename := fileNames[key]
+		dst := filepath.Join(tmpDir, docFilename)
+
+		if err := helpers.CreatePathAndCopy(src, dst); err != nil {
+			return fmt.Errorf("failed to copy documentation file %s: %w", src, err)
+		}
+
+		if err := os.Chmod(dst, helpers.ReadWriteUser); err != nil {
+			return fmt.Errorf("failed to set permissions on documentation file %s: %w", dst, err)
+		}
+	}
+
+	tarPath := filepath.Join(buildPath, DocumentationTar)
+	if err := createReproducibleTarballFromDir(tmpDir, "", tarPath, true); err != nil {
+		return fmt.Errorf("failed to create documentation tarball: %w", err)
 	}
 
 	return nil

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -27,16 +27,14 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/git"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
+	"github.com/zarf-dev/zarf/src/internal/packager/images"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
-	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/actions"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
-	"github.com/zarf-dev/zarf/src/pkg/value"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 // AssembleOptions are the options for creating a package from a package object
@@ -51,21 +49,16 @@ type AssembleOptions struct {
 	// When DifferentialPackage is set the zarf package created only includes images and repos not in the differential package
 	DifferentialPackage v1alpha1.ZarfPackage
 	OCIConcurrency      int
-	// CachePath is the path to the Zarf cache, used to cache images and charts
+	// CachePath is the path to the Zarf cache, used to cache images
 	CachePath string
 	// WithBuildMachineInfo includes build machine information (hostname and username) in the package metadata
 	WithBuildMachineInfo bool
-	types.RemoteOptions
 }
 
 // AssemblePackage takes a package definition and returns a package layout with all the resources collected
 func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string, opts AssembleOptions) (*PackageLayout, error) {
 	l := logger.From(ctx)
 	l.Info("assembling package", "path", packagePath)
-
-	if err := validateImageArchivesNoDuplicates(pkg.Components); err != nil {
-		return nil, err
-	}
 
 	if opts.DifferentialPackage.Metadata.Name != "" {
 		l.Debug("creating differential package", "differential", opts.DifferentialPackage)
@@ -104,26 +97,14 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		return nil, err
 	}
 	for _, component := range pkg.Components {
-		err := assemblePackageComponent(ctx, component, packagePath, buildPath, opts.CachePath, opts.RemoteOptions)
+		err := assemblePackageComponent(ctx, component, packagePath, buildPath)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	componentImages := []transform.Image{}
-	manifests := []images.ImageWithManifest{}
 	for _, component := range pkg.Components {
-		for _, imageArchive := range component.ImageArchives {
-			if !filepath.IsAbs(imageArchive.Path) {
-				imageArchive.Path = filepath.Join(packagePath, imageArchive.Path)
-			}
-
-			archiveImageManifests, err := images.Unpack(ctx, imageArchive, filepath.Join(buildPath, ImagesDir), pkg.Metadata.Architecture)
-			if err != nil {
-				return nil, err
-			}
-			manifests = append(manifests, archiveImageManifests...)
-		}
 		for _, src := range component.Images {
 			refInfo, err := transform.ParseImageRef(src)
 			if err != nil {
@@ -137,25 +118,25 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 	}
 	sbomImageList := []transform.Image{}
 	if len(componentImages) > 0 {
-		pullOpts := images.PullOptions{
+		pullCfg := images.PullConfig{
 			OCIConcurrency:        opts.OCIConcurrency,
+			DestinationDirectory:  filepath.Join(buildPath, ImagesDir),
+			ImageList:             componentImages,
 			Arch:                  pkg.Metadata.Architecture,
 			RegistryOverrides:     opts.RegistryOverrides,
 			CacheDirectory:        filepath.Join(opts.CachePath, ImagesDir),
-			PlainHTTP:             opts.RemoteOptions.PlainHTTP,
-			InsecureSkipTLSVerify: opts.RemoteOptions.InsecureSkipTLSVerify,
+			PlainHTTP:             config.CommonOptions.PlainHTTP,
+			InsecureSkipTLSVerify: config.CommonOptions.InsecureSkipTLSVerify,
 		}
-		imageManifests, err := images.Pull(ctx, componentImages, filepath.Join(buildPath, ImagesDir), pullOpts)
+		manifests, err := images.Pull(ctx, pullCfg)
 		if err != nil {
 			return nil, err
 		}
-		manifests = append(manifests, imageManifests...)
-	}
-
-	for _, manifest := range manifests {
-		ok := images.OnlyHasImageLayers(manifest.Manifest)
-		if ok {
-			sbomImageList = append(sbomImageList, manifest.Image)
+		for image, manifest := range manifests {
+			ok := images.OnlyHasImageLayers(manifest)
+			if ok {
+				sbomImageList = append(sbomImageList, image)
+			}
 		}
 
 		// Sort images index to make build reproducible.
@@ -175,20 +156,11 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		}
 	}
 
-	l.Debug("merging values files to package", "files", pkg.Values.Files)
-	if err = mergeAndWriteValuesFile(ctx, pkg.Values.Files, packagePath, buildPath); err != nil {
-		return nil, err
-	}
-
-	// Copy schema file if specified
-	if pkg.Values.Schema != "" {
-		if err = copyValuesSchema(ctx, pkg.Values.Schema, packagePath, buildPath); err != nil {
+	l.Debug("copying values files to package", "files", pkg.Values.Files)
+	for _, file := range pkg.Values.Files {
+		if err = copyValuesFile(ctx, file, packagePath, buildPath); err != nil {
 			return nil, err
 		}
-	}
-
-	if err = createDocumentationTar(pkg, packagePath, buildPath); err != nil {
-		return nil, err
 	}
 
 	checksumContent, checksumSha, err := getChecksum(buildPath)
@@ -213,8 +185,7 @@ func AssemblePackage(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath 
 		return nil, err
 	}
 
-	// skip verification on package creation
-	pkgLayout, err := LoadFromDir(ctx, buildPath, PackageLayoutOptions{VerificationStrategy: VerifyNever})
+	pkgLayout, err := LoadFromDir(ctx, buildPath, PackageLayoutOptions{SkipSignatureValidation: true})
 	if err != nil {
 		return nil, err
 	}
@@ -246,10 +217,6 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 
 	buildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
-		return nil, err
-	}
-
-	if err = createDocumentationTar(pkg, packagePath, buildPath); err != nil {
 		return nil, err
 	}
 
@@ -288,8 +255,8 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 	}
 
 	layoutOpts := PackageLayoutOptions{
-		VerificationStrategy: VerifyNever,
-		IsPartial:            false,
+		SkipSignatureValidation: true,
+		IsPartial:               false,
 	}
 	pkgLayout, err := LoadFromDir(ctx, buildPath, layoutOpts)
 	if err != nil {
@@ -309,47 +276,7 @@ func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath
 	return pkgLayout, nil
 }
 
-// validateImageArchivesNoDuplicates ensures no image appears in multiple image archives
-// and that images in image archives don't conflict with images in component.Images.
-func validateImageArchivesNoDuplicates(components []v1alpha1.ZarfComponent) error {
-	imageToArchive := make(map[string]string)
-
-	for _, comp := range components {
-		for _, archive := range comp.ImageArchives {
-			for _, image := range archive.Images {
-				refInfo, err := transform.ParseImageRef(image)
-				if err != nil {
-					return fmt.Errorf("failed to parse image ref %s in archive %s: %w", image, archive.Path, err)
-				}
-
-				if existingArchivePath, exists := imageToArchive[refInfo.Reference]; exists {
-					// A user may want to represent the same tar twice across components if both components need the same image
-					if existingArchivePath != archive.Path {
-						return fmt.Errorf("image %s appears in multiple image archives: %s and %s", refInfo.Reference, existingArchivePath, archive.Path)
-					}
-				} else {
-					imageToArchive[refInfo.Reference] = archive.Path
-				}
-			}
-		}
-	}
-
-	for _, comp := range components {
-		for _, image := range comp.Images {
-			refInfo, err := transform.ParseImageRef(image)
-			if err != nil {
-				return fmt.Errorf("failed to parse image ref %s in component %s: %w", image, comp.Name, err)
-			}
-			if archivePath, exists := imageToArchive[refInfo.Reference]; exists {
-				return fmt.Errorf("image %s from %s is also pulled by component %s", refInfo.Reference, archivePath, comp.Name)
-			}
-		}
-	}
-
-	return nil
-}
-
-func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfComponent, packagePath, buildPath, cachePath string, remoteOpts types.RemoteOptions) (err error) {
+func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfComponent, packagePath, buildPath string) (err error) {
 	tmpBuildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return err
@@ -372,7 +299,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 	for _, chart := range component.Charts {
 		chartPath := filepath.Join(compBuildPath, string(ChartsComponentDir))
 		valuesFilePath := filepath.Join(compBuildPath, string(ValuesComponentDir))
-		err := PackageChart(ctx, chart, packagePath, chartPath, valuesFilePath, cachePath, remoteOpts)
+		err := PackageChart(ctx, chart, packagePath, chartPath, valuesFilePath)
 		if err != nil {
 			return err
 		}
@@ -388,7 +315,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				// get the compressedFileName from the source
 				compressedFileName, err := helpers.ExtractBasePathFromURL(file.Source)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err)
+					return fmt.Errorf(lang.ErrFileNameExtract, file.Source, err.Error())
 				}
 				tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 				if err != nil {
@@ -401,18 +328,18 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 				// If the file is an archive, download it to the componentPath.Temp
 				if err := utils.DownloadToFile(ctx, file.Source, compressedFile); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
 				}
 				decompressOpts := archive.DecompressOpts{
 					Files: []string{file.ExtractPath},
 				}
 				err = archive.Decompress(ctx, compressedFile, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err)
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, compressedFileName, err.Error())
 				}
 			} else {
 				if err := utils.DownloadToFile(ctx, file.Source, dst); err != nil {
-					return fmt.Errorf(lang.ErrDownloading, file.Source, err)
+					return fmt.Errorf(lang.ErrDownloading, file.Source, err.Error())
 				}
 			}
 		} else {
@@ -426,7 +353,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				}
 				err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 				if err != nil {
-					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
+					return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
 				}
 			} else {
 				if err := helpers.CreatePathAndCopy(src, dst); err != nil {
@@ -448,7 +375,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 		// Abort packaging on invalid shasum (if one is specified).
 		if file.Shasum != "" {
 			if err := helpers.SHAsMatch(dst, file.Shasum); err != nil {
-				return fmt.Errorf("sha mismatch for %s: %w", file.Source, err)
+				return err
 			}
 		}
 
@@ -471,7 +398,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 
 		if helpers.IsURL(data.Source) {
 			if err := utils.DownloadToFile(ctx, data.Source, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, data.Source, err)
+				return fmt.Errorf(lang.ErrDownloading, data.Source, err.Error())
 			}
 		} else {
 			src := data.Source
@@ -479,7 +406,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 				src = filepath.Join(packagePath, data.Source)
 			}
 			if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-				return fmt.Errorf("unable to copy data injection %s: %w", data.Source, err)
+				return fmt.Errorf("unable to copy data injection %s: %s", data.Source, err.Error())
 			}
 		}
 	}
@@ -540,7 +467,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 		// Copy manifests without any processing.
 		if helpers.IsURL(path) {
 			if err := utils.DownloadToFile(ctx, path, dst); err != nil {
-				return fmt.Errorf(lang.ErrDownloading, path, err)
+				return fmt.Errorf(lang.ErrDownloading, path, err.Error())
 			}
 		} else {
 			src := path
@@ -570,7 +497,7 @@ func PackageManifest(ctx context.Context, manifest v1alpha1.ZarfManifest, compBu
 }
 
 // PackageChart takes a Zarf Chart definition and packs it into a package layout
-func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath, chartPath, valuesFilePath, cachePath string, remoteOpts types.RemoteOptions) error {
+func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath string, chartPath string, valuesFilePath string) error {
 	if chart.LocalPath != "" && !filepath.IsAbs(chart.LocalPath) {
 		chart.LocalPath = filepath.Join(packagePath, chart.LocalPath)
 	}
@@ -583,7 +510,7 @@ func PackageChart(ctx context.Context, chart v1alpha1.ZarfChart, packagePath, ch
 		valuesFiles = append(valuesFiles, v)
 	}
 	chart.ValuesFiles = valuesFiles
-	if err := helm.PackageChart(ctx, chart, chartPath, valuesFilePath, cachePath, remoteOpts); err != nil {
+	if err := helm.PackageChart(ctx, chart, chartPath, valuesFilePath); err != nil {
 		return err
 	}
 	chart.ValuesFiles = oldValuesFiles
@@ -606,7 +533,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 
 	for chartIdx, chart := range component.Charts {
 		if chart.LocalPath != "" {
-			rel := filepath.Join(string(ChartsComponentDir), fmt.Sprintf("%s-%d", chart.Name, chartIdx))
+			rel := filepath.ToSlash(filepath.Join(string(ChartsComponentDir), fmt.Sprintf("%s-%d", chart.Name, chartIdx)))
 			dst := filepath.Join(compBuildPath, rel)
 
 			file := chart.LocalPath
@@ -625,7 +552,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 				continue
 			}
 
-			rel := fmt.Sprintf("%s-%d", helm.StandardName(string(ValuesComponentDir), chart), valuesIdx)
+			rel := filepath.ToSlash(fmt.Sprintf("%s-%d", helm.StandardName(string(ValuesComponentDir), chart), valuesIdx))
 			component.Charts[chartIdx].ValuesFiles[valuesIdx] = rel
 
 			if !filepath.IsAbs(path) {
@@ -642,7 +569,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			continue
 		}
 
-		rel := filepath.Join(string(FilesComponentDir), strconv.Itoa(filesIdx), filepath.Base(file.Target))
+		rel := filepath.ToSlash(filepath.Join(string(FilesComponentDir), strconv.Itoa(filesIdx), filepath.Base(file.Target)))
 		dst := filepath.Join(compBuildPath, rel)
 		destinationDir := filepath.Dir(dst)
 		src := file.Source
@@ -656,7 +583,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			}
 			err = archive.Decompress(ctx, src, destinationDir, decompressOpts)
 			if err != nil {
-				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err)
+				return fmt.Errorf(lang.ErrFileExtract, file.ExtractPath, src, err.Error())
 			}
 
 			// Make sure dst reflects the actual file or directory.
@@ -681,7 +608,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 		// Abort packaging on invalid shasum (if one is specified).
 		if file.Shasum != "" {
 			if err := helpers.SHAsMatch(dst, file.Shasum); err != nil {
-				return fmt.Errorf("sha mismatch for %s: %w", file.Source, err)
+				return err
 			}
 		}
 
@@ -699,7 +626,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 	}
 
 	for dataIdx, data := range component.DataInjections {
-		rel := filepath.Join(string(DataComponentDir), strconv.Itoa(dataIdx), filepath.Base(data.Target.Path))
+		rel := filepath.ToSlash(filepath.Join(string(DataComponentDir), strconv.Itoa(dataIdx), filepath.Base(data.Target.Path)))
 		dst := filepath.Join(compBuildPath, rel)
 
 		src := data.Source
@@ -707,7 +634,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 			src = filepath.Join(packagePath, src)
 		}
 		if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-			return fmt.Errorf("unable to copy data injection %s: %w", src, err)
+			return fmt.Errorf("unable to copy data injection %s: %s", src, err.Error())
 		}
 
 		component.DataInjections[dataIdx].Source = rel
@@ -721,7 +648,7 @@ func assembleSkeletonComponent(ctx context.Context, component v1alpha1.ZarfCompo
 	}
 	for manifestIdx, manifest := range component.Manifests {
 		for fileIdx, path := range manifest.Files {
-			rel := filepath.Join(string(ManifestsComponentDir), fmt.Sprintf("%s-%d.yaml", manifest.Name, fileIdx))
+			rel := filepath.ToSlash(filepath.Join(string(ManifestsComponentDir), fmt.Sprintf("%s-%d.yaml", manifest.Name, fileIdx)))
 			dst := filepath.Join(compBuildPath, rel)
 
 			// Copy manifests without any processing.
@@ -813,18 +740,6 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 	// Record the flavor of Zarf used to build this package (if any).
 	pkg.Build.Flavor = flavor
 
-	var versionRequirements []v1alpha1.VersionRequirement
-	for _, comp := range pkg.Components {
-		if len(comp.ImageArchives) > 0 {
-			versionRequirements = append(versionRequirements, v1alpha1.VersionRequirement{
-				Version: "v0.68.0",
-				Reason:  "This package contains image archives which will only be recognized on v0.68.0+",
-			})
-			break
-		}
-	}
-	pkg.Build.VersionRequirements = versionRequirements
-
 	// We lose the ordering for the user-provided registry overrides.
 	overrides := make(map[string]string, len(registryOverrides))
 	for i := range registryOverrides {
@@ -836,10 +751,6 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 	// set signed to false by default - this is updated if signing occurs.
 	signed := false
 	pkg.Build.Signed = &signed
-
-	// Record checksums.txt as a supplemental file — it cannot checksum itself.
-	// Signature files are appended by SignPackage() if signing occurs.
-	pkg.Build.ProvenanceFiles = []string{Checksums}
 
 	return pkg
 }
@@ -965,113 +876,35 @@ func createReproducibleTarballFromDir(dirPath, dirPrefix, tarballPath string, ov
 	})
 }
 
-func mergeAndWriteValuesFile(ctx context.Context, files []string, packagePath, buildPath string) error {
+func copyValuesFile(ctx context.Context, file, packagePath, buildPath string) error {
 	l := logger.From(ctx)
 
-	if len(files) == 0 {
-		return nil
+	// Process local values file
+	src := file
+	if !filepath.IsAbs(src) {
+		src = filepath.Join(packagePath, ValuesDir, file)
+	}
+	// Validate src
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("unable to access values file %s: %w", src, err)
 	}
 
-	// Build absolute paths for all values files
-	valueFilePaths := make([]string, len(files))
-	for i, file := range files {
-		src := file
-		if !filepath.IsAbs(src) {
-			src = filepath.Join(packagePath, file)
-		}
-		// Validate src exists
-		if _, err := os.Stat(src); err != nil {
-			return fmt.Errorf("unable to access values file %s: %w", src, err)
-		}
-		valueFilePaths[i] = src
+	// Ensure relative paths don't munge the destination and write outside of the package tmpdir
+	cleanFile := filepath.Clean(file)
+	if strings.HasPrefix(cleanFile, "..") {
+		return fmt.Errorf("values file path %s escapes package directory", file)
 	}
 
-	// Parse and merge all values files
-	vals, err := value.ParseFiles(ctx, valueFilePaths, value.ParseFilesOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to parse values files: %w", err)
-	}
-
-	// Write merged values to YAML
-	dst := filepath.Join(buildPath, ValuesYAML)
-	l.Debug("writing merged values file", "dst", dst, "fileCount", len(files))
-	if err := utils.WriteYaml(dst, vals, helpers.ReadWriteUser); err != nil {
-		return fmt.Errorf("failed to write merged values file: %w", err)
-	}
-
-	return nil
-}
-
-// copyValuesSchema validates and copies a values schema file to the build directory.
-// It validates the schema is valid JSON Schema, checks for path traversal, and copies
-// the file to the package root.
-func copyValuesSchema(ctx context.Context, schema, packagePath, buildPath string) error {
-	l := logger.From(ctx)
-	l.Debug("copying values schema file to package", "schema", schema)
-
-	// Resolve the schema source path from package root
-	schemaSrc := schema
-	if !filepath.IsAbs(schemaSrc) {
-		schemaSrc = filepath.Join(packagePath, schema)
-	}
-
-	// Validate the schema is valid JSON Schema
-	if err := value.ValidateSchemaFile(schemaSrc); err != nil {
-		return fmt.Errorf("values schema validation failed: %w", err)
-	}
-
-	// Copy schema file to package root
-	schemaDst := filepath.Join(buildPath, ValuesSchema)
-	l.Debug("copying values schema file", "src", schemaSrc, "dst", schemaDst)
-	if err := helpers.CreatePathAndCopy(schemaSrc, schemaDst); err != nil {
-		return fmt.Errorf("failed to copy values schema file %s: %w", schemaSrc, err)
+	//Copy file to pre-archive package - destination includes ValuesDir
+	dst := filepath.Join(buildPath, ValuesDir, cleanFile)
+	l.Debug("copying values file", "src", src, "dst", dst)
+	if err := helpers.CreatePathAndCopy(src, dst); err != nil {
+		return fmt.Errorf("failed to copy values file %s: %w", src, err)
 	}
 
 	// Set appropriate file permissions
-	if err := os.Chmod(schemaDst, helpers.ReadWriteUser); err != nil {
-		return fmt.Errorf("failed to set permissions on values schema file %s: %w", schemaDst, err)
-	}
-
-	return nil
-}
-
-func createDocumentationTar(pkg v1alpha1.ZarfPackage, packagePath, buildPath string) (err error) {
-	if len(pkg.Documentation) == 0 {
-		return nil
-	}
-
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory for documentation: %w", err)
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
-	// Get the mapping of keys to their final filenames (with deduplication logic)
-	fileNames := GetDocumentationFileNames(pkg.Documentation)
-
-	for key, file := range pkg.Documentation {
-		src := file
-		if !filepath.IsAbs(src) {
-			src = filepath.Join(packagePath, file)
-		}
-
-		docFilename := fileNames[key]
-		dst := filepath.Join(tmpDir, docFilename)
-
-		if err := helpers.CreatePathAndCopy(src, dst); err != nil {
-			return fmt.Errorf("failed to copy documentation file %s: %w", src, err)
-		}
-
-		if err := os.Chmod(dst, helpers.ReadWriteUser); err != nil {
-			return fmt.Errorf("failed to set permissions on documentation file %s: %w", dst, err)
-		}
-	}
-
-	tarPath := filepath.Join(buildPath, DocumentationTar)
-	if err := createReproducibleTarballFromDir(tmpDir, "", tarPath, true); err != nil {
-		return fmt.Errorf("failed to create documentation tarball: %w", err)
+	if err := os.Chmod(dst, helpers.ReadWriteUser); err != nil {
+		return fmt.Errorf("failed to set permissions on values file %s: %w", dst, err)
 	}
 
 	return nil

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -12,19 +12,17 @@ import (
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 	_ "modernc.org/sqlite"
 )
 
-func TestCreateSkeleton(t *testing.T) {
+func TestAssembleSkeleton(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.TestContext(t)
 
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	pkg, err := load.PackageDefinition(ctx, "./testdata/zarf-skeleton-package", load.DefinitionOptions{})
 	require.NoError(t, err)
 
@@ -37,6 +35,7 @@ func TestCreateSkeleton(t *testing.T) {
 	expectedChecksum := `0fea7403536c0c0e2a2d9b235d4b3716e86eefd8e78e7b14412dd5a750b77474 components/kustomizations.tar
 54f657b43323e1ebecb0758835b8d01a0113b61b7bab0f4a8156f031128d00f9 components/data-injections.tar
 879bfe82d20f7bdcd60f9e876043cc4343af4177a6ee8b2660c304a5b6c70be7 components/files.tar
+bd82245bfc3c79abfa23dcf72c8099a2788c1b6073464f1ee0c6b64b9c8ef2f6 documentation.tar
 c497f1a56559ea0a9664160b32e4b377df630454ded6a3787924130c02f341a6 components/manifests.tar
 fb7ebee94a4479bacddd71195030a483b0b0b96d4f73f7fcd2c2c8e0fce0c5c6 components/helm-charts.tar
 `
@@ -57,7 +56,6 @@ func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {
 
 func TestGetSBOM(t *testing.T) {
 	t.Parallel()
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 
 	ctx := testutil.TestContext(t)
 
@@ -89,7 +87,6 @@ func TestGetSBOM(t *testing.T) {
 }
 
 func TestCreateAbsoluteSources(t *testing.T) {
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
 	tests := []struct {
 		name       string
@@ -113,11 +110,16 @@ func TestCreateAbsoluteSources(t *testing.T) {
 			require.NoError(t, err)
 			absoluteKustomizePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "kustomize"))
 			require.NoError(t, err)
+			absoluteDocsPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "doc.md"))
+			require.NoError(t, err)
 			componentName := "absolute-files"
 			pkg := v1alpha1.ZarfPackage{
 				Kind: v1alpha1.ZarfPackageConfig,
 				Metadata: v1alpha1.ZarfMetadata{
 					Name: "standard",
+				},
+				Documentation: map[string]string{
+					"docs": absoluteDocsPath,
 				},
 				Components: []v1alpha1.ZarfComponent{
 					{
@@ -172,6 +174,10 @@ func TestCreateAbsoluteSources(t *testing.T) {
 				pkgLayout, err = layout.AssemblePackage(ctx, pkg, tmpdir, layout.AssembleOptions{SkipSBOM: true})
 				require.NoError(t, err)
 			}
+			docsDir := filepath.Join(tmpdir, "docs-dir")
+			err = pkgLayout.GetDocumentation(ctx, docsDir, []string{})
+			require.NoError(t, err)
+			require.FileExists(t, filepath.Join(docsDir, "doc.md"))
 
 			// Ensure the component has the correct files
 			fileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.FilesComponentDir)
@@ -200,7 +206,7 @@ func TestCreateAbsoluteSources(t *testing.T) {
 
 func TestCreateAbsolutePathImports(t *testing.T) {
 	t.Parallel()
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
+
 	ctx := testutil.TestContext(t)
 	tmpdir := t.TempDir()
 	absoluteFilePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "data.txt"))

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -12,17 +12,19 @@ import (
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 	_ "modernc.org/sqlite"
 )
 
-func TestAssembleSkeleton(t *testing.T) {
+func TestCreateSkeleton(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.TestContext(t)
 
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	pkg, err := load.PackageDefinition(ctx, "./testdata/zarf-skeleton-package", load.DefinitionOptions{})
 	require.NoError(t, err)
 
@@ -35,12 +37,13 @@ func TestAssembleSkeleton(t *testing.T) {
 	expectedChecksum := `0fea7403536c0c0e2a2d9b235d4b3716e86eefd8e78e7b14412dd5a750b77474 components/kustomizations.tar
 54f657b43323e1ebecb0758835b8d01a0113b61b7bab0f4a8156f031128d00f9 components/data-injections.tar
 879bfe82d20f7bdcd60f9e876043cc4343af4177a6ee8b2660c304a5b6c70be7 components/files.tar
-bd82245bfc3c79abfa23dcf72c8099a2788c1b6073464f1ee0c6b64b9c8ef2f6 documentation.tar
 c497f1a56559ea0a9664160b32e4b377df630454ded6a3787924130c02f341a6 components/manifests.tar
 fb7ebee94a4479bacddd71195030a483b0b0b96d4f73f7fcd2c2c8e0fce0c5c6 components/helm-charts.tar
 `
 
 	require.Equal(t, expectedChecksum, string(b))
+	testutil.RequireNoBackslashInPackagePaths(t, pkgLayout.Pkg)
+	require.Equal(t, "e9cc0c25b81b7a5abb29f181110210eab3274ec07a080cd171730bfa590575d9", testutil.ChecksumZarfYAMLContent(t, pkgLayout.Pkg), "skeleton zarf.yaml checksum drift — package would differ across build hosts")
 }
 
 func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {
@@ -54,6 +57,7 @@ func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {
 
 func TestGetSBOM(t *testing.T) {
 	t.Parallel()
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 
 	ctx := testutil.TestContext(t)
 
@@ -85,6 +89,7 @@ func TestGetSBOM(t *testing.T) {
 }
 
 func TestCreateAbsoluteSources(t *testing.T) {
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
 	tests := []struct {
 		name       string
@@ -108,16 +113,11 @@ func TestCreateAbsoluteSources(t *testing.T) {
 			require.NoError(t, err)
 			absoluteKustomizePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "kustomize"))
 			require.NoError(t, err)
-			absoluteDocsPath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "doc.md"))
-			require.NoError(t, err)
 			componentName := "absolute-files"
 			pkg := v1alpha1.ZarfPackage{
 				Kind: v1alpha1.ZarfPackageConfig,
 				Metadata: v1alpha1.ZarfMetadata{
 					Name: "standard",
-				},
-				Documentation: map[string]string{
-					"docs": absoluteDocsPath,
 				},
 				Components: []v1alpha1.ZarfComponent{
 					{
@@ -172,10 +172,6 @@ func TestCreateAbsoluteSources(t *testing.T) {
 				pkgLayout, err = layout.AssemblePackage(ctx, pkg, tmpdir, layout.AssembleOptions{SkipSBOM: true})
 				require.NoError(t, err)
 			}
-			docsDir := filepath.Join(tmpdir, "docs-dir")
-			err = pkgLayout.GetDocumentation(ctx, docsDir, []string{})
-			require.NoError(t, err)
-			require.FileExists(t, filepath.Join(docsDir, "doc.md"))
 
 			// Ensure the component has the correct files
 			fileComponent, err := pkgLayout.GetComponentDir(ctx, tmpdir, componentName, layout.FilesComponentDir)
@@ -204,7 +200,7 @@ func TestCreateAbsoluteSources(t *testing.T) {
 
 func TestCreateAbsolutePathImports(t *testing.T) {
 	t.Parallel()
-
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	ctx := testutil.TestContext(t)
 	tmpdir := t.TempDir()
 	absoluteFilePath, err := filepath.Abs(filepath.Join("testdata", "zarf-package", "data.txt"))

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -42,7 +42,7 @@ fb7ebee94a4479bacddd71195030a483b0b0b96d4f73f7fcd2c2c8e0fce0c5c6 components/helm
 
 	require.Equal(t, expectedChecksum, string(b))
 	testutil.RequireNoBackslashInPackagePaths(t, pkgLayout.Pkg)
-	require.Equal(t, "e9cc0c25b81b7a5abb29f181110210eab3274ec07a080cd171730bfa590575d9", testutil.ChecksumZarfYAMLContent(t, pkgLayout.Pkg), "skeleton zarf.yaml checksum drift — package would differ across build hosts")
+	require.Equal(t, "20c2cf8bde902c8daad1ad9fb3cd9f06741550ac34401474500a24835cb36114", testutil.ChecksumZarfYAMLContent(t, pkgLayout.Pkg), "skeleton zarf.yaml checksum drift — package would differ across build hosts")
 }
 
 func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+	"github.com/zarf-dev/zarf/src/types"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -36,20 +37,25 @@ func getComponentToImportName(component v1alpha1.ZarfComponent) string {
 	return component.Name
 }
 
-func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool) (v1alpha1.ZarfPackage, error) {
+func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool, remoteOptions types.RemoteOptions) (v1alpha1.ZarfPackage, error) {
 	l := logger.From(ctx)
 	start := time.Now()
+
+	pkgPath, err := layout.ResolvePackagePath(packagePath)
+	if err != nil {
+		return v1alpha1.ZarfPackage{}, err
+	}
 
 	// Zarf imports merge in the top level package objects variables and constants
 	// however, imports are defined at the component level.
 	// Two packages can both import one another as long as the importing components are on a different chains.
 	// To detect cyclic imports, the stack is checked to see if the package has already been imported on that chain.
 	// Recursive calls only include components from the imported pkg that have the name of the component to import
-	importStack = append(importStack, packagePath)
+	importStack = append(importStack, pkgPath.BaseDir)
 
 	l.Debug("start layout.ResolveImports",
 		"pkg", pkg.Metadata.Name,
-		"path", packagePath,
+		"path", pkgPath.ManifestFile,
 		"arch", arch,
 		"flavor", flavor,
 		"importStack", len(importStack),
@@ -76,13 +82,19 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 
 		var importedPkg v1alpha1.ZarfPackage
 		if component.Import.Path != "" {
-			importPath := filepath.Join(packagePath, component.Import.Path)
+			importPath := filepath.Join(pkgPath.BaseDir, component.Import.Path)
 			for _, sp := range importStack {
 				if sp == importPath {
-					return v1alpha1.ZarfPackage{}, fmt.Errorf("package %s imported in cycle by %s in component %s", filepath.ToSlash(importPath), filepath.ToSlash(packagePath), component.Name)
+					return v1alpha1.ZarfPackage{}, fmt.Errorf("package %s imported in cycle by %s in component %s", filepath.ToSlash(importPath), filepath.ToSlash(pkgPath.BaseDir), component.Name)
 				}
 			}
-			b, err := os.ReadFile(filepath.Join(importPath, layout.ZarfYAML))
+
+			importPkgPath, err := layout.ResolvePackagePath(importPath)
+			if err != nil {
+				return v1alpha1.ZarfPackage{}, fmt.Errorf("unable to access import package path %q: %w", importPath, err)
+			}
+
+			b, err := os.ReadFile(importPkgPath.ManifestFile)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
@@ -97,7 +109,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 				}
 			}
 			importedPkg.Components = relevantComponents
-			importedPkg, err = resolveImports(ctx, importedPkg, importPath, arch, flavor, importStack, cachePath, skipVersionCheck)
+			importedPkg, err = resolveImports(ctx, importedPkg, importPkgPath.ManifestFile, arch, flavor, importStack, cachePath, skipVersionCheck, remoteOptions)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
@@ -106,12 +118,16 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
-			remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(), cacheModifier)
+			remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(),
+				cacheModifier, oci.WithPlainHTTP(remoteOptions.PlainHTTP), oci.WithInsecureSkipVerify(remoteOptions.InsecureSkipTLSVerify))
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
 			_, err = remote.ResolveRoot(ctx)
 			if err != nil {
+				if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
+					return v1alpha1.ZarfPackage{}, fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
+				}
 				return v1alpha1.ZarfPackage{}, err
 			}
 			importedPkg, err = remote.FetchZarfYAML(ctx)
@@ -140,11 +156,21 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		}
 		importedComponent := found[0]
 
-		importPath, err := fetchOCISkeleton(ctx, component, packagePath, cachePath)
+		importPath, err := fetchOCISkeleton(ctx, component, pkgPath.BaseDir, cachePath, remoteOptions)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, err
 		}
-		importedComponent = fixPaths(importedComponent, importPath, packagePath)
+
+		// this is a special case for paths and imports where we do not want to join BaseDir and importPath
+		// we check that the path is valid but ensure the value remains relative for fixing
+		fileInfo, err := os.Stat(filepath.Join(pkgPath.BaseDir, importPath))
+		if err != nil {
+			return v1alpha1.ZarfPackage{}, fmt.Errorf("unable to access import path %q: %w", importPath, err)
+		}
+		if !fileInfo.IsDir() {
+			importPath = filepath.Dir(importPath)
+		}
+		importedComponent = fixPaths(importedComponent, importPath, pkgPath.BaseDir)
 		composed, err := overrideMetadata(importedComponent, component)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, err
@@ -218,7 +244,7 @@ func compatibleComponent(c v1alpha1.ZarfComponent, arch, flavor string) bool {
 }
 
 // TODO (phillebaba): Refactor package structure so that pullOCI can be used instead.
-func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string) (string, error) {
+func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string, remoteOptions types.RemoteOptions) (string, error) {
 	if component.Import.URL == "" {
 		return component.Import.Path, nil
 	}
@@ -234,12 +260,18 @@ func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, pac
 	}
 
 	// Get the descriptor for the component.
-	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton())
+	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(),
+		oci.WithPlainHTTP(remoteOptions.PlainHTTP), oci.WithInsecureSkipVerify(remoteOptions.InsecureSkipTLSVerify))
 	if err != nil {
 		return "", err
 	}
 	_, err = remote.ResolveRoot(ctx)
 	if err != nil {
+		// This error likely won't occur as the root has been resolved before this function is invoked.
+		// This serves as a secondary mechanism to highlight the potential for the package existing without a published skeleton.
+		if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
+			return "", fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
+		}
 		return "", fmt.Errorf("published skeleton package for %s does not exist: %w", component.Import.URL, err)
 	}
 	manifest, err := remote.FetchRoot(ctx)
@@ -396,6 +428,7 @@ func overrideResources(comp v1alpha1.ZarfComponent, override v1alpha1.ZarfCompon
 				}
 				comp.Charts[idx].ValuesFiles = append(comp.Charts[idx].ValuesFiles, overrideChart.ValuesFiles...)
 				comp.Charts[idx].Variables = append(comp.Charts[idx].Variables, overrideChart.Variables...)
+				comp.Charts[idx].Values = append(comp.Charts[idx].Values, overrideChart.Values...)
 				existing = true
 			}
 		}
@@ -426,6 +459,7 @@ func overrideResources(comp v1alpha1.ZarfComponent, override v1alpha1.ZarfCompon
 	}
 
 	comp.HealthChecks = append(comp.HealthChecks, override.HealthChecks...)
+	comp.ImageArchives = append(comp.ImageArchives, override.ImageArchives...)
 
 	return comp
 }
@@ -444,6 +478,11 @@ func fixPaths(child v1alpha1.ZarfComponent, relativeToHead, packagePath string) 
 	for fileIdx, file := range child.Files {
 		composed := makePathRelativeTo(file.Source, relativeToHead)
 		child.Files[fileIdx].Source = composed
+	}
+
+	for idx, imageArchive := range child.ImageArchives {
+		composed := makePathRelativeTo(imageArchive.Path, relativeToHead)
+		child.ImageArchives[idx].Path = composed
 	}
 
 	for chartIdx, chart := range child.Charts {

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -19,7 +19,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
-	"github.com/zarf-dev/zarf/src/types"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -37,25 +36,20 @@ func getComponentToImportName(component v1alpha1.ZarfComponent) string {
 	return component.Name
 }
 
-func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool, remoteOptions types.RemoteOptions) (v1alpha1.ZarfPackage, error) {
+func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool) (v1alpha1.ZarfPackage, error) {
 	l := logger.From(ctx)
 	start := time.Now()
-
-	pkgPath, err := layout.ResolvePackagePath(packagePath)
-	if err != nil {
-		return v1alpha1.ZarfPackage{}, err
-	}
 
 	// Zarf imports merge in the top level package objects variables and constants
 	// however, imports are defined at the component level.
 	// Two packages can both import one another as long as the importing components are on a different chains.
 	// To detect cyclic imports, the stack is checked to see if the package has already been imported on that chain.
 	// Recursive calls only include components from the imported pkg that have the name of the component to import
-	importStack = append(importStack, pkgPath.BaseDir)
+	importStack = append(importStack, packagePath)
 
 	l.Debug("start layout.ResolveImports",
 		"pkg", pkg.Metadata.Name,
-		"path", pkgPath.ManifestFile,
+		"path", packagePath,
 		"arch", arch,
 		"flavor", flavor,
 		"importStack", len(importStack),
@@ -82,19 +76,13 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 
 		var importedPkg v1alpha1.ZarfPackage
 		if component.Import.Path != "" {
-			importPath := filepath.Join(pkgPath.BaseDir, component.Import.Path)
+			importPath := filepath.Join(packagePath, component.Import.Path)
 			for _, sp := range importStack {
 				if sp == importPath {
-					return v1alpha1.ZarfPackage{}, fmt.Errorf("package %s imported in cycle by %s in component %s", filepath.ToSlash(importPath), filepath.ToSlash(pkgPath.BaseDir), component.Name)
+					return v1alpha1.ZarfPackage{}, fmt.Errorf("package %s imported in cycle by %s in component %s", filepath.ToSlash(importPath), filepath.ToSlash(packagePath), component.Name)
 				}
 			}
-
-			importPkgPath, err := layout.ResolvePackagePath(importPath)
-			if err != nil {
-				return v1alpha1.ZarfPackage{}, fmt.Errorf("unable to access import package path %q: %w", importPath, err)
-			}
-
-			b, err := os.ReadFile(importPkgPath.ManifestFile)
+			b, err := os.ReadFile(filepath.Join(importPath, layout.ZarfYAML))
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
@@ -109,7 +97,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 				}
 			}
 			importedPkg.Components = relevantComponents
-			importedPkg, err = resolveImports(ctx, importedPkg, importPkgPath.ManifestFile, arch, flavor, importStack, cachePath, skipVersionCheck, remoteOptions)
+			importedPkg, err = resolveImports(ctx, importedPkg, importPath, arch, flavor, importStack, cachePath, skipVersionCheck)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
@@ -118,16 +106,12 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
-			remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(),
-				cacheModifier, oci.WithPlainHTTP(remoteOptions.PlainHTTP), oci.WithInsecureSkipVerify(remoteOptions.InsecureSkipTLSVerify))
+			remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(), cacheModifier)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, err
 			}
 			_, err = remote.ResolveRoot(ctx)
 			if err != nil {
-				if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
-					return v1alpha1.ZarfPackage{}, fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
-				}
 				return v1alpha1.ZarfPackage{}, err
 			}
 			importedPkg, err = remote.FetchZarfYAML(ctx)
@@ -156,21 +140,11 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		}
 		importedComponent := found[0]
 
-		importPath, err := fetchOCISkeleton(ctx, component, pkgPath.BaseDir, cachePath, remoteOptions)
+		importPath, err := fetchOCISkeleton(ctx, component, packagePath, cachePath)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, err
 		}
-
-		// this is a special case for paths and imports where we do not want to join BaseDir and importPath
-		// we check that the path is valid but ensure the value remains relative for fixing
-		fileInfo, err := os.Stat(filepath.Join(pkgPath.BaseDir, importPath))
-		if err != nil {
-			return v1alpha1.ZarfPackage{}, fmt.Errorf("unable to access import path %q: %w", importPath, err)
-		}
-		if !fileInfo.IsDir() {
-			importPath = filepath.Dir(importPath)
-		}
-		importedComponent = fixPaths(importedComponent, importPath, pkgPath.BaseDir)
+		importedComponent = fixPaths(importedComponent, importPath, packagePath)
 		composed, err := overrideMetadata(importedComponent, component)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, err
@@ -244,7 +218,7 @@ func compatibleComponent(c v1alpha1.ZarfComponent, arch, flavor string) bool {
 }
 
 // TODO (phillebaba): Refactor package structure so that pullOCI can be used instead.
-func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string, remoteOptions types.RemoteOptions) (string, error) {
+func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string) (string, error) {
 	if component.Import.URL == "" {
 		return component.Import.Path, nil
 	}
@@ -260,18 +234,12 @@ func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, pac
 	}
 
 	// Get the descriptor for the component.
-	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(),
-		oci.WithPlainHTTP(remoteOptions.PlainHTTP), oci.WithInsecureSkipVerify(remoteOptions.InsecureSkipTLSVerify))
+	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton())
 	if err != nil {
 		return "", err
 	}
 	_, err = remote.ResolveRoot(ctx)
 	if err != nil {
-		// This error likely won't occur as the root has been resolved before this function is invoked.
-		// This serves as a secondary mechanism to highlight the potential for the package existing without a published skeleton.
-		if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
-			return "", fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
-		}
 		return "", fmt.Errorf("published skeleton package for %s does not exist: %w", component.Import.URL, err)
 	}
 	manifest, err := remote.FetchRoot(ctx)
@@ -428,7 +396,6 @@ func overrideResources(comp v1alpha1.ZarfComponent, override v1alpha1.ZarfCompon
 				}
 				comp.Charts[idx].ValuesFiles = append(comp.Charts[idx].ValuesFiles, overrideChart.ValuesFiles...)
 				comp.Charts[idx].Variables = append(comp.Charts[idx].Variables, overrideChart.Variables...)
-				comp.Charts[idx].Values = append(comp.Charts[idx].Values, overrideChart.Values...)
 				existing = true
 			}
 		}
@@ -459,7 +426,6 @@ func overrideResources(comp v1alpha1.ZarfComponent, override v1alpha1.ZarfCompon
 	}
 
 	comp.HealthChecks = append(comp.HealthChecks, override.HealthChecks...)
-	comp.ImageArchives = append(comp.ImageArchives, override.ImageArchives...)
 
 	return comp
 }
@@ -471,18 +437,13 @@ func makePathRelativeTo(path, relativeTo string) string {
 	if filepath.IsAbs(path) {
 		return path
 	}
-	return filepath.Join(relativeTo, path)
+	return filepath.ToSlash(filepath.Join(relativeTo, path))
 }
 
 func fixPaths(child v1alpha1.ZarfComponent, relativeToHead, packagePath string) v1alpha1.ZarfComponent {
 	for fileIdx, file := range child.Files {
 		composed := makePathRelativeTo(file.Source, relativeToHead)
 		child.Files[fileIdx].Source = composed
-	}
-
-	for idx, imageArchive := range child.ImageArchives {
-		composed := makePathRelativeTo(imageArchive.Path, relativeToHead)
-		child.ImageArchives[idx].Path = composed
 	}
 
 	for chartIdx, chart := range child.Charts {

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
+	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
-	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestResolveImportsCircular(t *testing.T) {
@@ -23,48 +23,52 @@ func TestResolveImportsCircular(t *testing.T) {
 
 	ctx := testutil.TestContext(t)
 
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
+
 	b, err := os.ReadFile(filepath.Join("./testdata/import/circular/first", layout.ZarfYAML))
 	require.NoError(t, err)
 	pkg, err := pkgcfg.Parse(ctx, b)
 	require.NoError(t, err)
 
-	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false, types.RemoteOptions{})
+	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false)
 	require.EqualError(t, err, "package testdata/import/circular/second imported in cycle by testdata/import/circular/third in component component")
 }
 
 func TestResolveImports(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.TestContext(t)
-
+	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
 	testCases := []struct {
-		name   string
-		path   string
-		flavor string
+		name             string
+		path             string
+		flavor           string
+		expectedChecksum string
 	}{
 		{
-			name: "two zarf.yaml files import each other",
-			path: "./testdata/import/import-each-other",
+			name:             "two zarf.yaml files import each other",
+			path:             "./testdata/import/import-each-other",
+			expectedChecksum: "1ba733591d28761e89f6a576593cb3a09000f3d6a699212214a5aceaf74455c0",
 		},
 		{
-			name: "variables and constants are resolved correctly",
-			path: "./testdata/import/variables",
+			name:             "variables and constants are resolved correctly",
+			path:             "./testdata/import/variables",
+			expectedChecksum: "41e3bdf823769eb2c13079191179ee723a6b8550c5492a8668233de8b77e03da",
 		},
 		{
-			name: "two separate chains of imports importing a common file",
-			path: "./testdata/import/branch",
+			name:             "two separate chains of imports importing a common file",
+			path:             "./testdata/import/branch",
+			expectedChecksum: "5213106f8fb4a752a44fc2fd370c06335c31069113d9148ad627082510e9a4ef",
 		},
 		{
-			name:   "flavor is preserved when importing",
-			path:   "./testdata/import/flavor",
-			flavor: "pistachio",
+			name:             "flavor is preserved when importing",
+			path:             "./testdata/import/flavor",
+			flavor:           "pistachio",
+			expectedChecksum: "9c60125954b1b38a5947401411b87cde3d586e5ff8eef03bcc37dae1e24ab08e",
 		},
 		{
-			name: "chart version and url properties are not overridden",
-			path: "./testdata/import/chart",
-		},
-		{
-			name: "archives work as expected",
-			path: "./testdata/import/archives",
+			name:             "chart version and url properties are not overridden",
+			path:             "./testdata/import/chart",
+			expectedChecksum: "e1b2c6ed6e17d37a6861046e4443440028994c38400e7089d481435a9e149df8",
 		},
 	}
 
@@ -77,7 +81,7 @@ func TestResolveImports(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false, types.RemoteOptions{})
+			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false)
 			require.NoError(t, err)
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
@@ -86,6 +90,8 @@ func TestResolveImports(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, expectedPkg, resolvedPkg)
+			testutil.RequireNoBackslashInPackagePaths(t, resolvedPkg)
+			require.Equal(t, tc.expectedChecksum, testutil.ChecksumZarfYAMLContent(t, resolvedPkg), "resolved zarf.yaml checksum drift — package would differ across build hosts")
 		})
 	}
 }

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -64,8 +64,9 @@ func TestResolveImports(t *testing.T) {
 			expectedChecksum: "9c60125954b1b38a5947401411b87cde3d586e5ff8eef03bcc37dae1e24ab08e",
 		},
 		{
-			name:             "chart version and url properties are not overridden",
-			path:             "./testdata/import/chart",
+			name: "chart version and url properties are not overridden",
+			path: "./testdata/import/chart",
+
 			expectedChecksum: "cc62674a6faa1c9685aac0c8266dacec3b91e0a9466c8d1ce3664e019348b43a",
 		},
 		{
@@ -102,6 +103,9 @@ func TestResolveImports(t *testing.T) {
 func TestMakePathRelativeTo(t *testing.T) {
 	t.Parallel()
 
+	absPath, err := filepath.Abs(filepath.Join("abs", "data.txt"))
+	require.NoError(t, err)
+
 	tests := []struct {
 		name       string
 		path       string
@@ -128,9 +132,9 @@ func TestMakePathRelativeTo(t *testing.T) {
 		},
 		{
 			name:       "absolute path passes through untouched",
-			path:       "/abs/data.txt",
+			path:       absPath,
 			relativeTo: "import",
-			expected:   "/abs/data.txt",
+			expected:   absPath,
 		},
 	}
 
@@ -139,7 +143,9 @@ func TestMakePathRelativeTo(t *testing.T) {
 			t.Parallel()
 			got := makePathRelativeTo(tt.path, tt.relativeTo)
 			require.Equal(t, tt.expected, got)
-			require.Falsef(t, strings.ContainsRune(got, '\\'), "result %q contains a backslash", got)
+			if !filepath.IsAbs(tt.path) {
+				require.Falsef(t, strings.ContainsRune(got, '\\'), "result %q contains a backslash", got)
+			}
 		})
 	}
 }

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -66,11 +66,12 @@ func TestResolveImports(t *testing.T) {
 		{
 			name:             "chart version and url properties are not overridden",
 			path:             "./testdata/import/chart",
-			expectedChecksum: "e1b2c6ed6e17d37a6861046e4443440028994c38400e7089d481435a9e149df8",
+			expectedChecksum: "cc62674a6faa1c9685aac0c8266dacec3b91e0a9466c8d1ce3664e019348b43a",
 		},
 		{
-			name: "archives work as expected",
-			path: "./testdata/import/archives",
+			name:             "archives work as expected",
+			path:             "./testdata/import/archives",
+			expectedChecksum: "9601cb578d72727bba116d008a23f63ac6dd40c3a685e1d790d376469792db5a",
 		},
 	}
 
@@ -94,6 +95,51 @@ func TestResolveImports(t *testing.T) {
 			require.Equal(t, expectedPkg, resolvedPkg)
 			testutil.RequireNoBackslashInPackagePaths(t, resolvedPkg)
 			require.Equal(t, tc.expectedChecksum, testutil.ChecksumZarfYAMLContent(t, resolvedPkg), "resolved zarf.yaml checksum drift — package would differ across build hosts")
+		})
+	}
+}
+
+func TestMakePathRelativeTo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		relativeTo string
+		expected   string
+	}{
+		{
+			name:       "multi-segment relative path joins with forward slashes",
+			path:       "nested/data.txt",
+			relativeTo: "import",
+			expected:   "import/nested/data.txt",
+		},
+		{
+			name:       "single-segment relative path joins with forward slash",
+			path:       "data.txt",
+			relativeTo: "import",
+			expected:   "import/data.txt",
+		},
+		{
+			name:       "URL passes through untouched",
+			path:       "oci://example.com/pkg:v1",
+			relativeTo: "import",
+			expected:   "oci://example.com/pkg:v1",
+		},
+		{
+			name:       "absolute path passes through untouched",
+			path:       "/abs/data.txt",
+			relativeTo: "import",
+			expected:   "/abs/data.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := makePathRelativeTo(tt.path, tt.relativeTo)
+			require.Equal(t, tt.expected, got)
+			require.Falsef(t, strings.ContainsRune(got, '\\'), "result %q contains a backslash", got)
 		})
 	}
 }

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
-	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
+	"github.com/zarf-dev/zarf/src/types"
 )
 
 func TestResolveImportsCircular(t *testing.T) {
@@ -23,21 +23,19 @@ func TestResolveImportsCircular(t *testing.T) {
 
 	ctx := testutil.TestContext(t)
 
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
-
 	b, err := os.ReadFile(filepath.Join("./testdata/import/circular/first", layout.ZarfYAML))
 	require.NoError(t, err)
 	pkg, err := pkgcfg.Parse(ctx, b)
 	require.NoError(t, err)
 
-	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false)
+	_, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false, types.RemoteOptions{})
 	require.EqualError(t, err, "package testdata/import/circular/second imported in cycle by testdata/import/circular/third in component component")
 }
 
 func TestResolveImports(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.TestContext(t)
-	lint.ZarfSchema = testutil.LoadSchema(t, "../../../../zarf.schema.json")
+
 	testCases := []struct {
 		name             string
 		path             string
@@ -70,6 +68,10 @@ func TestResolveImports(t *testing.T) {
 			path:             "./testdata/import/chart",
 			expectedChecksum: "e1b2c6ed6e17d37a6861046e4443440028994c38400e7089d481435a9e149df8",
 		},
+		{
+			name: "archives work as expected",
+			path: "./testdata/import/archives",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -81,7 +83,7 @@ func TestResolveImports(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false)
+			resolvedPkg, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false, types.RemoteOptions{})
 			require.NoError(t, err)
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))

--- a/src/test/testutil/paths.go
+++ b/src/test/testutil/paths.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package testutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+// ChecksumZarfYAMLContent returns sha256(marshal(pkg)) with pkg.Build zeroed.
+// Build carries intrinsically non-reproducible values (timestamp, user,
+// hostname, CLI version) so it is excluded; the result pins everything else
+// and must be stable across build hosts.
+func ChecksumZarfYAMLContent(t *testing.T, pkg v1alpha1.ZarfPackage) string {
+	t.Helper()
+	pkg.Build = v1alpha1.ZarfBuildData{}
+	b, err := goyaml.Marshal(pkg)
+	require.NoError(t, err)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// RequireNoBackslashInPackagePaths asserts every path field serialized into a
+// built zarf.yaml uses forward-slash separators, so artifacts are byte-identical
+// across build hosts.
+func RequireNoBackslashInPackagePaths(t *testing.T, pkg v1alpha1.ZarfPackage) {
+	t.Helper()
+
+	check := func(field, value string) {
+		require.Falsef(t, strings.ContainsRune(value, '\\'), "%s contains a backslash: %q", field, value)
+	}
+
+	for i, f := range pkg.Values.Files {
+		check("values.files["+strconv.Itoa(i)+"]", f)
+	}
+
+	for ci, comp := range pkg.Components {
+		prefix := "components[" + strconv.Itoa(ci) + "]"
+		for fi, f := range comp.Files {
+			check(prefix+".files["+strconv.Itoa(fi)+"].source", f.Source)
+		}
+		for chi, ch := range comp.Charts {
+			check(prefix+".charts["+strconv.Itoa(chi)+"].localPath", ch.LocalPath)
+			for vi, v := range ch.ValuesFiles {
+				check(prefix+".charts["+strconv.Itoa(chi)+"].valuesFiles["+strconv.Itoa(vi)+"]", v)
+			}
+		}
+		for mi, m := range comp.Manifests {
+			for fi, f := range m.Files {
+				check(prefix+".manifests["+strconv.Itoa(mi)+"].files["+strconv.Itoa(fi)+"]", f)
+			}
+			for ki, k := range m.Kustomizations {
+				check(prefix+".manifests["+strconv.Itoa(mi)+"].kustomizations["+strconv.Itoa(ki)+"]", k)
+			}
+		}
+		for di, d := range comp.DataInjections {
+			check(prefix+".dataInjections["+strconv.Itoa(di)+"].source", d.Source)
+		}
+		actionsByName := map[string][]v1alpha1.ZarfComponentAction{
+			"before":    comp.Actions.OnCreate.Before,
+			"after":     comp.Actions.OnCreate.After,
+			"onFailure": comp.Actions.OnCreate.OnFailure,
+			"onSuccess": comp.Actions.OnCreate.OnSuccess,
+		}
+		for name, actions := range actionsByName {
+			for ai, action := range actions {
+				if action.Dir != nil {
+					check(prefix+".actions.onCreate."+name+"["+strconv.Itoa(ai)+"].dir", *action.Dir)
+				}
+			}
+		}
+		check(prefix+".actions.onCreate.defaults.dir", comp.Actions.OnCreate.Defaults.Dir)
+	}
+}


### PR DESCRIPTION
## Description

I bumped this issue in priority after realizing the implications. 

Built Zarf packages should be byte-identical across operating systems, but filepath.Join was producing OS-native separators in path strings that get serialized into the published zarf package.

This really only impacts import/skeletons and how paths are resolved to my knowledge. Worth doing now as a pattern before we introduce any new import/component behaviors. 

This statically defines checksums in testing which can be a burden during development when the package shape changes but a worthwhile tradeoff for reproducibility. 

## Related Issue

Fixes #3275 
<!-- or -->
Relates to #

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
