### PR TITLE
chore(ci): bump action dependencies and pin versions

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -8,6 +8,10 @@ runs:
       with:
         cosign-release: 'v3.0.6'
 
-    - uses: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
+    - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        syft-version: 'v1.42.3'
 
-    - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      with:
+        version: 'v0.34.0'


### PR DESCRIPTION
## Description

Noticed the following warning on release workflows:

>Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b, docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ 

These tend not to be picked up by dependabot for some reason. Regardless I bumped both to latest and used the appropriate tooling version inputs to pin to specific versions per newly established conventions. 

## Related Issue

No associated issue

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
