### PR TITLE
feat(release): signed init packages

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -123,6 +123,15 @@ jobs:
           make release-init-package ARCH=amd64 AGENT_IMAGE_TAG=$CLI_VERSION
           make release-init-package ARCH=arm64 AGENT_IMAGE_TAG=$CLI_VERSION
 
+      - name: Sign Init Packages
+        run: |
+          build/zarf package sign build/zarf-init-amd64-$CLI_VERSION.tar.zst \
+            --keyless \
+            --confirm
+          build/zarf package sign build/zarf-init-arm64-$CLI_VERSION.tar.zst \
+            --keyless \
+            --confirm
+
       - name: Publish Init Package as OCI and Skeleton
         run: |
           CLI_VERSION=$CLI_VERSION make publish-init-package ARCH=amd64 REPOSITORY_URL=ghcr.io/zarf-dev/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,15 @@ jobs:
           make release-init-package ARCH=amd64 AGENT_IMAGE_TAG=$GITHUB_REF_NAME
           make release-init-package ARCH=arm64 AGENT_IMAGE_TAG=$GITHUB_REF_NAME
 
+      - name: Sign Init Packages
+        run: |
+          build/zarf package sign build/zarf-init-amd64-$GITHUB_REF_NAME.tar.zst \
+            --keyless \
+            --confirm
+          build/zarf package sign build/zarf-init-arm64-$GITHUB_REF_NAME.tar.zst \
+            --keyless \
+            --confirm
+
       - name: Publish Init Package as OCI and Skeleton
         run: |
           CLI_VERSION=$GITHUB_REF_NAME make publish-init-package ARCH=amd64 REPOSITORY_URL=ghcr.io/zarf-dev/packages

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,26 @@ release:
   mode: append
   extra_files:
     - glob: ./build/zarf-init-*
+  footer: |
+    ## Verifying Init Packages
+
+    The init packages in this release are signed with keyless Sigstore signing. Verify with:
+
+    **amd64:**
+    ```bash
+    zarf package verify zarf-init-amd64-{{ .Tag }}.tar.zst \
+      --certificate-identity "https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/{{ .Tag }}" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+    ```
+
+    **arm64:**
+    ```bash
+    zarf package verify zarf-init-arm64-{{ .Tag }}.tar.zst \
+      --certificate-identity "https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/{{ .Tag }}" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+    ```
+
+    See [RELEASES.md](https://github.com/zarf-dev/zarf/blob/{{ .Tag }}/RELEASES.md#verifying-the-init-package) for details.
 
 # Update the 'generic' brew formula and create a versioned brew formula for artifacts from this release
 brews:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -95,6 +95,26 @@ zarf package verify <package.tar.zst> --trusted-root src/pkg/signing/embedded_tr
 
 If the refresh fails (network unavailable, TUF root mismatch), do not commit the file. The previous committed version remains valid until the next successful refresh.
 
+### Verifying the Init Package
+
+The init package is signed with keyless Sigstore signing during the release workflow. Consumers can verify offline using the embedded TrustedRoot:
+
+**Tagged release:**
+```bash
+zarf package verify zarf-init-amd64-vX.Y.Z.tar.zst \
+  --certificate-identity-regexp "https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+**Nightly build:**
+```bash
+zarf package verify zarf-init-amd64-vX.Y.Z-nightly.tar.zst \
+  --certificate-identity-regexp "https://github.com/zarf-dev/zarf/.github/workflows/nightly-release.yaml@refs/heads/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+The `--certificate-identity-regexp` pins the identity to the specific release workflow and ref type, preventing acceptance of packages signed by an unrelated workflow. The embedded TrustedRoot (refreshed before each release) validates the Fulcio certificate chain without network access.
+
 ### Manual Releases (if needed)
 
 For cases where you need to manually create a release (e.g., release candidates):


### PR DESCRIPTION
## Description

Adds a step to the release/nightly-release process that signs the init packages prior to publishing. All required permissions are available by default in the workflows as well as the token required. 

Adds a footer note to the goreleaser configuration to support verification of the init package. 

## Related Issue

Fixes #4574

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
