### PR TITLE
fix: add cluster timeout cluster.New in dev deploy

### DIFF
--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -136,7 +136,9 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 			return c.RequiresCluster()
 		})
 		if requiresCluster {
-			d.c, err = cluster.New(ctx)
+			timeoutCtx, cancel := context.WithTimeout(ctx, cluster.DefaultTimeout)
+			defer cancel()
+			d.c, err = cluster.NewWithWait(timeoutCtx)
 			if err != nil {
 				return err
 			}

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -136,7 +136,7 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 			return c.RequiresCluster()
 		})
 		if requiresCluster {
-			d.c, err = cluster.NewWithWait(ctx)
+			d.c, err = cluster.New(ctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

We recently add a call to `cluster.NewWithWait` to dev deploy, but we never set the context timeout, meaning it could wait forever. Unlikely practically, but might as well fix

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
