### PR TITLE
chore(examples): fail fast on error

### DIFF
--- a/examples/kiwix/zarf.yaml
+++ b/examples/kiwix/zarf.yaml
@@ -23,7 +23,7 @@ components:
       onCreate:
         before:
           # Download a .zim file of a DevOps Stack Exchange snapshot so that it can placed in the image we're building
-          - cmd: curl https://zarf-init-resources-dev.s3.us-east-1.amazonaws.com/devops.stackexchange.com_en_all_2026-02.zim -o zim-data/devops.stackexchange.com_en_all_2026-02.zim
+          - cmd: curl -fSL https://zarf-init-resources-dev.s3.us-east-1.amazonaws.com/devops.stackexchange.com_en_all_2026-02.zim -o zim-data/devops.stackexchange.com_en_all_2026-02.zim
           # Below are some more examples of *.zim files of available content:
           # https://library.kiwix.org/?lang=eng
           # NOTE: If `zarf package create`ing regularly you should mirror content to a web host you control to be a friendly neighbor


### PR DESCRIPTION
## Description

I recalled an additional problem that lead to the CI failures for this `kiwix` package whereby the curl originally failed silently. 

`-fSL` will ensure this fails fast (during package create)
```
-f / --fail: exit non-zero on HTTP 4xx/5xx instead of writing the error body to the file
-S / --show-error: still print the error message (useful alongside -s, harmless on its own)
-L / --location: follow redirects (S3 sometimes 301s/307s)
```

## Related Issue

No associated issue

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
