### PR TITLE
ci: speed up windows tests

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -40,9 +40,10 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run Windows unit tests
-        run: make test-unit
+        run: make test-unit-quick
         shell: pwsh
 
   test-e2e-without-cluster:
@@ -55,6 +56,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build Windows binary and zarf packages
         uses: ./.github/actions/packages

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          # Windows can take 20+ minutes in the post-setup step if there is a cache
           cache: false
 
       - name: Run Windows unit tests
@@ -56,6 +57,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          # Windows can take 20+ minutes in the post-setup step if there is a cache
           cache: false
 
       - name: Build Windows binary and zarf packages

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,10 @@ test-upgrade: ## Run the Zarf CLI E2E tests for an external registry and cluster
 test-unit: ## Run unit tests
 	go test -failfast -v -race -coverprofile=coverage.out -covermode=atomic $$(go list ./... | grep -v '^github.com/zarf-dev/zarf/src/test')
 
+.PHONY: test-unit-quick
+test-unit-quick: ## Run unit tests without the race detector or coverage
+	go test -failfast -v $$(go list ./... | grep -v '^github.com/zarf-dev/zarf/src/test')
+
 # INTERNAL: used to test that a dev has ran `make docs-and-schema` in their PR
 test-docs-and-schema:
 	$(MAKE) docs-and-schema


### PR DESCRIPTION
## Description

It's common for windows unit tests to take 40+ minutes https://github.com/zarf-dev/zarf/actions/runs/25177060585/job/73811938191. Often 20+ minutes waiting on the post-setup step, I believe because of the cache. I'm hoping this will speed it up. 

From this PR, unit tests took 11 minutes, and there was no 20 minute shutdown time. If we move to a vendor system this will get even faster

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
