### PR TITLE
feat: verify dynamic path fields in package config are clean

### DIFF
--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -181,9 +181,9 @@ func (f ZarfFile) IsTemplate() bool {
 // ZarfChart defines a helm chart to be deployed.
 type ZarfChart struct {
 	// The name of the chart within Zarf; note that this must be unique and does not need to be the same as the name in the chart repo.
-	Name string `json:"name"`
+	Name string `json:"name" jsonschema:"pattern=^[^/\\\\]*$"`
 	// The version of the chart to deploy; for git-based charts this is also the tag of the git repo by default (when not using the '@' syntax for 'repos').
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" jsonschema:"pattern=^[^/\\\\]*$"`
 	// The URL of the OCI registry, chart repository, or git repo where the helm chart is stored.
 	URL string `json:"url,omitempty" jsonschema:"example=OCI registry: oci://ghcr.io/stefanprodan/charts/podinfo,example=helm chart repo: https://stefanprodan.github.io/podinfo,example=git repo: https://github.com/stefanprodan/podinfo (note the '@' syntax for 'repos' is supported here too)"`
 	// The name of a chart within a Helm repository (defaults to the Zarf name of the chart).
@@ -252,7 +252,7 @@ type ZarfChartValue struct {
 // ZarfManifest defines raw manifests Zarf will deploy as a helm chart.
 type ZarfManifest struct {
 	// A name to give this collection of manifests; this will become the name of the dynamically-created helm chart.
-	Name string `json:"name"`
+	Name string `json:"name" jsonschema:"pattern=^[^/\\\\]*$"`
 	// The namespace to deploy the manifests to.
 	Namespace string `json:"namespace,omitempty"`
 	// List of local K8s YAML files or remote URLs to deploy (in order).

--- a/src/api/v1alpha1/package.go
+++ b/src/api/v1alpha1/package.go
@@ -213,7 +213,7 @@ type ZarfMetadata struct {
 	// Additional information about this package.
 	Description string `json:"description,omitempty"`
 	// Generic string set by a package author to track the package version (Note: ZarfInitConfigs will always be versioned to the CLIVersion they were created with).
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" jsonschema:"pattern=^[^/\\\\]*$"`
 	// Link to package information when online.
 	URL string `json:"url,omitempty"`
 	// An image URL to embed in this package (Reserved for future use in Zarf UI).
@@ -260,11 +260,11 @@ type ZarfBuildData struct {
 	// Whether this package was created with differential components.
 	Differential bool `json:"differential,omitempty"`
 	// Version of a previously built package used as the basis for creating this differential package.
-	DifferentialPackageVersion string `json:"differentialPackageVersion,omitempty"`
+	DifferentialPackageVersion string `json:"differentialPackageVersion,omitempty" jsonschema:"pattern=^[^/\\\\]*$"`
 	// List of components that were not included in this package due to differential packaging.
 	DifferentialMissing []string `json:"differentialMissing,omitempty"`
 	// The flavor of Zarf used to build this package.
-	Flavor string `json:"flavor,omitempty"`
+	Flavor string `json:"flavor,omitempty" jsonschema:"pattern=^[^/\\\\]*$"`
 	// Whether this package was signed
 	Signed *bool `json:"signed,omitempty"`
 	// Requirements for specific package operations.

--- a/src/pkg/lint/schema_test.go
+++ b/src/pkg/lint/schema_test.go
@@ -54,6 +54,26 @@ func TestZarfSchema(t *testing.T) {
 			},
 		},
 		{
+			name: "path separators in dynamic path fields",
+			pkg: v1alpha1.ZarfPackage{
+				APIVersion: v1alpha1.APIVersion,
+				Kind:       v1alpha1.ZarfPackageConfig,
+				Metadata:   v1alpha1.ZarfMetadata{Name: "pkg", Version: "a/b"},
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name:      "comp",
+						Charts:    []v1alpha1.ZarfChart{{Name: "a/b", Version: "1.0"}},
+						Manifests: []v1alpha1.ZarfManifest{{Name: `a\b`}},
+					},
+				},
+			},
+			expectedSchemaStrings: []string{
+				"metadata.version: Does not match pattern '^[^/\\\\]*$'",
+				"components.0.charts.0.name: Does not match pattern '^[^/\\\\]*$'",
+				"components.0.manifests.0.name: Does not match pattern '^[^/\\\\]*$'",
+			},
+		},
+		{
 			name: "invalid package",
 			pkg: v1alpha1.ZarfPackage{
 				APIVersion: "bad-api-version/wrong",

--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -725,5 +725,47 @@ func validatePackageIntegrity(pkgLayout *PackageLayout, isPartial bool) error {
 		return fmt.Errorf("package contains additional files not present in the checksum %s", strings.Join(filePaths, ", "))
 	}
 
+	return validatePackagePaths(pkgLayout.Pkg)
+}
+
+// validatePackagePaths checks that package config fields used as filesystem
+// path components do not contain path traversal sequences or separators.
+func validatePackagePaths(pkg v1alpha1.ZarfPackage) error {
+	if !isCleanPath(pkg.Metadata.Name) {
+		return fmt.Errorf("package metadata name %q would result in an invalid path", pkg.Metadata.Name)
+	}
+	if !isCleanPath(pkg.Metadata.Version) {
+		return fmt.Errorf("package metadata version %q would result in an invalid path", pkg.Metadata.Version)
+	}
+	if !isCleanPath(pkg.Build.Flavor) {
+		return fmt.Errorf("package build flavor %q would result in an invalid path", pkg.Build.Flavor)
+	}
+	if !isCleanPath(pkg.Build.DifferentialPackageVersion) {
+		return fmt.Errorf("package build differential package version %q would result in an invalid path", pkg.Build.DifferentialPackageVersion)
+	}
+	for _, comp := range pkg.Components {
+		if !isCleanPath(comp.Name) {
+			return fmt.Errorf("component name %q would result in an invalid path", comp.Name)
+		}
+		for _, chart := range comp.Charts {
+			if !isCleanPath(chart.Name) {
+				return fmt.Errorf("chart name %q in component %q would result in an invalid path", chart.Name, comp.Name)
+			}
+			if !isCleanPath(chart.Version) {
+				return fmt.Errorf("chart version %q in component %q would result in an invalid path", chart.Version, comp.Name)
+			}
+		}
+		for _, manifest := range comp.Manifests {
+			if !isCleanPath(manifest.Name) {
+				return fmt.Errorf("manifest name %q in component %q would result in an invalid path", manifest.Name, comp.Name)
+			}
+		}
+	}
 	return nil
+}
+
+// isCleanPath returns true if s is safe to embed in a file path:
+// it must not be ".." and must not contain path separators.
+func isCleanPath(s string) bool {
+	return s != ".." && !strings.ContainsAny(s, `/\`)
 }

--- a/src/pkg/packager/layout/package_test.go
+++ b/src/pkg/packager/layout/package_test.go
@@ -1785,3 +1785,132 @@ func TestSignPackage_PopulatesProvenanceFiles(t *testing.T) {
 		require.Equal(t, []string{Checksums}, pkgLayout.Pkg.Build.ProvenanceFiles)
 	})
 }
+
+func TestValidatePackagePaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pkg     v1alpha1.ZarfPackage
+		wantErr string
+	}{
+		{
+			name: "valid names",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "my-package", Version: "1.0.0"},
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name:      "my-component",
+						Charts:    []v1alpha1.ZarfChart{{Name: "my-chart", Version: "1.2.3"}},
+						Manifests: []v1alpha1.ZarfManifest{{Name: "my-manifest"}},
+					},
+				},
+			},
+		},
+		{
+			name:    "metadata name traversal",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: "../../evil"}},
+			wantErr: `package metadata name "../../evil" would result in an invalid path`,
+		},
+		{
+			name:    "metadata name is traversal",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: ".."}},
+			wantErr: `package metadata name ".." would result in an invalid path`,
+		},
+		{
+			name:    "metadata version traversal",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: "pkg", Version: "../bad"}},
+			wantErr: `package metadata version "../bad" would result in an invalid path`,
+		},
+		{
+			name:    "metadata name absolute path",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: "/etc/passwd"}},
+			wantErr: `package metadata name "/etc/passwd" would result in an invalid path`,
+		},
+		{
+			name:    "build flavor traversal",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: "pkg"}, Build: v1alpha1.ZarfBuildData{Flavor: "../evil"}},
+			wantErr: `package build flavor "../evil" would result in an invalid path`,
+		},
+		{
+			name:    "build differential package version traversal",
+			pkg:     v1alpha1.ZarfPackage{Metadata: v1alpha1.ZarfMetadata{Name: "pkg"}, Build: v1alpha1.ZarfBuildData{DifferentialPackageVersion: "../evil"}},
+			wantErr: `package build differential package version "../evil" would result in an invalid path`,
+		},
+		{
+			name: "component name traversal",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata:   v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{{Name: "../../etc/passwd"}},
+			},
+			wantErr: `component name "../../etc/passwd" would result in an invalid path`,
+		},
+		{
+			name: "component name is traversal",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata:   v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{{Name: ".."}},
+			},
+			wantErr: `component name ".." would result in an invalid path`,
+		},
+		{
+			name: "component name with backslash",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata:   v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{{Name: `evil\path`}},
+			},
+			wantErr: `component name "evil\\path" would result in an invalid path`,
+		},
+		{
+			name: "chart name traversal",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "comp", Charts: []v1alpha1.ZarfChart{{Name: "../evil", Version: "1.0"}}},
+				},
+			},
+			wantErr: `chart name "../evil" in component "comp" would result in an invalid path`,
+		},
+		{
+			name: "chart version traversal",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "comp", Charts: []v1alpha1.ZarfChart{{Name: "chart", Version: "../bad"}}},
+				},
+			},
+			wantErr: `chart version "../bad" in component "comp" would result in an invalid path`,
+		},
+		{
+			name: "manifest name with slash",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "comp", Manifests: []v1alpha1.ZarfManifest{{Name: "a/b"}}},
+				},
+			},
+			wantErr: `manifest name "a/b" in component "comp" would result in an invalid path`,
+		},
+		{
+			name: "manifest name is traversal",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "pkg"},
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "comp", Manifests: []v1alpha1.ZarfManifest{{Name: ".."}}},
+				},
+			},
+			wantErr: `manifest name ".." in component "comp" would result in an invalid path`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePackagePaths(tt.pkg)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/src/pkg/schema/zarf-v1alpha1-schema.json
+++ b/src/pkg/schema/zarf-v1alpha1-schema.json
@@ -333,10 +333,12 @@
         },
         "differentialPackageVersion": {
           "description": "Version of a previously built package used as the basis for creating this differential package.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "flavor": {
           "description": "The flavor of Zarf used to build this package.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "migrations": {
@@ -415,6 +417,7 @@
         },
         "name": {
           "description": "The name of the chart within Zarf; note that this must be unique and does not need to be the same as the name in the chart repo.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "namespace": {
@@ -478,6 +481,7 @@
         },
         "version": {
           "description": "The version of the chart to deploy; for git-based charts this is also the tag of the git repo by default (when not using the '@' syntax for 'repos').",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         }
       },
@@ -1138,6 +1142,7 @@
         },
         "name": {
           "description": "A name to give this collection of manifests; this will become the name of the dynamically-created helm chart.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "namespace": {
@@ -1239,6 +1244,7 @@
         },
         "version": {
           "description": "Generic string set by a package author to track the package version (Note: ZarfInitConfigs will always be versioned to the CLIVersion they were created with).",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "yolo": {

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -333,10 +333,12 @@
         },
         "differentialPackageVersion": {
           "description": "Version of a previously built package used as the basis for creating this differential package.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "flavor": {
           "description": "The flavor of Zarf used to build this package.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "migrations": {
@@ -415,6 +417,7 @@
         },
         "name": {
           "description": "The name of the chart within Zarf; note that this must be unique and does not need to be the same as the name in the chart repo.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "namespace": {
@@ -478,6 +481,7 @@
         },
         "version": {
           "description": "The version of the chart to deploy; for git-based charts this is also the tag of the git repo by default (when not using the '@' syntax for 'repos').",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         }
       },
@@ -1138,6 +1142,7 @@
         },
         "name": {
           "description": "A name to give this collection of manifests; this will become the name of the dynamically-created helm chart.",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "namespace": {
@@ -1239,6 +1244,7 @@
         },
         "version": {
           "description": "Generic string set by a package author to track the package version (Note: ZarfInitConfigs will always be versioned to the CLIVersion they were created with).",
+          "pattern": "^[^/\\\\]*$",
           "type": "string"
         },
         "yolo": {


### PR DESCRIPTION
## Description

We've seen some previous potential security vulnerabilities in Zarf stemming from the fact some fields are used to build dynamic paths on the file system. There are no active vulnerabilities that I know of that use this, but this should give an extra layer of safety. Added checks to the schema to avoid any genuine mistakes on create; added checks at load time to verify that there is not a maliciously edited package to get around schema checks.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
