### PR TITLE
chore(deps): limit dependencies in favor of built-ins or core libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -642,7 +642,7 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.46.1
-	sigs.k8s.io/controller-runtime v0.24.0
+	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1 // indirect
 	sigs.k8s.io/release-utils v0.12.4 // indirect

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -23,12 +23,14 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 const (
@@ -147,14 +149,11 @@ func WatcherForConfig(cfg *rest.Config) (watcher.StatusWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient, err := rest.HTTPClientFor(cfg)
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
-	restMapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
-	if err != nil {
-		return nil, err
-	}
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 	sw := watcher.NewDefaultStatusWatcher(dynamicClient, restMapper)
 	return sw, nil
 }

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -159,7 +160,7 @@ func pullOCI(ctx context.Context, opts pullOCIOptions) (*layout.PackageLayout, e
 		if len(layerTypes) == 0 {
 			layerTypes = zoci.GetAllLayerTypes()
 		}
-		layerTypes = helpers.RemoveMatches(layerTypes, func(lt zoci.LayerType) bool {
+		layerTypes = slices.DeleteFunc(layerTypes, func(lt zoci.LayerType) bool {
 			return lt == zoci.ImageLayers
 		})
 	}

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/requirements"
 	"github.com/zarf-dev/zarf/src/pkg/feature"
@@ -133,7 +132,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 					}
 
 					// remove the helm chart from the installed charts slice.
-					depComp.InstalledCharts = helpers.RemoveMatches(depComp.InstalledCharts, func(t state.InstalledChart) bool {
+					depComp.InstalledCharts = slices.DeleteFunc(depComp.InstalledCharts, func(t state.InstalledChart) bool {
 						return t.ChartName == chart.ChartName
 					})
 
@@ -156,7 +155,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 
 			// remove the component from deploy components slice.
 			if opts.Cluster != nil {
-				depPkg.DeployedComponents = helpers.RemoveMatches(depPkg.DeployedComponents, func(t state.DeployedComponent) bool {
+				depPkg.DeployedComponents = slices.DeleteFunc(depPkg.DeployedComponents, func(t state.DeployedComponent) bool {
 					return t.Name == depComp.Name
 				})
 				err = opts.Cluster.UpdateDeployedPackage(ctx, *depPkg)


### PR DESCRIPTION
## Description

This PR introduces two changes:
1. Replace controller-runtime helpers with k8s native client-go ones. Allowing us to drop direct dependency, although not entirely eliminating it due to transitive dependency through flux.
2. Replace custom helpers (`helpers.RemoveMatches`) with golang buitl-in `slices` counterparts. 

## Related Issue

Relates to https://github.com/zarf-dev/zarf/issues/4895

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
