### PR TITLE
chore: move kiwix example s3 url

### DIFF
--- a/examples/kiwix/zarf.yaml
+++ b/examples/kiwix/zarf.yaml
@@ -23,7 +23,7 @@ components:
       onCreate:
         before:
           # Download a .zim file of a DevOps Stack Exchange snapshot so that it can placed in the image we're building
-          - cmd: curl https://zarf-remote.s3.us-east-2.amazonaws.com/testdata/devops.stackexchange.com_en_all_2023-05.zim -o zim-data/devops.stackexchange.com_en_all_2023-05.zim
+          - cmd: curl https://zarf-init-resources-dev.s3.us-east-1.amazonaws.com/devops.stackexchange.com_en_all_2026-02.zim -o zim-data/devops.stackexchange.com_en_all_2026-02.zim
           # Below are some more examples of *.zim files of available content:
           # https://library.kiwix.org/?lang=eng
           # NOTE: If `zarf package create`ing regularly you should mirror content to a web host you control to be a friendly neighbor

--- a/src/test/packages/23-data-injections/zarf.yaml
+++ b/src/test/packages/23-data-injections/zarf.yaml
@@ -33,7 +33,7 @@ components:
       onCreate:
         before:
           # Download a .zim file of a DevOps Stack Exchange snapshot into the data directory for use with Kiwix
-          - cmd: curl https://zarf-remote.s3.us-east-2.amazonaws.com/testdata/devops.stackexchange.com_en_all_2023-05.zim -o zim-data/devops.stackexchange.com_en_all_2023-05.zim
+          - cmd: curl https://zarf-init-resources-dev.s3.us-east-1.amazonaws.com/devops.stackexchange.com_en_all_2026-02.zim -o zim-data/devops.stackexchange.com_en_all_2026-02.zim
           # Below are some more examples of *.zim files of available content:
           # https://library.kiwix.org/?lang=eng
           # NOTE: If `zarf package create`ing regularly you should mirror content to a web host you control to be a friendly neighbor

--- a/src/test/packages/23-data-injections/zarf.yaml
+++ b/src/test/packages/23-data-injections/zarf.yaml
@@ -33,7 +33,7 @@ components:
       onCreate:
         before:
           # Download a .zim file of a DevOps Stack Exchange snapshot into the data directory for use with Kiwix
-          - cmd: curl https://zarf-init-resources-dev.s3.us-east-1.amazonaws.com/devops.stackexchange.com_en_all_2026-02.zim -o zim-data/devops.stackexchange.com_en_all_2026-02.zim
+          - cmd: curl https://zarf-remote.s3.us-east-2.amazonaws.com/testdata/devops.stackexchange.com_en_all_2023-05.zim -o zim-data/devops.stackexchange.com_en_all_2023-05.zim
           # Below are some more examples of *.zim files of available content:
           # https://library.kiwix.org/?lang=eng
           # NOTE: If `zarf package create`ing regularly you should mirror content to a web host you control to be a friendly neighbor


### PR DESCRIPTION
## Description

This fixes a broken s3 url in the kiwix example

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
