### PR TITLE
fix(deploy): scope installedCharts by namespace override

### DIFF
--- a/src/pkg/cluster/zarf_test.go
+++ b/src/pkg/cluster/zarf_test.go
@@ -14,8 +14,65 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 )
+
+func TestGetInstalledChartsForComponentNamespaceOverride(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := &Cluster{Clientset: fake.NewClientset()}
+
+	componentName := "games"
+	packageName := "dos-games"
+
+	packages := []state.DeployedPackage{
+		{
+			Name: packageName,
+			DeployedComponents: []state.DeployedComponent{{
+				Name: componentName,
+				InstalledCharts: []state.InstalledChart{
+					{Namespace: "dos-games", ChartName: "zarf-original"},
+				},
+			}},
+		},
+		{
+			Name:              packageName,
+			NamespaceOverride: "arcade-alt",
+			DeployedComponents: []state.DeployedComponent{{
+				Name: componentName,
+				InstalledCharts: []state.InstalledChart{
+					{Namespace: "arcade-alt", ChartName: "zarf-override"},
+				},
+			}},
+		},
+	}
+
+	for _, p := range packages {
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.GetSecretName(),
+				Namespace: "zarf",
+				Labels:    map[string]string{state.ZarfPackageInfoLabel: p.Name},
+			},
+			Data: map[string][]byte{"data": b},
+		}
+		_, err = c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &secret, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	component := v1alpha1.ZarfComponent{Name: componentName}
+
+	originalCharts, err := c.GetInstalledChartsForComponent(ctx, packageName, component)
+	require.NoError(t, err)
+	require.Equal(t, []state.InstalledChart{{Namespace: "dos-games", ChartName: "zarf-original"}}, originalCharts)
+
+	overrideCharts, err := c.GetInstalledChartsForComponent(ctx, packageName, component, state.WithPackageNamespaceOverride("arcade-alt"))
+	require.NoError(t, err)
+	require.Equal(t, []state.InstalledChart{{Namespace: "arcade-alt", ChartName: "zarf-override"}}, overrideCharts)
+}
 
 func TestGetDeployedPackage(t *testing.T) {
 	t.Parallel()

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -249,7 +249,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 
 		// Ensure we don't overwrite any installedCharts data when updating the package secret
 		if d.isConnectedToCluster() {
-			installedCharts, err := d.c.GetInstalledChartsForComponent(ctx, pkgLayout.Pkg.Metadata.Name, component)
+			installedCharts, err := d.c.GetInstalledChartsForComponent(ctx, pkgLayout.Pkg.Metadata.Name, component, state.WithPackageNamespaceOverride(opts.NamespaceOverride))
 			if err != nil {
 				l.Debug("unable to fetch installed Helm charts", "component", component.Name, "error", err.Error())
 			}

--- a/src/test/e2e/40_namespace_override_test.go
+++ b/src/test/e2e/40_namespace_override_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -65,9 +66,35 @@ func TestSingleNamespaceOverride(t *testing.T) {
 		require.Equal(t, "test2", configMap.Namespace)
 	}
 
+	// The override package's state secret must list only charts deployed under the override namespace
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "secret", "-n", "zarf", "zarf-package-test-package-override-test2", "-o", "jsonpath={.data.data}")
+	require.NoError(t, err, stdOut, stdErr)
+	rawSecret, err := base64.StdEncoding.DecodeString(stdOut)
+	require.NoError(t, err)
+	overridePkg := struct {
+		DeployedComponents []struct {
+			InstalledCharts []struct {
+				Namespace string `json:"namespace"`
+			} `json:"installedCharts"`
+		} `json:"deployedComponents"`
+	}{}
+	require.NoError(t, json.Unmarshal(rawSecret, &overridePkg))
+	for _, c := range overridePkg.DeployedComponents {
+		for _, chart := range c.InstalledCharts {
+			require.Equal(t, "test2", chart.Namespace, "override package secret must not reference baseline namespace charts")
+		}
+	}
+
 	// remove the baseline by package name
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "test-package", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
+
+	// removing the baseline must not tear down the override's helm release
+	stdOut, stdErr, err = e2e.Kubectl(t, "get", "configmaps", "-l", "zarf.dev/package=test-package,zarf.dev/namespace-override=test2", "--all-namespaces", "-o", "json")
+	require.NoError(t, err, stdOut, stdErr)
+	configMaps = &corev1.ConfigMapList{}
+	require.NoError(t, json.Unmarshal([]byte(stdOut), configMaps))
+	require.Len(t, configMaps.Items, 3, "override deployment should survive baseline removal")
 
 	// remove the namespace-override package by package name
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "test-package", "--namespace", "test2", "--confirm")

--- a/src/test/e2e/40_namespace_override_test.go
+++ b/src/test/e2e/40_namespace_override_test.go
@@ -66,19 +66,10 @@ func TestSingleNamespaceOverride(t *testing.T) {
 		require.Equal(t, "test2", configMap.Namespace)
 	}
 
-	// The override package's state secret must list only charts deployed under the override namespace
-	stdOut, stdErr, err = e2e.Kubectl(t, "get", "secret", "-n", "zarf", "zarf-package-test-package-override-test2", "-o", "jsonpath={.data.data}")
-	require.NoError(t, err, stdOut, stdErr)
-	rawSecret, err := base64.StdEncoding.DecodeString(stdOut)
+	c, err := cluster.New(t.Context())
 	require.NoError(t, err)
-	overridePkg := struct {
-		DeployedComponents []struct {
-			InstalledCharts []struct {
-				Namespace string `json:"namespace"`
-			} `json:"installedCharts"`
-		} `json:"deployedComponents"`
-	}{}
-	require.NoError(t, json.Unmarshal(rawSecret, &overridePkg))
+	overridePkg, err := c.GetDeployedPackage(t.Context(), "test-package", state.WithPackageNamespaceOverride("test2"))
+	require.NoError(t, err)
 	for _, c := range overridePkg.DeployedComponents {
 		for _, chart := range c.InstalledCharts {
 			require.Equal(t, "test2", chart.Namespace, "override package secret must not reference baseline namespace charts")

--- a/src/test/e2e/40_namespace_override_test.go
+++ b/src/test/e2e/40_namespace_override_test.go
@@ -5,7 +5,6 @@
 package test
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -13,6 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/state"
 )
 
 func TestSingleNamespaceOverride(t *testing.T) {


### PR DESCRIPTION
## Description

Passes namespace override state to installed chart state during deploy. Also adds/extends test coverage.

## Related Issue

Fixes https://github.com/zarf-dev/zarf/issues/4872

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
