### PR TITLE
chore(go): update go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ Every commit now runs the hooks; linting can also be invoked directly via `make 
 
 When upgrading a pinned hook, run `pre-commit autoupdate --freeze` — the `--freeze` flag writes the resolved commit SHA (rather than the tag) back into `rev:`. Update the trailing tag comment to match, so the config stays auditable.
 
+### Go Version Policy
+
+Zarf is consumed as a Go library, so the `go` directive in `go.mod` sets the minimum Go version every downstream consumer must use to build zarf.
+
+- Keep the directive at the oldest currently-supported Go major version (see [Go's release policy](https://go.dev/doc/devel/release#policy)). Setting it higher forces every downstream consumer to upgrade alongside us.
+- Bump the directive only when zarf code adopts a language feature or stdlib API that requires it. Transitive dependencies can also force a bump if they raise their own `go` directive above ours.
+- Patch-version bumps are optional for library consumers (they patch via their own toolchain), but appropriate when fixes affect code paths zarf exercises, the shipped CLI binary, or trigger scanner/SBOM noise against the declared version.
+- Reassess on each Go major release.
+
+Bumping the directive raises the minimum for every consumer; call it out in the PR description and reference it in release notes.
+
 ### Contributing Guidelines
 
 Zarf is a tool used within the United States Government and as such security is our highest priority. Contributors external to Defense Unicorns or non-Zarf maintainers will require two (2) reviewers.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarf-dev/zarf
 
-go 1.25.8
+go 1.25.9
 
 // TODO (@AABRO): Pending merge into github.com/gojsonschema/gojsonschema (https://github.com/gojsonschema/gojsonschema/pull/5)
 replace github.com/xeipuuv/gojsonschema => github.com/defenseunicorns/gojsonschema v0.0.0-20231116163348-e00f069122d6


### PR DESCRIPTION
## Description

We have users behind enterprise proxies reporting issues that boil down to limitations in golang and the stdlib itself. 

I think it's important to call out the implications of bumping the project go version - particularly the implications to downstream consumers of the library. The contributing documentation felt like the most appropriate location. If zarf bumps to the latest available version - we inherently have put all consumers under the burden of ensuring they can do the same as we've raised the "floor" of versions they must use - and in some scenarios that requires extra work. 

To say this another way:
> Each individual go directive is a minimum the module declares for itself: "to build me, you need at least this version." That's a per-module floor.

> When you build, Go walks the dependency graph, collects every module's floor, and picks the maximum of those floors as the effective Go version for the build. That single number is what satisfies everyone, because the highest floor automatically clears all the lower ones.

Unless we have a distinct need for the latest minor version features OR a core dependency raises the floor for us - we should attempt to use the oldest-supported go version (N-1) per Golang policy. 

Bumping patches may be needed as required and documented in the inlcuded guidance. Additionally we should call out when this version changes. In this example - bumping to `1.25.9` resolves a number of [findings](https://github.com/golang/go/issues?q=milestone%3AGo1.25.9+label%3ACherryPickApproved) that are relevant to our utility of the stdlib. 

Note: on a quick adventure - I see the next helm release is likely going to force us up to 1.26.0. 

## Related Issue

No associated issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
