### PR TITLE
chore(ci): update data injection test

### DIFF
--- a/src/test/e2e/23_data_injection_test.go
+++ b/src/test/e2e/23_data_injection_test.go
@@ -26,7 +26,7 @@ func TestDataInjection(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	ctx := logger.WithContext(context.Background(), test.GetLogger(t))
-	packageName := fmt.Sprintf("zarf-package-kiwix-%s-3.5.0.tar", e2e.Arch)
+	packageName := fmt.Sprintf("zarf-package-data-injection-%s-1.0.0.tar", e2e.Arch)
 	path := filepath.Join(tmpdir, packageName)
 
 	sbomPath := filepath.Join(tmpdir, ".sbom-location")
@@ -37,17 +37,17 @@ func TestDataInjection(t *testing.T) {
 	}
 
 	// Verify the file and injection marker were created
-	runningKiwixPod, _, err := e2e.Kubectl(t, "--namespace=kiwix", "get", "pods", "--selector=app=kiwix-serve", "--field-selector=status.phase=Running", "--output=jsonpath={.items[0].metadata.name}")
+	runningPod, _, err := e2e.Kubectl(t, "--namespace=data-injection", "get", "pods", "--selector=app=file-server", "--field-selector=status.phase=Running", "--output=jsonpath={.items[0].metadata.name}")
 	require.NoError(t, err)
-	stdOut, stdErr, err = e2e.Kubectl(t, "--namespace=kiwix", "logs", runningKiwixPod, "--tail=5", "-c=kiwix-serve")
+	stdOut, stdErr, err = e2e.Kubectl(t, "--namespace=data-injection", "logs", runningPod, "--tail=50", "-c=file-server")
 	require.NoError(t, err, stdOut, stdErr)
-	require.Contains(t, stdOut, "devops.stackexchange.com_en_all_2023-05.zim")
+	require.Contains(t, stdOut, "hello.txt")
 	require.Contains(t, stdOut, ".zarf-injection-")
 
 	// need target to equal svc that we are trying to connect to call checkForZarfConnectLabel
 	c, err := cluster.New(ctx)
 	require.NoError(t, err)
-	tunnel, err := c.Connect(ctx, "kiwix")
+	tunnel, err := c.Connect(ctx, "file-server")
 	require.NoError(t, err)
 	defer tunnel.Close()
 
@@ -55,7 +55,7 @@ func TestDataInjection(t *testing.T) {
 	require.Len(t, endpoints, 1)
 
 	// Ensure connection
-	resp, err := http.Get(endpoints[0])
+	resp, err := http.Get(endpoints[0] + "/hello.txt")
 	require.NoError(t, err, resp)
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -63,13 +63,11 @@ func TestDataInjection(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", path, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
-	// Ensure that the `requirements.txt` file is discovered correctly
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "inspect", "sbom", path, "--output", sbomPath)
 	require.NoError(t, err, stdOut, stdErr)
-	require.FileExists(t, filepath.Join(sbomPath, "kiwix", "compare.html"), "A compare.html file should have been made")
 
-	require.FileExists(t, filepath.Join(sbomPath, "kiwix", "sbom-viewer-zarf-component-kiwix-serve.html"), "The data-injection component should have an SBOM viewer")
-	require.FileExists(t, filepath.Join(sbomPath, "kiwix", "zarf-component-kiwix-serve.json"), "The data-injection component should have an SBOM json")
+	require.FileExists(t, filepath.Join(sbomPath, "data-injection", "sbom-viewer-zarf-component-file-server.html"), "The data-injection component should have an SBOM viewer")
+	require.FileExists(t, filepath.Join(sbomPath, "data-injection", "zarf-component-file-server.json"), "The data-injection component should have an SBOM json")
 }
 
 func runDataInjection(t *testing.T, path string) {

--- a/src/test/packages/23-data-injections/injected-data/hello.txt
+++ b/src/test/packages/23-data-injections/injected-data/hello.txt
@@ -1,0 +1,1 @@
+Hello from Zarf data injection!

--- a/src/test/packages/23-data-injections/manifests/deployment.yaml
+++ b/src/test/packages/23-data-injections/manifests/deployment.yaml
@@ -1,26 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kiwix-serve
-  namespace: kiwix
+  name: file-server
+  namespace: data-injection
   labels:
-    app: kiwix-serve
+    app: file-server
 spec:
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: kiwix-serve
+      app: file-server
   template:
     metadata:
       labels:
-        app: kiwix-serve
+        app: file-server
     spec:
-      # Kiwix can hot-load files from the filesystem, but if your application cannot, this example shows how you can use an initContainer to bootstrap the injected files.
+      # The main container can hot-load files from the filesystem, but if your application cannot, this example shows how you can use an initContainer to bootstrap the injected files.
       # It's necessary to include the ###ZARF_DATA_INJECTION_MARKER### somewhere in the podspec, otherwise data injections will not occur.
       initContainers:
         - name: data-loader
-          image: alpine:3.18
+          image: ghcr.io/static-web-server/static-web-server:2.32.1-alpine
           command:
             [
               "sh",
@@ -39,13 +39,13 @@ spec:
             - mountPath: /data
               name: data
       containers:
-        - name: kiwix-serve
-          image: "ghcr.io/kiwix/kiwix-serve:3.5.0-2"
+        - name: file-server
+          image: "ghcr.io/static-web-server/static-web-server:2.32.1-alpine"
           command:
             [
               "sh",
               "-c",
-              "ls -la /data && kiwix-serve -v /data/*.zim",
+              "ls -la /data && exec static-web-server --root /data --port 80 --log-level error",
             ]
           ports:
             - name: http
@@ -53,19 +53,19 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              memory: "16Mi"
+              cpu: "50m"
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "64Mi"
+              cpu: "100m"
           volumeMounts:
             - name: data
               mountPath: /data
           readinessProbe:
             httpGet:
-              path: /
+              path: /hello.txt
               port: 80
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: kiwix-data
+            claimName: injected-data

--- a/src/test/packages/23-data-injections/manifests/persistence.yaml
+++ b/src/test/packages/23-data-injections/manifests/persistence.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: kiwix-data
+  name: injected-data
 spec:
   accessModes:
     - ReadWriteOnce

--- a/src/test/packages/23-data-injections/manifests/service.yaml
+++ b/src/test/packages/23-data-injections/manifests/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kiwix
+  name: file-server
   annotations:
-    zarf.dev/connect-description: "View the Kiwix web interface"
+    zarf.dev/connect-description: "View the injected files"
   labels:
-    zarf.dev/connect-name: kiwix
+    zarf.dev/connect-name: file-server
 spec:
   selector:
-    app: kiwix-serve
+    app: file-server
   ports:
     - name: http
       port: 8080

--- a/src/test/packages/23-data-injections/manifests/service.yaml
+++ b/src/test/packages/23-data-injections/manifests/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: file-server
   annotations:
     zarf.dev/connect-description: "View the injected files"
+    zarf.dev/connect-url: "/hello.txt"    
   labels:
     zarf.dev/connect-name: file-server
 spec:

--- a/src/test/packages/23-data-injections/zarf.yaml
+++ b/src/test/packages/23-data-injections/zarf.yaml
@@ -1,39 +1,30 @@
 kind: ZarfPackageConfig
 metadata:
-  name: kiwix
-  description: Demo Zarf data injection with Kiwix (https://www.kiwix.org/en/)
+  name: data-injection
+  description: E2E test for Zarf data injection into a running pod
   # (optional) Some large datasets may already be compressed making Zarf compression less efficient
   uncompressed: true
-  version: 3.5.0
+  version: 1.0.0
 
 components:
-  - name: kiwix-serve
+  - name: file-server
     required: true
     manifests:
-      - name: kiwix-serve
-        namespace: kiwix
+      - name: file-server
+        namespace: data-injection
         files:
           - manifests/persistence.yaml
           - manifests/deployment.yaml
           - manifests/service.yaml
     images:
-      - ghcr.io/kiwix/kiwix-serve:3.5.0-2
-      - alpine:3.18
+      - ghcr.io/static-web-server/static-web-server:2.32.1-alpine
     # Add new data into the cluster, these will keep trying up until their timeout
     dataInjections:
       # Injection in the data directory using the data-loader init container
-      - source: zim-data
+      - source: injected-data
         target:
-          namespace: kiwix
-          selector: app=kiwix-serve
+          namespace: data-injection
+          selector: app=file-server
           container: data-loader
           path: /data
         compress: true
-    actions:
-      onCreate:
-        before:
-          # Download a .zim file of a DevOps Stack Exchange snapshot into the data directory for use with Kiwix
-          - cmd: curl https://zarf-remote.s3.us-east-2.amazonaws.com/testdata/devops.stackexchange.com_en_all_2023-05.zim -o zim-data/devops.stackexchange.com_en_all_2023-05.zim
-          # Below are some more examples of *.zim files of available content:
-          # https://library.kiwix.org/?lang=eng
-          # NOTE: If `zarf package create`ing regularly you should mirror content to a web host you control to be a friendly neighbor


### PR DESCRIPTION
## Description

Update the data injection test to no longer use the kiwix example. We'll still need to push an image for kiwix to the zarf organization projects for the example. 

the connect label still functions but you need to navigate to `/hello.txt` as I didn't add an index file. 

## Related Issue

no associated issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
