### PR TITLE
ci(signing): add nightly check for trusted root updates

### DIFF
--- a/.github/workflows/nightly-trusted-root.yml
+++ b/.github/workflows/nightly-trusted-root.yml
@@ -1,0 +1,40 @@
+name: Daily Trusted Root Update Check
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # Every day at 0700 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-trusted-root:
+    if: ${{ github.repository == 'zarf-dev/zarf' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download latest Zarf binary
+        run: |
+          set -euo pipefail
+          gh release download --repo zarf-dev/zarf --pattern "zarf_*_Linux_amd64" --dir /tmp
+          mv /tmp/zarf_*_Linux_amd64 /tmp/zarf
+          chmod +x /tmp/zarf
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fetch current Sigstore trusted root
+        run: |
+          /tmp/zarf tools trusted-root create --with-default-services --out /tmp/current_trusted_root.json
+          jq --indent 2 . /tmp/current_trusted_root.json > /tmp/current_trusted_root_formatted.json
+
+      - name: Diff against embedded trusted root
+        run: diff src/pkg/signing/embedded_trusted_root.json /tmp/current_trusted_root_formatted.json
+
+      - name: Notify Slack on change detected
+        if: failure()
+        uses: ./.github/actions/slack
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-trusted-root.yml
+++ b/.github/workflows/nightly-trusted-root.yml
@@ -1,9 +1,13 @@
-name: Daily Trusted Root Update Check
+name: Nightly Trusted Root Update Check
 
 on:
   schedule:
-    - cron: "0 7 * * *" # Every day at 0700 UTC
+    - cron: "15 7 * * *" # Every day at 0715 UTC
   workflow_dispatch:
+
+concurrency:
+  group: nightly-trusted-root-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,6 +16,7 @@ jobs:
   check-trusted-root:
     if: ${{ github.repository == 'zarf-dev/zarf' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -19,8 +24,7 @@ jobs:
       - name: Download latest Zarf binary
         run: |
           set -euo pipefail
-          gh release download --repo zarf-dev/zarf --pattern "zarf_*_Linux_amd64" --dir /tmp
-          mv /tmp/zarf_*_Linux_amd64 /tmp/zarf
+          gh release download --repo zarf-dev/zarf --pattern "zarf_*_Linux_amd64" -O /tmp/zarf
           chmod +x /tmp/zarf
         env:
           GH_TOKEN: ${{ github.token }}
@@ -31,7 +35,7 @@ jobs:
           jq --indent 2 . /tmp/current_trusted_root.json > /tmp/current_trusted_root_formatted.json
 
       - name: Diff against embedded trusted root
-        run: diff src/pkg/signing/embedded_trusted_root.json /tmp/current_trusted_root_formatted.json
+        run: diff -u src/pkg/signing/embedded_trusted_root.json /tmp/current_trusted_root_formatted.json
 
       - name: Notify Slack on change detected
         if: failure()


### PR DESCRIPTION
## Description

Adds a nightly check for public good sigstore trusted root updates. 

Uses the latest released version of zarf to perform the update. All tooling should be readily available on the runner and follows existing slack integrations (which could be updated to other channels in the future). 

## Related Issue

Fixes #4908

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
