### PR TITLE
feat(values)!: support state built-ins

### DIFF
--- a/examples/values-templating/nginx-configmap.yaml
+++ b/examples/values-templating/nginx-configmap.yaml
@@ -72,6 +72,15 @@ data:
         <pre>Repeat and Indent Example:</pre>
         <pre>{{ .Values.site.message | repeat 3 | indent 4 }}</pre>
 
+        <!-- State Template Examples -->
+        <!-- .State fields expose Zarf runtime state set during zarf init.
+             Non-sensitive fields are always available without any stateAccess declaration. -->
+        <h3>Cluster State (via .State)</h3>
+        <pre>Registry: {{ .State.Registry.Address }}</pre>
+        <pre>Storage class: {{ .State.StorageClass }}</pre>
+        <pre>IP family: {{ .State.IPFamily }}</pre>
+        <pre>IPv6 only: {{ eq .State.IPFamily "ipv6" }}</pre>
+
         {{ .Values.site.footer }}
       </body>
     </html>

--- a/examples/values-templating/readme.md
+++ b/examples/values-templating/readme.md
@@ -1,10 +1,11 @@
 # [ALPHA] Values & Templates Example
 
-This example demonstrates the pre-release alpha version of Zarf's values templating system, including support for **Sprig functions** for advanced template processing and **Helm chart value overrides**.
+This example demonstrates the pre-release alpha version of Zarf's values templating system, including support for **Sprig functions** for advanced template processing, **Helm chart value overrides**, and **cluster state access** via `.State`.
 
 ## Features Demonstrated
 
 - **Basic templating** with `{{ .Values.* }}`, `{{ .Build.* }}`, `{{ .Metadata.* }}`, `{{ .Constants.* }}`, and `{{ .Variables.* }}`
+- **Cluster state** with `{{ .State.Registry.Address }}`, `{{ .State.StorageClass }}`, `{{ .State.IPFamily }}`, and other non-sensitive runtime fields via `.State`
 - **Sprig functions** for string manipulation, lists, math, encoding, and more
 - **File templating** with both simple substitution and complex transformations
 - **Dynamic configuration** using template functions for practical Kubernetes deployments

--- a/examples/values-templating/zarf.yaml
+++ b/examples/values-templating/zarf.yaml
@@ -78,5 +78,18 @@ components:
           - cmd: |
               echo "This {{ .wontBeProcessed }} stays as-is"
 
+  - name: state-templates
+    description: "Demonstrates .State fields in actions — public cluster state, no stateAccess declaration required"
+    required: true
+    actions:
+      onDeploy:
+        before:
+          - cmd: |
+              echo "Registry:      {{ .State.Registry.Address }}"
+              echo "Storage class: {{ .State.StorageClass }}"
+              echo "IP family:     {{ .State.IPFamily }}"
+              echo "Registry mode: {{ .State.Registry.Mode }}"
+            template: true
+
 documentation:
   readme: readme.md

--- a/examples/values-templating/zarf.yaml
+++ b/examples/values-templating/zarf.yaml
@@ -78,18 +78,5 @@ components:
           - cmd: |
               echo "This {{ .wontBeProcessed }} stays as-is"
 
-  - name: state-templates
-    description: "Demonstrates .State fields in actions — public cluster state, no stateAccess declaration required"
-    required: true
-    actions:
-      onDeploy:
-        before:
-          - cmd: |
-              echo "Registry:      {{ .State.Registry.Address }}"
-              echo "Storage class: {{ .State.StorageClass }}"
-              echo "IP family:     {{ .State.IPFamily }}"
-              echo "Registry mode: {{ .State.Registry.Mode }}"
-            template: true
-
 documentation:
   readme: readme.md

--- a/site/src/content/docs/ref/values.mdx
+++ b/site/src/content/docs/ref/values.mdx
@@ -196,4 +196,4 @@ components:
       - agentCerts            # unlocks .State.Agent.{CA,Cert,Key} (base64-encoded)
 ```
 
-See the [values-templating example](/examples/values-templating) for a working demonstration of `.State` fields in manifests and actions.
+See the [values-templating example](/ref/examples/values-templating/) for a working demonstration of `.State` fields in manifests and actions.

--- a/site/src/content/docs/ref/values.mdx
+++ b/site/src/content/docs/ref/values.mdx
@@ -155,3 +155,45 @@ In addition to user supplied Variables, and Constants, Zarf maintains a list of 
 Because files can be deployed without a Kubernetes cluster, some built-in values such as `###ZARF_REGISTRY###` may not be available if no previous component has required access to the cluster. If you need one of these built-in values, a prior component will need to have been called that requires access to the cluster, such as `images`, `repos`, `charts`, `manifests`, or `dataInjections`.
 
 :::
+
+### Cluster State (`.State`)
+
+The `.State` object exposes Zarf cluster state in **manifests**, **files**, and **action `cmd` fields** that have `template: true` set.
+
+**Non-sensitive fields** are always available with no additional declaration:
+
+| Field | Description |
+|---|---|
+| `.State.StorageClass` | Default storage class (cf. `###ZARF_STORAGE_CLASS###`) |
+| `.State.IPFamily` | `"ipv4"`, `"ipv6"`, or `"dual"` (cf. `###ZARF_IPV6_ONLY###`) |
+| `.State.Registry.Address` | Registry URL (cf. `###ZARF_REGISTRY###`) |
+| `.State.Registry.Port` | Registry port (cf. `###ZARF_REGISTRY_PORT###`) |
+| `.State.Registry.PushUsername` | Registry push username |
+| `.State.Registry.PullUsername` | Registry pull username |
+| `.State.Registry.Mode` | `"nodeport"`, `"proxy"`, or `"external"` (cf. `###ZARF_REGISTRY_PROXY###`) |
+| `.State.Registry.MTLSEnabled` | `bool` (cf. `###ZARF_REGISTRY_MTLS_ENABLED###`) |
+| `.State.Registry.SeedAddress` | Localhost seed registry address (cf. `###ZARF_SEED_REGISTRY###`) |
+| `.State.Git.Address` | Git server URL |
+| `.State.Git.PushUsername` | Git push username (cf. `###ZARF_GIT_PUSH###`) |
+| `.State.Git.PullUsername` | Git pull username (cf. `###ZARF_GIT_PULL###`) |
+| `.State.Git.IsInternal` | `bool` |
+| `.State.Artifact.Address` | Artifact server URL |
+| `.State.Artifact.PushUsername` | Artifact push username |
+| `.State.Injector.Image` | Injector container image (cf. `###ZARF_INJECTOR_IMAGE###`) |
+| `.State.Injector.Port` | Injector host port (cf. `###ZARF_INJECTOR_HOSTPORT###`) |
+| `.State.Injector.PayloadConfigMaps` | Number of payload ConfigMaps (cf. `###ZARF_INJECTOR_PAYLOAD_CONFIGMAPS###`) |
+| `.State.Injector.PayloadShaSum` | SHA sum of injector payload (cf. `###ZARF_INJECTOR_SHASUM###`) |
+
+**Sensitive fields** require a `stateAccess` declaration on the component. Accessing a sensitive field without the corresponding group causes a template error at deploy time:
+
+```yaml
+components:
+  - name: my-component
+    stateAccess:
+      - registryCredentials   # unlocks .State.Registry.{PushPassword,PullPassword,Secret,Htpasswd}
+      - gitCredentials        # unlocks .State.Git.{PushPassword,PullPassword}
+      - artifactCredentials   # unlocks .State.Artifact.PushToken
+      - agentCerts            # unlocks .State.Agent.{CA,Cert,Key} (base64-encoded)
+```
+
+See the [values-templating example](/examples/values-templating) for a working demonstration of `.State` fields in manifests and actions.

--- a/site/src/content/docs/ref/values.mdx
+++ b/site/src/content/docs/ref/values.mdx
@@ -177,8 +177,6 @@ The `.State` object exposes Zarf cluster state in **manifests**, **files**, and 
 | `.State.Git.PushUsername` | Git push username (cf. `###ZARF_GIT_PUSH###`) |
 | `.State.Git.PullUsername` | Git pull username (cf. `###ZARF_GIT_PULL###`) |
 | `.State.Git.IsInternal` | `bool` |
-| `.State.Artifact.Address` | Artifact server URL |
-| `.State.Artifact.PushUsername` | Artifact push username |
 | `.State.Injector.Image` | Injector container image (cf. `###ZARF_INJECTOR_IMAGE###`) |
 | `.State.Injector.Port` | Injector host port (cf. `###ZARF_INJECTOR_HOSTPORT###`) |
 | `.State.Injector.PayloadConfigMaps` | Number of payload ConfigMaps (cf. `###ZARF_INJECTOR_PAYLOAD_CONFIGMAPS###`) |
@@ -192,7 +190,6 @@ components:
     stateAccess:
       - registryCredentials   # unlocks .State.Registry.{PushPassword,PullPassword,Secret,Htpasswd}
       - gitCredentials        # unlocks .State.Git.{PushPassword,PullPassword}
-      - artifactCredentials   # unlocks .State.Artifact.PushToken
       - agentCerts            # unlocks .State.Agent.{CA,Cert,Key} (base64-encoded)
 ```
 

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -58,7 +58,7 @@ type ZarfComponent struct {
 	HealthChecks []NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
 	// Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).
-	// Valid values: "registryCredentials", "gitCredentials", "artifactCredentials", "agentCerts".
+	// Valid values: "registryCredentials", "gitCredentials", "agentCerts".
 	StateAccess []StateAccessKey `json:"stateAccess,omitempty"`
 }
 
@@ -70,8 +70,6 @@ const (
 	StateAccessRegistryCredentials StateAccessKey = "registryCredentials"
 	// StateAccessGitCredentials unlocks .State.Git.{PushPassword,PullPassword}.
 	StateAccessGitCredentials StateAccessKey = "gitCredentials"
-	// StateAccessArtifactCredentials unlocks .State.Artifact.PushToken.
-	StateAccessArtifactCredentials StateAccessKey = "artifactCredentials"
 	// StateAccessAgentCerts unlocks .State.Agent.{CA,Cert,Key} (base64-encoded) and adds the .State.Agent sub-object.
 	StateAccessAgentCerts StateAccessKey = "agentCerts"
 )

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -56,6 +56,12 @@ type ZarfComponent struct {
 
 	// List of resources to health check after deployment
 	HealthChecks []NamespacedObjectKindReference `json:"healthChecks,omitempty"`
+
+	// Grants this component access to credential fields (passwords, tokens) within {{ .State }}
+	// during template processing. Without this, accessing .State.Registry.PushPassword etc.
+	// causes a template error. Only set this when the component genuinely requires credentials
+	// in its manifests, files, or actions.
+	SensitiveStateAccess bool `json:"sensitiveStateAccess,omitempty" jsonschema:"description=Grants access to credential fields within .State during Go template processing"`
 }
 
 // ImageArchive points to an archived file containing an OCI layout

--- a/src/api/v1alpha1/component.go
+++ b/src/api/v1alpha1/component.go
@@ -57,12 +57,24 @@ type ZarfComponent struct {
 	// List of resources to health check after deployment
 	HealthChecks []NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
-	// Grants this component access to credential fields (passwords, tokens) within {{ .State }}
-	// during template processing. Without this, accessing .State.Registry.PushPassword etc.
-	// causes a template error. Only set this when the component genuinely requires credentials
-	// in its manifests, files, or actions.
-	SensitiveStateAccess bool `json:"sensitiveStateAccess,omitempty" jsonschema:"description=Grants access to credential fields within .State during Go template processing"`
+	// Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).
+	// Valid values: "registryCredentials", "gitCredentials", "artifactCredentials", "agentCerts".
+	StateAccess []StateAccessKey `json:"stateAccess,omitempty"`
 }
+
+// StateAccessKey identifies a named group of sensitive state fields available in {{ .State }} Go templates.
+type StateAccessKey string
+
+const (
+	// StateAccessRegistryCredentials unlocks .State.Registry.{PushPassword,PullPassword,Secret,Htpasswd}.
+	StateAccessRegistryCredentials StateAccessKey = "registryCredentials"
+	// StateAccessGitCredentials unlocks .State.Git.{PushPassword,PullPassword}.
+	StateAccessGitCredentials StateAccessKey = "gitCredentials"
+	// StateAccessArtifactCredentials unlocks .State.Artifact.PushToken.
+	StateAccessArtifactCredentials StateAccessKey = "artifactCredentials"
+	// StateAccessAgentCerts unlocks .State.Agent.{CA,Cert,Key} (base64-encoded) and adds the .State.Agent sub-object.
+	StateAccessAgentCerts StateAccessKey = "agentCerts"
+)
 
 // ImageArchive points to an archived file containing an OCI layout
 type ImageArchive struct {

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -56,13 +56,11 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 			"INJECTOR_SHASUM":             s.InjectorInfo.PayLoadShaSum,
 
 			// Registry info
-			"REGISTRY":                regInfo.Address,
-			"NODEPORT":                fmt.Sprintf("%d", regInfo.Port),
-			"REGISTRY_PORT":           fmt.Sprintf("%d", regInfo.Port),
-			"REGISTRY_AUTH_PUSH_USER": regInfo.PushUsername,
-			"REGISTRY_AUTH_PUSH":      regInfo.PushPassword,
-			"REGISTRY_AUTH_PULL_USER": regInfo.PullUsername,
-			"REGISTRY_AUTH_PULL":      regInfo.PullPassword,
+			"REGISTRY":           regInfo.Address,
+			"NODEPORT":           fmt.Sprintf("%d", regInfo.Port),
+			"REGISTRY_PORT":      fmt.Sprintf("%d", regInfo.Port),
+			"REGISTRY_AUTH_PUSH": regInfo.PushPassword,
+			"REGISTRY_AUTH_PULL": regInfo.PullPassword,
 
 			// Git server info
 			"GIT_PUSH":      gitInfo.PushUsername,
@@ -105,10 +103,6 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 				templateMap[strings.ToUpper(fmt.Sprintf("###ZARF_%s###", key))].Sensitive = true
 			}
 		}
-	}
-
-	if s != nil {
-		logger.From(ctx).Warn("State builtin templates (###ZARF_REGISTRY###, ###ZARF_STORAGE_CLASS###, etc.) are deprecated and will be removed in v1.0.0. Use {{ .State.Registry.Address }} and related fields instead.")
 	}
 
 	debugPrintTemplateMap(ctx, templateMap)

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -56,11 +56,13 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 			"INJECTOR_SHASUM":             s.InjectorInfo.PayLoadShaSum,
 
 			// Registry info
-			"REGISTRY":           regInfo.Address,
-			"NODEPORT":           fmt.Sprintf("%d", regInfo.Port),
-			"REGISTRY_PORT":      fmt.Sprintf("%d", regInfo.Port),
-			"REGISTRY_AUTH_PUSH": regInfo.PushPassword,
-			"REGISTRY_AUTH_PULL": regInfo.PullPassword,
+			"REGISTRY":                regInfo.Address,
+			"NODEPORT":                fmt.Sprintf("%d", regInfo.Port),
+			"REGISTRY_PORT":           fmt.Sprintf("%d", regInfo.Port),
+			"REGISTRY_AUTH_PUSH_USER": regInfo.PushUsername,
+			"REGISTRY_AUTH_PUSH":      regInfo.PushPassword,
+			"REGISTRY_AUTH_PULL_USER": regInfo.PullUsername,
+			"REGISTRY_AUTH_PULL":      regInfo.PullPassword,
 
 			// Git server info
 			"GIT_PUSH":      gitInfo.PushUsername,
@@ -103,6 +105,10 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 				templateMap[strings.ToUpper(fmt.Sprintf("###ZARF_%s###", key))].Sensitive = true
 			}
 		}
+	}
+
+	if s != nil {
+		logger.From(ctx).Warn("State builtin templates (###ZARF_REGISTRY###, ###ZARF_STORAGE_CLASS###, etc.) are deprecated and will be removed in v1.0.0. Use {{ .State.Registry.Address }} and related fields instead.")
 	}
 
 	debugPrintTemplateMap(ctx, templateMap)

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -17,7 +17,6 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/interactive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
 )
 
@@ -81,7 +80,7 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 
 		case "zarf-seed-registry", "zarf-registry":
 			builtinMap["SEED_REGISTRY"] = state.LocalhostRegistryAddress(s.IPFamily, s.InjectorInfo.Port)
-			htpasswd, err := generateHtpasswd(&regInfo)
+			htpasswd, err := regInfo.Htpasswd()
 			if err != nil {
 				return templateMap, err
 			}
@@ -108,26 +107,6 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 	debugPrintTemplateMap(ctx, templateMap)
 
 	return templateMap, nil
-}
-
-// generateHtpasswd returns an htpasswd string for the current state's RegistryInfo.
-func generateHtpasswd(regInfo *state.RegistryInfo) (string, error) {
-	// Only calculate this for internal registries to allow longer external passwords
-	if regInfo.IsInternal() {
-		pushUser, err := utils.GetHtpasswdString(regInfo.PushUsername, regInfo.PushPassword)
-		if err != nil {
-			return "", fmt.Errorf("error generating htpasswd string: %w", err)
-		}
-
-		pullUser, err := utils.GetHtpasswdString(regInfo.PullUsername, regInfo.PullPassword)
-		if err != nil {
-			return "", fmt.Errorf("error generating htpasswd string: %w", err)
-		}
-
-		return fmt.Sprintf("%s\\n%s", pushUser, pullUser), nil
-	}
-
-	return "", nil
 }
 
 func debugPrintTemplateMap(ctx context.Context, templateMap map[string]*variables.TextTemplate) {

--- a/src/internal/packager/template/template_test.go
+++ b/src/internal/packager/template/template_test.go
@@ -83,32 +83,6 @@ func TestGetSanitizedTemplateMap(t *testing.T) {
 	}
 }
 
-func TestGetZarfTemplatesRegistryUsernames(t *testing.T) {
-	t.Parallel()
-	s := &state.State{
-		RegistryInfo: state.RegistryInfo{
-			Address:      "registry.example.com",
-			Port:         5000,
-			PushUsername: "push-user",
-			PullUsername: "pull-user",
-			PushPassword: "push-secret",
-			PullPassword: "pull-secret",
-		},
-	}
-	templateMap, err := GetZarfTemplates(context.Background(), "my-component", s)
-	require.NoError(t, err)
-
-	pushUser, ok := templateMap["###ZARF_REGISTRY_AUTH_PUSH_USER###"]
-	require.True(t, ok, "expected ###ZARF_REGISTRY_AUTH_PUSH_USER### in template map")
-	require.Equal(t, "push-user", pushUser.Value)
-	require.False(t, pushUser.Sensitive, "registry push username should not be sensitive")
-
-	pullUser, ok := templateMap["###ZARF_REGISTRY_AUTH_PULL_USER###"]
-	require.True(t, ok, "expected ###ZARF_REGISTRY_AUTH_PULL_USER### in template map")
-	require.Equal(t, "pull-user", pullUser.Value)
-	require.False(t, pullUser.Sensitive, "registry pull username should not be sensitive")
-}
-
 func TestGetZarfTemplatesForIPv6SeedRegistry(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/src/internal/packager/template/template_test.go
+++ b/src/internal/packager/template/template_test.go
@@ -83,6 +83,32 @@ func TestGetSanitizedTemplateMap(t *testing.T) {
 	}
 }
 
+func TestGetZarfTemplatesRegistryUsernames(t *testing.T) {
+	t.Parallel()
+	s := &state.State{
+		RegistryInfo: state.RegistryInfo{
+			Address:      "registry.example.com",
+			Port:         5000,
+			PushUsername: "push-user",
+			PullUsername: "pull-user",
+			PushPassword: "push-secret",
+			PullPassword: "pull-secret",
+		},
+	}
+	templateMap, err := GetZarfTemplates(context.Background(), "my-component", s)
+	require.NoError(t, err)
+
+	pushUser, ok := templateMap["###ZARF_REGISTRY_AUTH_PUSH_USER###"]
+	require.True(t, ok, "expected ###ZARF_REGISTRY_AUTH_PUSH_USER### in template map")
+	require.Equal(t, "push-user", pushUser.Value)
+	require.False(t, pushUser.Sensitive, "registry push username should not be sensitive")
+
+	pullUser, ok := templateMap["###ZARF_REGISTRY_AUTH_PULL_USER###"]
+	require.True(t, ok, "expected ###ZARF_REGISTRY_AUTH_PULL_USER### in template map")
+	require.Equal(t, "pull-user", pullUser.Value)
+	require.False(t, pullUser.Sensitive, "registry pull username should not be sensitive")
+}
+
 func TestGetZarfTemplatesForIPv6SeedRegistry(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -109,9 +109,7 @@ func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
 
 // WithState adds Zarf runtime state to the template Objects under the "State" key.
 // Non-sensitive fields (addresses, usernames, configuration) are always included.
-// Sensitive fields (passwords, tokens) are only included when allowSensitive is true —
-// accessing them without opt-in causes a template error (missingkey=error).
-// If s is nil, the Objects map is returned unchanged.
+// Sensitive fields (passwords, tokens) are only included when allowSensitive is true
 func (o Objects) WithState(s *state.State, allowSensitive bool) Objects {
 	if s == nil {
 		return o

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -107,10 +107,22 @@ func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
 	return o
 }
 
+// StateAccess bundles the runtime state with its access permissions for template rendering.
+// A zero value (nil State) is safe and causes WithState to be a no-op.
+type StateAccess struct {
+	// State is the Zarf runtime state loaded from the cluster.
+	State *state.State
+	// AllowSensitive controls whether credential fields (passwords, tokens) are included
+	// in the .State template object. Without this, accessing them causes a template error.
+	AllowSensitive bool
+}
+
 // WithState adds Zarf runtime state to the template Objects under the "State" key.
 // Non-sensitive fields (addresses, usernames, configuration) are always included.
-// Sensitive fields (passwords, tokens) are only included when allowSensitive is true
-func (o Objects) WithState(s *state.State, allowSensitive bool) Objects {
+// Sensitive fields (passwords, tokens) are only included when access.AllowSensitive is true.
+// If access.State is nil, the Objects map is returned unchanged.
+func (o Objects) WithState(access StateAccess) Objects {
+	s := access.State
 	if s == nil {
 		return o
 	}
@@ -134,7 +146,7 @@ func (o Objects) WithState(s *state.State, allowSensitive bool) Objects {
 		"PushUsername": s.ArtifactServer.PushUsername,
 	}
 
-	if allowSensitive {
+	if access.AllowSensitive {
 		registry["PushPassword"] = s.RegistryInfo.PushPassword
 		registry["PullPassword"] = s.RegistryInfo.PullPassword
 		registry["Secret"] = s.RegistryInfo.Secret

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -7,11 +7,13 @@ package template
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	ttmpl "text/template"
 	"time"
@@ -107,24 +109,25 @@ func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
 	return o
 }
 
-// StateAccess bundles the runtime state with its access permissions for template rendering.
+// StateAccess bundles the runtime state with the named access groups a component has declared.
 // A zero value (nil State) is safe and causes WithState to be a no-op.
 type StateAccess struct {
 	// State is the Zarf runtime state loaded from the cluster.
 	State *state.State
-	// AllowSensitive controls whether credential fields (passwords, tokens) are included
-	// in the .State template object. Without this, accessing them causes a template error.
-	AllowSensitive bool
+	// AccessKeys lists which groups of sensitive state fields the component may access.
+	// Accessing a field whose group is not listed causes a template error (missingkey=error).
+	AccessKeys []v1alpha1.StateAccessKey
 }
 
 // WithState adds Zarf runtime state to the template Objects under the "State" key.
-// Non-sensitive fields (addresses, usernames, configuration) are always included.
-// Sensitive fields (passwords, tokens) are only included when access.AllowSensitive is true.
+// Non-sensitive fields (addresses, usernames, counts) are always included.
+// Sensitive field groups are only included when the corresponding StateAccessKey is present in
+// access.AccessKeys — accessing an absent group causes a template error (missingkey=error).
 // If access.State is nil, the Objects map is returned unchanged.
-func (o Objects) WithState(access StateAccess) Objects {
+func (o Objects) WithState(access StateAccess) (Objects, error) {
 	s := access.State
 	if s == nil {
-		return o
+		return o, nil
 	}
 
 	registry := map[string]any{
@@ -134,6 +137,7 @@ func (o Objects) WithState(access StateAccess) Objects {
 		"PullUsername": s.RegistryInfo.PullUsername,
 		"Mode":         string(s.RegistryInfo.RegistryMode),
 		"MTLSEnabled":  s.RegistryInfo.ShouldUseMTLS(),
+		"SeedAddress":  state.LocalhostRegistryAddress(s.IPFamily, s.InjectorInfo.Port),
 	}
 	git := map[string]any{
 		"Address":      s.GitServer.Address,
@@ -145,29 +149,51 @@ func (o Objects) WithState(access StateAccess) Objects {
 		"Address":      s.ArtifactServer.Address,
 		"PushUsername": s.ArtifactServer.PushUsername,
 	}
+	injector := map[string]any{
+		"Image":             s.InjectorInfo.Image,
+		"Port":              s.InjectorInfo.Port,
+		"PayloadConfigMaps": s.InjectorInfo.PayLoadConfigMapAmount,
+		"PayloadShaSum":     s.InjectorInfo.PayLoadShaSum,
+	}
 
-	if access.AllowSensitive {
+	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessRegistryCredentials) {
 		registry["PushPassword"] = s.RegistryInfo.PushPassword
 		registry["PullPassword"] = s.RegistryInfo.PullPassword
 		registry["Secret"] = s.RegistryInfo.Secret
+		htpasswd, err := s.RegistryInfo.Htpasswd()
+		if err != nil {
+			return o, fmt.Errorf("generating htpasswd for .State.Registry.Htpasswd: %w", err)
+		}
+		registry["Htpasswd"] = htpasswd
+	}
+	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessGitCredentials) {
 		git["PushPassword"] = s.GitServer.PushPassword
 		git["PullPassword"] = s.GitServer.PullPassword
+	}
+	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessArtifactCredentials) {
 		artifact["PushToken"] = s.ArtifactServer.PushToken
 	}
 
-	o[objectKeyState] = map[string]any{
+	stateMap := map[string]any{
 		"Distro":       s.Distro,
 		"StorageClass": s.StorageClass,
 		"IPFamily":     string(s.IPFamily),
 		"Registry":     registry,
 		"Git":          git,
 		"Artifact":     artifact,
-		"Injector": map[string]any{
-			"Image": s.InjectorInfo.Image,
-			"Port":  s.InjectorInfo.Port,
-		},
+		"Injector":     injector,
 	}
-	return o
+
+	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessAgentCerts) {
+		stateMap["Agent"] = map[string]any{
+			"CA":   base64.StdEncoding.EncodeToString(s.AgentTLS.CA),
+			"Cert": base64.StdEncoding.EncodeToString(s.AgentTLS.Cert),
+			"Key":  base64.StdEncoding.EncodeToString(s.AgentTLS.Key),
+		}
+	}
+
+	o[objectKeyState] = stateMap
+	return o, nil
 }
 
 // Apply takes a string, fills in the templates with the given Objects, and returns a new string.

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -145,10 +145,6 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 		"PullUsername": s.GitServer.PullUsername,
 		"IsInternal":   s.GitServer.IsInternal(),
 	}
-	artifact := map[string]any{
-		"Address":      s.ArtifactServer.Address,
-		"PushUsername": s.ArtifactServer.PushUsername,
-	}
 	injector := map[string]any{
 		"Image":             s.InjectorInfo.Image,
 		"Port":              s.InjectorInfo.Port,
@@ -170,9 +166,6 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 		git["PushPassword"] = s.GitServer.PushPassword
 		git["PullPassword"] = s.GitServer.PullPassword
 	}
-	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessArtifactCredentials) {
-		artifact["PushToken"] = s.ArtifactServer.PushToken
-	}
 
 	stateMap := map[string]any{
 		"Distro":       s.Distro,
@@ -180,7 +173,6 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 		"IPFamily":     string(s.IPFamily),
 		"Registry":     registry,
 		"Git":          git,
-		"Artifact":     artifact,
 		"Injector":     injector,
 	}
 

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -21,6 +21,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
 )
@@ -40,6 +41,7 @@ const (
 	objectKeyBuild     = "Build"
 	objectKeyConstants = "Constants"
 	objectKeyVariables = "Variables"
+	objectKeyState     = "State"
 )
 
 // NewObjects instantiates an Objects map, which provides templating context. The "with" options below allow for
@@ -101,6 +103,59 @@ func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
 	// Are any Constants set? Load them
 	if len(pkg.Constants) > 0 {
 		o.WithConstants(pkg.Constants)
+	}
+	return o
+}
+
+// WithState adds Zarf runtime state to the template Objects under the "State" key.
+// Non-sensitive fields (addresses, usernames, configuration) are always included.
+// Sensitive fields (passwords, tokens) are only included when allowSensitive is true —
+// accessing them without opt-in causes a template error (missingkey=error).
+// If s is nil, the Objects map is returned unchanged.
+func (o Objects) WithState(s *state.State, allowSensitive bool) Objects {
+	if s == nil {
+		return o
+	}
+
+	registry := map[string]any{
+		"Address":      s.RegistryInfo.Address,
+		"Port":         s.RegistryInfo.Port,
+		"PushUsername": s.RegistryInfo.PushUsername,
+		"PullUsername": s.RegistryInfo.PullUsername,
+		"Mode":         string(s.RegistryInfo.RegistryMode),
+		"MTLSEnabled":  s.RegistryInfo.ShouldUseMTLS(),
+	}
+	git := map[string]any{
+		"Address":      s.GitServer.Address,
+		"PushUsername": s.GitServer.PushUsername,
+		"PullUsername": s.GitServer.PullUsername,
+		"IsInternal":   s.GitServer.IsInternal(),
+	}
+	artifact := map[string]any{
+		"Address":      s.ArtifactServer.Address,
+		"PushUsername": s.ArtifactServer.PushUsername,
+	}
+
+	if allowSensitive {
+		registry["PushPassword"] = s.RegistryInfo.PushPassword
+		registry["PullPassword"] = s.RegistryInfo.PullPassword
+		registry["Secret"] = s.RegistryInfo.Secret
+		git["PushPassword"] = s.GitServer.PushPassword
+		git["PullPassword"] = s.GitServer.PullPassword
+		artifact["PushToken"] = s.ArtifactServer.PushToken
+	}
+
+	o[objectKeyState] = map[string]any{
+		"Distro":       s.Distro,
+		"StorageClass": s.StorageClass,
+		"IPFamily":     string(s.IPFamily),
+		"Registry":     registry,
+		"Git":          git,
+		"Artifact":     artifact,
+		"Injector": map[string]any{
+			"Image": s.InjectorInfo.Image,
+			"Port":  s.InjectorInfo.Port,
+		},
 	}
 	return o
 }

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -6,12 +6,14 @@ package template
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
@@ -1172,6 +1174,7 @@ func testState() *state.State {
 			PullUsername: "pull-user",
 			PullPassword: "pull-secret",
 			Secret:       "registry-secret",
+			RegistryMode: state.RegistryModeNodePort,
 		},
 		GitServer: state.GitServerInfo{
 			Address:      "git.example.com",
@@ -1186,8 +1189,15 @@ func testState() *state.State {
 			PushToken:    "artifact-token",
 		},
 		InjectorInfo: state.InjectorInfo{
-			Image: "injector:latest",
-			Port:  5001,
+			Image:                  "injector:latest",
+			Port:                   5001,
+			PayLoadConfigMapAmount: 3,
+			PayLoadShaSum:          "abc123",
+		},
+		AgentTLS: pki.GeneratedPKI{
+			CA:   []byte("ca-data"),
+			Cert: []byte("cert-data"),
+			Key:  []byte("key-data"),
 		},
 	}
 }
@@ -1195,7 +1205,8 @@ func testState() *state.State {
 func TestWithState_NilState(t *testing.T) {
 	t.Parallel()
 	objs := NewObjects(value.Values{})
-	result := objs.WithState(StateAccess{})
+	result, err := objs.WithState(StateAccess{})
+	require.NoError(t, err)
 	require.NotContains(t, result, objectKeyState)
 }
 
@@ -1203,24 +1214,25 @@ func TestWithState_NonSensitiveFields(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s})
-
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{State: s})
+	require.NoError(t, err)
 	require.Contains(t, objs, objectKeyState)
 
-	// Non-sensitive fields render correctly
 	for tmpl, expected := range map[string]string{
-		`{{ .State.Distro }}`:                s.Distro,
-		`{{ .State.StorageClass }}`:          s.StorageClass,
-		`{{ .State.IPFamily }}`:              string(s.IPFamily),
-		`{{ .State.Registry.Address }}`:      s.RegistryInfo.Address,
-		`{{ .State.Registry.PushUsername }}`: s.RegistryInfo.PushUsername,
-		`{{ .State.Registry.PullUsername }}`: s.RegistryInfo.PullUsername,
-		`{{ .State.Git.Address }}`:           s.GitServer.Address,
-		`{{ .State.Git.PushUsername }}`:      s.GitServer.PushUsername,
-		`{{ .State.Git.PullUsername }}`:      s.GitServer.PullUsername,
-		`{{ .State.Artifact.Address }}`:      s.ArtifactServer.Address,
-		`{{ .State.Artifact.PushUsername }}`: s.ArtifactServer.PushUsername,
-		`{{ .State.Injector.Image }}`:        s.InjectorInfo.Image,
+		`{{ .State.Distro }}`:                     s.Distro,
+		`{{ .State.StorageClass }}`:               s.StorageClass,
+		`{{ .State.IPFamily }}`:                   string(s.IPFamily),
+		`{{ .State.Registry.Address }}`:           s.RegistryInfo.Address,
+		`{{ .State.Registry.PushUsername }}`:      s.RegistryInfo.PushUsername,
+		`{{ .State.Registry.PullUsername }}`:      s.RegistryInfo.PullUsername,
+		`{{ .State.Git.Address }}`:                s.GitServer.Address,
+		`{{ .State.Git.PushUsername }}`:           s.GitServer.PushUsername,
+		`{{ .State.Git.PullUsername }}`:           s.GitServer.PullUsername,
+		`{{ .State.Artifact.Address }}`:           s.ArtifactServer.Address,
+		`{{ .State.Artifact.PushUsername }}`:      s.ArtifactServer.PushUsername,
+		`{{ .State.Injector.Image }}`:             s.InjectorInfo.Image,
+		`{{ .State.Injector.PayloadConfigMaps }}`: "3",
+		`{{ .State.Injector.PayloadShaSum }}`:     s.InjectorInfo.PayLoadShaSum,
 	} {
 		out, err := Apply(ctx, tmpl, objs)
 		require.NoError(t, err, "template %q should render without error", tmpl)
@@ -1232,38 +1244,168 @@ func TestWithState_SensitiveFieldsBlockedWithoutOptIn(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s})
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{State: s})
+	require.NoError(t, err)
 
-	// Sensitive fields must not be accessible — missingkey=error causes a template failure
+	// Sensitive fields must not be accessible without declaring the group
 	for _, tmpl := range []string{
 		`{{ .State.Registry.PushPassword }}`,
 		`{{ .State.Registry.PullPassword }}`,
 		`{{ .State.Registry.Secret }}`,
+		`{{ .State.Registry.Htpasswd }}`,
 		`{{ .State.Git.PushPassword }}`,
 		`{{ .State.Git.PullPassword }}`,
 		`{{ .State.Artifact.PushToken }}`,
+		`{{ .State.Agent.CA }}`,
 	} {
 		_, err := Apply(ctx, tmpl, objs)
-		require.Error(t, err, "template %q should fail without sensitiveStateAccess", tmpl)
+		require.Error(t, err, "template %q should fail without the matching stateAccess group", tmpl)
 	}
 }
 
-func TestWithState_SensitiveFieldsAvailableWithOptIn(t *testing.T) {
+func TestWithState_RegistryCredentialsGroup(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s, AllowSensitive: true})
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
+		State:      s,
+		AccessKeys: []v1alpha1.StateAccessKey{v1alpha1.StateAccessRegistryCredentials},
+	})
+	require.NoError(t, err)
 
 	for tmpl, expected := range map[string]string{
 		`{{ .State.Registry.PushPassword }}`: s.RegistryInfo.PushPassword,
 		`{{ .State.Registry.PullPassword }}`: s.RegistryInfo.PullPassword,
 		`{{ .State.Registry.Secret }}`:       s.RegistryInfo.Secret,
-		`{{ .State.Git.PushPassword }}`:      s.GitServer.PushPassword,
-		`{{ .State.Git.PullPassword }}`:      s.GitServer.PullPassword,
-		`{{ .State.Artifact.PushToken }}`:    s.ArtifactServer.PushToken,
 	} {
 		out, err := Apply(ctx, tmpl, objs)
-		require.NoError(t, err, "template %q should render with sensitiveStateAccess=true", tmpl)
-		require.Equal(t, expected, out, "template %q rendered unexpected value", tmpl)
+		require.NoError(t, err, "template %q should render with registryCredentials", tmpl)
+		require.Equal(t, expected, out)
 	}
+	// Other sensitive groups must still be blocked
+	_, err = Apply(ctx, `{{ .State.Git.PushPassword }}`, objs)
+	require.Error(t, err, "gitCredentials should still be blocked")
+}
+
+func TestWithState_GitCredentialsGroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
+		State:      s,
+		AccessKeys: []v1alpha1.StateAccessKey{v1alpha1.StateAccessGitCredentials},
+	})
+	require.NoError(t, err)
+
+	for tmpl, expected := range map[string]string{
+		`{{ .State.Git.PushPassword }}`: s.GitServer.PushPassword,
+		`{{ .State.Git.PullPassword }}`: s.GitServer.PullPassword,
+	} {
+		out, err := Apply(ctx, tmpl, objs)
+		require.NoError(t, err, "template %q should render with gitCredentials", tmpl)
+		require.Equal(t, expected, out)
+	}
+	// Other groups must remain blocked
+	_, err = Apply(ctx, `{{ .State.Registry.PushPassword }}`, objs)
+	require.Error(t, err, "registryCredentials should still be blocked")
+	_, err = Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
+	require.Error(t, err, "artifactCredentials should still be blocked")
+}
+
+func TestWithState_ArtifactCredentialsGroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
+		State:      s,
+		AccessKeys: []v1alpha1.StateAccessKey{v1alpha1.StateAccessArtifactCredentials},
+	})
+	require.NoError(t, err)
+
+	out, err := Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
+	require.NoError(t, err)
+	require.Equal(t, s.ArtifactServer.PushToken, out)
+
+	// Other groups must remain blocked
+	_, err = Apply(ctx, `{{ .State.Registry.PushPassword }}`, objs)
+	require.Error(t, err, "registryCredentials should still be blocked")
+	_, err = Apply(ctx, `{{ .State.Git.PushPassword }}`, objs)
+	require.Error(t, err, "gitCredentials should still be blocked")
+}
+
+func TestWithState_AgentCertsGroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
+		State:      s,
+		AccessKeys: []v1alpha1.StateAccessKey{v1alpha1.StateAccessAgentCerts},
+	})
+	require.NoError(t, err)
+
+	// Agent sub-map is only present when agentCerts is declared
+	stateMap, ok := objs[objectKeyState].(map[string]any)
+	require.True(t, ok, "state object should be map[string]any")
+	require.Contains(t, stateMap, "Agent")
+
+	for tmpl, expectedB64 := range map[string][]byte{
+		`{{ .State.Agent.CA }}`:   s.AgentTLS.CA,
+		`{{ .State.Agent.Cert }}`: s.AgentTLS.Cert,
+		`{{ .State.Agent.Key }}`:  s.AgentTLS.Key,
+	} {
+		out, err := Apply(ctx, tmpl, objs)
+		require.NoError(t, err, "template %q should render with agentCerts", tmpl)
+		require.Equal(t, base64.StdEncoding.EncodeToString(expectedB64), out)
+	}
+
+	// Other groups must remain blocked
+	_, err = Apply(ctx, `{{ .State.Registry.PushPassword }}`, objs)
+	require.Error(t, err, "registryCredentials should still be blocked")
+	_, err = Apply(ctx, `{{ .State.Git.PushPassword }}`, objs)
+	require.Error(t, err, "gitCredentials should still be blocked")
+}
+
+func TestWithState_AgentMapAbsentWithoutGroup(t *testing.T) {
+	t.Parallel()
+	s := testState()
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{State: s})
+	require.NoError(t, err)
+	stateMap, ok := objs[objectKeyState].(map[string]any)
+	require.True(t, ok, "state object should be map[string]any")
+	require.NotContains(t, stateMap, "Agent",
+		"Agent sub-map must not exist without agentCerts access key")
+}
+
+func TestWithState_MultipleGroups(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
+		State: s,
+		AccessKeys: []v1alpha1.StateAccessKey{
+			v1alpha1.StateAccessRegistryCredentials,
+			v1alpha1.StateAccessGitCredentials,
+		},
+	})
+	require.NoError(t, err)
+
+	// Both declared groups are accessible
+	for tmpl, expected := range map[string]string{
+		`{{ .State.Registry.PushPassword }}`: s.RegistryInfo.PushPassword,
+		`{{ .State.Registry.PullPassword }}`: s.RegistryInfo.PullPassword,
+		`{{ .State.Git.PushPassword }}`:      s.GitServer.PushPassword,
+		`{{ .State.Git.PullPassword }}`:      s.GitServer.PullPassword,
+	} {
+		out, err := Apply(ctx, tmpl, objs)
+		require.NoError(t, err, "template %q should render", tmpl)
+		require.Equal(t, expected, out)
+	}
+
+	// Undeclared groups remain blocked
+	_, err = Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
+	require.Error(t, err, "artifactCredentials should still be blocked")
+	stateMap, ok := objs[objectKeyState].(map[string]any)
+	require.True(t, ok, "state object should be map[string]any")
+	require.NotContains(t, stateMap, "Agent",
+		"Agent sub-map must not exist without agentCerts")
 }

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -1195,7 +1195,7 @@ func testState() *state.State {
 func TestWithState_NilState(t *testing.T) {
 	t.Parallel()
 	objs := NewObjects(value.Values{})
-	result := objs.WithState(nil, false)
+	result := objs.WithState(StateAccess{})
 	require.NotContains(t, result, objectKeyState)
 }
 
@@ -1203,7 +1203,7 @@ func TestWithState_NonSensitiveFields(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(s, false)
+	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s})
 
 	require.Contains(t, objs, objectKeyState)
 
@@ -1232,7 +1232,7 @@ func TestWithState_SensitiveFieldsBlockedWithoutOptIn(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(s, false)
+	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s})
 
 	// Sensitive fields must not be accessible — missingkey=error causes a template failure
 	for _, tmpl := range []string{
@@ -1252,7 +1252,7 @@ func TestWithState_SensitiveFieldsAvailableWithOptIn(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := testState()
-	objs := NewObjects(value.Values{}).WithState(s, true)
+	objs := NewObjects(value.Values{}).WithState(StateAccess{State: s, AllowSensitive: true})
 
 	for tmpl, expected := range map[string]string{
 		`{{ .State.Registry.PushPassword }}`: s.RegistryInfo.PushPassword,

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -1228,8 +1228,6 @@ func TestWithState_NonSensitiveFields(t *testing.T) {
 		`{{ .State.Git.Address }}`:                s.GitServer.Address,
 		`{{ .State.Git.PushUsername }}`:           s.GitServer.PushUsername,
 		`{{ .State.Git.PullUsername }}`:           s.GitServer.PullUsername,
-		`{{ .State.Artifact.Address }}`:           s.ArtifactServer.Address,
-		`{{ .State.Artifact.PushUsername }}`:      s.ArtifactServer.PushUsername,
 		`{{ .State.Injector.Image }}`:             s.InjectorInfo.Image,
 		`{{ .State.Injector.PayloadConfigMaps }}`: "3",
 		`{{ .State.Injector.PayloadShaSum }}`:     s.InjectorInfo.PayLoadShaSum,
@@ -1255,7 +1253,6 @@ func TestWithState_SensitiveFieldsBlockedWithoutOptIn(t *testing.T) {
 		`{{ .State.Registry.Htpasswd }}`,
 		`{{ .State.Git.PushPassword }}`,
 		`{{ .State.Git.PullPassword }}`,
-		`{{ .State.Artifact.PushToken }}`,
 		`{{ .State.Agent.CA }}`,
 	} {
 		_, err := Apply(ctx, tmpl, objs)
@@ -1308,29 +1305,6 @@ func TestWithState_GitCredentialsGroup(t *testing.T) {
 	// Other groups must remain blocked
 	_, err = Apply(ctx, `{{ .State.Registry.PushPassword }}`, objs)
 	require.Error(t, err, "registryCredentials should still be blocked")
-	_, err = Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
-	require.Error(t, err, "artifactCredentials should still be blocked")
-}
-
-func TestWithState_ArtifactCredentialsGroup(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	s := testState()
-	objs, err := NewObjects(value.Values{}).WithState(StateAccess{
-		State:      s,
-		AccessKeys: []v1alpha1.StateAccessKey{v1alpha1.StateAccessArtifactCredentials},
-	})
-	require.NoError(t, err)
-
-	out, err := Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
-	require.NoError(t, err)
-	require.Equal(t, s.ArtifactServer.PushToken, out)
-
-	// Other groups must remain blocked
-	_, err = Apply(ctx, `{{ .State.Registry.PushPassword }}`, objs)
-	require.Error(t, err, "registryCredentials should still be blocked")
-	_, err = Apply(ctx, `{{ .State.Git.PushPassword }}`, objs)
-	require.Error(t, err, "gitCredentials should still be blocked")
 }
 
 func TestWithState_AgentCertsGroup(t *testing.T) {
@@ -1402,8 +1376,8 @@ func TestWithState_MultipleGroups(t *testing.T) {
 	}
 
 	// Undeclared groups remain blocked
-	_, err = Apply(ctx, `{{ .State.Artifact.PushToken }}`, objs)
-	require.Error(t, err, "artifactCredentials should still be blocked")
+	_, err = Apply(ctx, `{{ .State.Agent.CA }}`, objs)
+	require.Error(t, err, "agentCerts should still be blocked")
 	stateMap, ok := objs[objectKeyState].(map[string]any)
 	require.True(t, ok, "state object should be map[string]any")
 	require.NotContains(t, stateMap, "Agent",

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/pkg/variables"
 )
@@ -1155,5 +1156,114 @@ func TestFromTOML_Errors(t *testing.T) {
 			require.True(t, ok, "expected Error key in result map")
 			require.Contains(t, errMsg, "toml:")
 		})
+	}
+}
+
+func testState() *state.State {
+	return &state.State{
+		Distro:       "k3s",
+		StorageClass: "standard",
+		IPFamily:     state.IPFamilyIPv4,
+		RegistryInfo: state.RegistryInfo{
+			Address:      "registry.example.com",
+			Port:         5000,
+			PushUsername: "push-user",
+			PushPassword: "push-secret",
+			PullUsername: "pull-user",
+			PullPassword: "pull-secret",
+			Secret:       "registry-secret",
+		},
+		GitServer: state.GitServerInfo{
+			Address:      "git.example.com",
+			PushUsername: "git-push-user",
+			PushPassword: "git-push-secret",
+			PullUsername: "git-pull-user",
+			PullPassword: "git-pull-secret",
+		},
+		ArtifactServer: state.ArtifactServerInfo{
+			Address:      "artifact.example.com",
+			PushUsername: "artifact-user",
+			PushToken:    "artifact-token",
+		},
+		InjectorInfo: state.InjectorInfo{
+			Image: "injector:latest",
+			Port:  5001,
+		},
+	}
+}
+
+func TestWithState_NilState(t *testing.T) {
+	t.Parallel()
+	objs := NewObjects(value.Values{})
+	result := objs.WithState(nil, false)
+	require.NotContains(t, result, objectKeyState)
+}
+
+func TestWithState_NonSensitiveFields(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs := NewObjects(value.Values{}).WithState(s, false)
+
+	require.Contains(t, objs, objectKeyState)
+
+	// Non-sensitive fields render correctly
+	for tmpl, expected := range map[string]string{
+		`{{ .State.Distro }}`:                s.Distro,
+		`{{ .State.StorageClass }}`:          s.StorageClass,
+		`{{ .State.IPFamily }}`:              string(s.IPFamily),
+		`{{ .State.Registry.Address }}`:      s.RegistryInfo.Address,
+		`{{ .State.Registry.PushUsername }}`: s.RegistryInfo.PushUsername,
+		`{{ .State.Registry.PullUsername }}`: s.RegistryInfo.PullUsername,
+		`{{ .State.Git.Address }}`:           s.GitServer.Address,
+		`{{ .State.Git.PushUsername }}`:      s.GitServer.PushUsername,
+		`{{ .State.Git.PullUsername }}`:      s.GitServer.PullUsername,
+		`{{ .State.Artifact.Address }}`:      s.ArtifactServer.Address,
+		`{{ .State.Artifact.PushUsername }}`: s.ArtifactServer.PushUsername,
+		`{{ .State.Injector.Image }}`:        s.InjectorInfo.Image,
+	} {
+		out, err := Apply(ctx, tmpl, objs)
+		require.NoError(t, err, "template %q should render without error", tmpl)
+		require.Equal(t, expected, out, "template %q rendered unexpected value", tmpl)
+	}
+}
+
+func TestWithState_SensitiveFieldsBlockedWithoutOptIn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs := NewObjects(value.Values{}).WithState(s, false)
+
+	// Sensitive fields must not be accessible — missingkey=error causes a template failure
+	for _, tmpl := range []string{
+		`{{ .State.Registry.PushPassword }}`,
+		`{{ .State.Registry.PullPassword }}`,
+		`{{ .State.Registry.Secret }}`,
+		`{{ .State.Git.PushPassword }}`,
+		`{{ .State.Git.PullPassword }}`,
+		`{{ .State.Artifact.PushToken }}`,
+	} {
+		_, err := Apply(ctx, tmpl, objs)
+		require.Error(t, err, "template %q should fail without sensitiveStateAccess", tmpl)
+	}
+}
+
+func TestWithState_SensitiveFieldsAvailableWithOptIn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := testState()
+	objs := NewObjects(value.Values{}).WithState(s, true)
+
+	for tmpl, expected := range map[string]string{
+		`{{ .State.Registry.PushPassword }}`: s.RegistryInfo.PushPassword,
+		`{{ .State.Registry.PullPassword }}`: s.RegistryInfo.PullPassword,
+		`{{ .State.Registry.Secret }}`:       s.RegistryInfo.Secret,
+		`{{ .State.Git.PushPassword }}`:      s.GitServer.PushPassword,
+		`{{ .State.Git.PullPassword }}`:      s.GitServer.PullPassword,
+		`{{ .State.Artifact.PushToken }}`:    s.ArtifactServer.PushToken,
+	} {
+		out, err := Apply(ctx, tmpl, objs)
+		require.NoError(t, err, "template %q should render with sensitiveStateAccess=true", tmpl)
+		require.Equal(t, expected, out, "template %q rendered unexpected value", tmpl)
 	}
 }

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -22,6 +22,7 @@ import (
 	ptmpl "github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/internal/template"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
+	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 	"github.com/zarf-dev/zarf/src/pkg/value"
@@ -30,13 +31,13 @@ import (
 )
 
 // Run runs all provided actions.
-func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values) error {
+func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, s *state.State, allowSensitive bool) error {
 	if variableConfig == nil {
 		variableConfig = ptmpl.GetZarfVariableConfig(ctx, false)
 	}
 
 	for _, a := range actions {
-		if err := runAction(ctx, basePath, defaultCfg, a, variableConfig, values); err != nil {
+		if err := runAction(ctx, basePath, defaultCfg, a, variableConfig, values, s, allowSensitive); err != nil {
 			return err
 		}
 	}
@@ -44,7 +45,7 @@ func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponent
 }
 
 // Run commands that a component has provided.
-func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values) error {
+func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, s *state.State, allowSensitive bool) error {
 	var cmdEscaped string
 	var err error
 	cmd := action.Cmd
@@ -53,7 +54,8 @@ func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfCom
 
 	tmplObjs := template.NewObjects(values).
 		WithConstants(variableConfig.GetConstants()).
-		WithVariables(variableConfig.GetSetVariableMap())
+		WithVariables(variableConfig.GetSetVariableMap()).
+		WithState(s, allowSensitive)
 
 	if action.Wait != nil {
 		err := runWaitAction(ctx, action, variableConfig, tmplObjs)

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -22,7 +22,6 @@ import (
 	ptmpl "github.com/zarf-dev/zarf/src/internal/packager/template"
 	"github.com/zarf-dev/zarf/src/internal/template"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
-	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
 	"github.com/zarf-dev/zarf/src/pkg/value"
@@ -31,13 +30,13 @@ import (
 )
 
 // Run runs all provided actions.
-func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, s *state.State, allowSensitive bool) error {
+func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, actions []v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, stateAccess template.StateAccess) error {
 	if variableConfig == nil {
 		variableConfig = ptmpl.GetZarfVariableConfig(ctx, false)
 	}
 
 	for _, a := range actions {
-		if err := runAction(ctx, basePath, defaultCfg, a, variableConfig, values, s, allowSensitive); err != nil {
+		if err := runAction(ctx, basePath, defaultCfg, a, variableConfig, values, stateAccess); err != nil {
 			return err
 		}
 	}
@@ -45,7 +44,7 @@ func Run(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponent
 }
 
 // Run commands that a component has provided.
-func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, s *state.State, allowSensitive bool) error {
+func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfComponentActionDefaults, action v1alpha1.ZarfComponentAction, variableConfig *variables.VariableConfig, values value.Values, stateAccess template.StateAccess) error {
 	var cmdEscaped string
 	var err error
 	cmd := action.Cmd
@@ -55,7 +54,7 @@ func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfCom
 	tmplObjs := template.NewObjects(values).
 		WithConstants(variableConfig.GetConstants()).
 		WithVariables(variableConfig.GetSetVariableMap()).
-		WithState(s, allowSensitive)
+		WithState(stateAccess)
 
 	if action.Wait != nil {
 		err := runWaitAction(ctx, action, variableConfig, tmplObjs)

--- a/src/pkg/packager/actions/actions.go
+++ b/src/pkg/packager/actions/actions.go
@@ -51,10 +51,13 @@ func runAction(ctx context.Context, basePath string, defaultCfg v1alpha1.ZarfCom
 	l := logger.From(ctx)
 	start := time.Now()
 
-	tmplObjs := template.NewObjects(values).
+	tmplObjs, err := template.NewObjects(values).
 		WithConstants(variableConfig.GetConstants()).
 		WithVariables(variableConfig.GetSetVariableMap()).
 		WithState(stateAccess)
+	if err != nil {
+		return err
+	}
 
 	if action.Wait != nil {
 		err := runWaitAction(ctx, action, variableConfig, tmplObjs)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -274,7 +274,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 		onDeploy := component.Actions.OnDeploy
 
 		onFailure := func() {
-			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals); err != nil {
+			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
 				l.Debug("unable to run component failure action", "error", err.Error())
 			}
 		}
@@ -311,7 +311,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 			}
 		}
 
-		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals); err != nil {
+		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
 			onFailure()
 			return nil, fmt.Errorf("unable to run component success action: %w", err)
 		}
@@ -464,12 +464,12 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	d.vc.SetApplicationTemplates(applicationTemplates)
 
 	// Populate objects available to templates in before actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
 		return nil, fmt.Errorf("unable to run component before action: %w", err)
 	}
 
 	if hasFiles {
-		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals); err != nil {
+		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals, d.s); err != nil {
 			return nil, fmt.Errorf("unable to process the component files: %w", err)
 		}
 	}
@@ -539,7 +539,7 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	}
 
 	// Populate objects available to templates in after actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
 		return charts, fmt.Errorf("unable to run component after action: %w", err)
 	}
 
@@ -664,7 +664,8 @@ func (d *deployer) installManifests(ctx context.Context, pkgLayout *layout.Packa
 					WithPackage(pkgLayout.Pkg).
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(d.vc.GetSetVariableMap()).
-					WithConstants(d.vc.GetConstants())
+					WithConstants(d.vc.GetConstants()).
+					WithState(d.s, component.SensitiveStateAccess)
 				if err := template.ApplyToFile(ctx, path, path, objs); err != nil {
 					return nil, err
 				}
@@ -801,7 +802,7 @@ func verifyClusterCompatibility(ctx context.Context, c *cluster.Cluster, pkgLayo
 	return nil
 }
 
-func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout, component v1alpha1.ZarfComponent, variableConfig *variables.VariableConfig, values value.Values) (err error) {
+func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout, component v1alpha1.ZarfComponent, variableConfig *variables.VariableConfig, values value.Values, s *state.State) (err error) {
 	l := logger.From(ctx)
 	start := time.Now()
 	l.Info("copying files", "count", len(component.Files))
@@ -874,7 +875,8 @@ func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout,
 					WithPackage(pkgLayout.Pkg).
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(variableConfig.GetSetVariableMap()).
-					WithConstants(variableConfig.GetConstants())
+					WithConstants(variableConfig.GetConstants()).
+					WithState(s, component.SensitiveStateAccess)
 				err = template.ApplyToFile(ctx, subFile, subFile, objs)
 				if err != nil {
 					return err

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -274,7 +274,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 		onDeploy := component.Actions.OnDeploy
 
 		onFailure := func() {
-			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
+			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
 				l.Debug("unable to run component failure action", "error", err.Error())
 			}
 		}
@@ -311,7 +311,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 			}
 		}
 
-		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
+		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
 			onFailure()
 			return nil, fmt.Errorf("unable to run component success action: %w", err)
 		}
@@ -464,12 +464,12 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	d.vc.SetApplicationTemplates(applicationTemplates)
 
 	// Populate objects available to templates in before actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
 		return nil, fmt.Errorf("unable to run component before action: %w", err)
 	}
 
 	if hasFiles {
-		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals, d.s); err != nil {
+		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
 			return nil, fmt.Errorf("unable to process the component files: %w", err)
 		}
 	}
@@ -539,7 +539,7 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	}
 
 	// Populate objects available to templates in after actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals, d.s, component.SensitiveStateAccess); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
 		return charts, fmt.Errorf("unable to run component after action: %w", err)
 	}
 
@@ -665,7 +665,7 @@ func (d *deployer) installManifests(ctx context.Context, pkgLayout *layout.Packa
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(d.vc.GetSetVariableMap()).
 					WithConstants(d.vc.GetConstants()).
-					WithState(d.s, component.SensitiveStateAccess)
+					WithState(template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess})
 				if err := template.ApplyToFile(ctx, path, path, objs); err != nil {
 					return nil, err
 				}
@@ -802,7 +802,7 @@ func verifyClusterCompatibility(ctx context.Context, c *cluster.Cluster, pkgLayo
 	return nil
 }
 
-func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout, component v1alpha1.ZarfComponent, variableConfig *variables.VariableConfig, values value.Values, s *state.State) (err error) {
+func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout, component v1alpha1.ZarfComponent, variableConfig *variables.VariableConfig, values value.Values, stateAccess template.StateAccess) (err error) {
 	l := logger.From(ctx)
 	start := time.Now()
 	l.Info("copying files", "count", len(component.Files))
@@ -876,7 +876,7 @@ func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout,
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(variableConfig.GetSetVariableMap()).
 					WithConstants(variableConfig.GetConstants()).
-					WithState(s, component.SensitiveStateAccess)
+					WithState(stateAccess)
 				err = template.ApplyToFile(ctx, subFile, subFile, objs)
 				if err != nil {
 					return err

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -274,7 +274,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 		onDeploy := component.Actions.OnDeploy
 
 		onFailure := func() {
-			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
+			if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnFailure, d.vc, d.vals, template.StateAccess{State: d.s, AccessKeys: component.StateAccess}); err != nil {
 				l.Debug("unable to run component failure action", "error", err.Error())
 			}
 		}
@@ -311,7 +311,7 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 			}
 		}
 
-		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
+		if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.OnSuccess, d.vc, d.vals, template.StateAccess{State: d.s, AccessKeys: component.StateAccess}); err != nil {
 			onFailure()
 			return nil, fmt.Errorf("unable to run component success action: %w", err)
 		}
@@ -464,12 +464,12 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	d.vc.SetApplicationTemplates(applicationTemplates)
 
 	// Populate objects available to templates in before actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.Before, d.vc, d.vals, template.StateAccess{State: d.s, AccessKeys: component.StateAccess}); err != nil {
 		return nil, fmt.Errorf("unable to run component before action: %w", err)
 	}
 
 	if hasFiles {
-		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
+		if err := processComponentFiles(ctx, pkgLayout, component, d.vc, d.vals, template.StateAccess{State: d.s, AccessKeys: component.StateAccess}); err != nil {
 			return nil, fmt.Errorf("unable to process the component files: %w", err)
 		}
 	}
@@ -539,7 +539,7 @@ func (d *deployer) deployComponent(ctx context.Context, pkgLayout *layout.Packag
 	}
 
 	// Populate objects available to templates in after actions
-	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals, template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess}); err != nil {
+	if err := actions.Run(ctx, cwd, onDeploy.Defaults, onDeploy.After, d.vc, d.vals, template.StateAccess{State: d.s, AccessKeys: component.StateAccess}); err != nil {
 		return charts, fmt.Errorf("unable to run component after action: %w", err)
 	}
 
@@ -660,12 +660,15 @@ func (d *deployer) installManifests(ctx context.Context, pkgLayout *layout.Packa
 			}
 			if manifest.IsTemplate() {
 				l.Debug("start manifest template", "manifest", manifest.Name, "path", path)
-				objs := template.NewObjects(d.vals).
+				objs, err := template.NewObjects(d.vals).
 					WithPackage(pkgLayout.Pkg).
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(d.vc.GetSetVariableMap()).
 					WithConstants(d.vc.GetConstants()).
-					WithState(template.StateAccess{State: d.s, AllowSensitive: component.SensitiveStateAccess})
+					WithState(template.StateAccess{State: d.s, AccessKeys: component.StateAccess})
+				if err != nil {
+					return nil, err
+				}
 				if err := template.ApplyToFile(ctx, path, path, objs); err != nil {
 					return nil, err
 				}
@@ -871,12 +874,15 @@ func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout,
 			// If the file has go-templating enabled, apply templates.
 			if file.IsTemplate() {
 				l.Debug("templates enabled, processing file", "name", file.Target)
-				objs := template.NewObjects(values).
+				objs, err := template.NewObjects(values).
 					WithPackage(pkgLayout.Pkg).
 					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(variableConfig.GetSetVariableMap()).
 					WithConstants(variableConfig.GetConstants()).
 					WithState(stateAccess)
+				if err != nil {
+					return err
+				}
 				err = template.ApplyToFile(ctx, subFile, subFile, objs)
 				if err != nil {
 					return err

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -329,7 +329,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, itpl.StateAccess{})
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, itpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
 			if err != nil {
 				return nil, err
 			}

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/template"
+	itpl "github.com/zarf-dev/zarf/src/internal/template"
 	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
@@ -328,7 +329,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, nil, false)
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, itpl.StateAccess{})
 			if err != nil {
 				return nil, err
 			}

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -329,7 +329,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, itpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, itpl.StateAccess{State: s, AccessKeys: component.StateAccess})
 			if err != nil {
 				return nil, err
 			}

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -328,7 +328,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg)
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, nil, false)
 			if err != nil {
 				return nil, err
 			}

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -180,7 +180,7 @@ func InspectPackageResources(ctx context.Context, pkgLayout *layout.PackageLayou
 							WithBuild(pkgLayout.Pkg.Build).
 							WithVariables(variableConfig.GetSetVariableMap()).
 							WithConstants(variableConfig.GetConstants()).
-							WithState(s, component.SensitiveStateAccess)
+							WithState(tmpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
 						if err := tmpl.ApplyToFile(ctx, path, path, objs); err != nil {
 							return nil, fmt.Errorf("error applying Go templates to manifest: %w", err)
 						}
@@ -321,7 +321,7 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, s, component.SensitiveStateAccess)
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, tmpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
 			if err != nil {
 				return nil, err
 			}
@@ -332,7 +332,7 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 	return resources, nil
 }
 
-func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig, vals value.Values, pkg v1alpha1.ZarfPackage, s *state.State, allowSensitive bool) (_ []Resource, err error) {
+func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig, vals value.Values, pkg v1alpha1.ZarfPackage, stateAccess tmpl.StateAccess) (_ []Resource, err error) {
 	if err := layout.PackageManifest(ctx, manifest, baseComponentDir, packagePath); err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, 
 			objs := tmpl.NewObjects(vals).
 				WithPackage(pkg).
 				WithVariables(variableConfig.GetSetVariableMap()).
-				WithState(s, allowSensitive)
+				WithState(stateAccess)
 
 			// Create a temp file for the output
 			tmpDir, err := os.MkdirTemp("", "zarf-inspect-*")

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -175,12 +175,15 @@ func InspectPackageResources(ctx context.Context, pkgLayout *layout.PackageLayou
 						return nil, fmt.Errorf("error templating the manifest: %w", err)
 					}
 					if manifest.IsTemplate() {
-						objs := tmpl.NewObjects(vals).
+						objs, err := tmpl.NewObjects(vals).
 							WithPackage(pkgLayout.Pkg).
 							WithBuild(pkgLayout.Pkg.Build).
 							WithVariables(variableConfig.GetSetVariableMap()).
 							WithConstants(variableConfig.GetConstants()).
-							WithState(tmpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
+							WithState(tmpl.StateAccess{State: s, AccessKeys: component.StateAccess})
+						if err != nil {
+							return nil, fmt.Errorf("error building state template objects: %w", err)
+						}
 						if err := tmpl.ApplyToFile(ctx, path, path, objs); err != nil {
 							return nil, fmt.Errorf("error applying Go templates to manifest: %w", err)
 						}
@@ -321,7 +324,7 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, tmpl.StateAccess{State: s, AllowSensitive: component.SensitiveStateAccess})
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, tmpl.StateAccess{State: s, AccessKeys: component.StateAccess})
 			if err != nil {
 				return nil, err
 			}
@@ -357,10 +360,13 @@ func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, 
 		var content []byte
 		if manifest.IsTemplate() {
 			// Create template objects with values, metadata, build, constants, and variables
-			objs := tmpl.NewObjects(vals).
+			objs, err := tmpl.NewObjects(vals).
 				WithPackage(pkg).
 				WithVariables(variableConfig.GetSetVariableMap()).
 				WithState(stateAccess)
+			if err != nil {
+				return fmt.Errorf("error building state template objects: %w", err)
+			}
 
 			// Create a temp file for the output
 			tmpDir, err := os.MkdirTemp("", "zarf-inspect-*")

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -179,7 +179,8 @@ func InspectPackageResources(ctx context.Context, pkgLayout *layout.PackageLayou
 							WithPackage(pkgLayout.Pkg).
 							WithBuild(pkgLayout.Pkg.Build).
 							WithVariables(variableConfig.GetSetVariableMap()).
-							WithConstants(variableConfig.GetConstants())
+							WithConstants(variableConfig.GetConstants()).
+							WithState(s, component.SensitiveStateAccess)
 						if err := tmpl.ApplyToFile(ctx, path, path, objs); err != nil {
 							return nil, fmt.Errorf("error applying Go templates to manifest: %w", err)
 						}
@@ -320,7 +321,7 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 			}
 		}
 		for _, manifest := range component.Manifests {
-			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg)
+			manifestResources, err := getTemplatedManifests(ctx, manifest, pkgPath.BaseDir, compBuildPath, variableConfig, vals, pkg, s, component.SensitiveStateAccess)
 			if err != nil {
 				return nil, err
 			}
@@ -331,7 +332,7 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 	return resources, nil
 }
 
-func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig, vals value.Values, pkg v1alpha1.ZarfPackage) (_ []Resource, err error) {
+func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, packagePath string, baseComponentDir string, variableConfig *variables.VariableConfig, vals value.Values, pkg v1alpha1.ZarfPackage, s *state.State, allowSensitive bool) (_ []Resource, err error) {
 	if err := layout.PackageManifest(ctx, manifest, baseComponentDir, packagePath); err != nil {
 		return nil, err
 	}
@@ -358,7 +359,8 @@ func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, 
 			// Create template objects with values, metadata, build, constants, and variables
 			objs := tmpl.NewObjects(vals).
 				WithPackage(pkg).
-				WithVariables(variableConfig.GetSetVariableMap())
+				WithVariables(variableConfig.GetSetVariableMap()).
+				WithState(s, allowSensitive)
 
 			// Create a temp file for the output
 			tmpDir, err := os.MkdirTemp("", "zarf-inspect-*")

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -30,6 +30,7 @@ import (
 	"github.com/zarf-dev/zarf/src/internal/git"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/kustomize"
+	"github.com/zarf-dev/zarf/src/internal/template"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -375,7 +376,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 	}
 
 	onCreate := component.Actions.OnCreate
-	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil, nil, nil, false); err != nil {
+	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil, nil, template.StateAccess{}); err != nil {
 		return fmt.Errorf("unable to run component before action: %w", err)
 	}
 
@@ -518,7 +519,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 		}
 	}
 
-	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil, nil, nil, false); err != nil {
+	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil, nil, template.StateAccess{}); err != nil {
 		return fmt.Errorf("unable to run component after action: %w", err)
 	}
 

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -375,7 +375,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 	}
 
 	onCreate := component.Actions.OnCreate
-	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil, nil); err != nil {
+	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.Before, nil, nil, nil, false); err != nil {
 		return fmt.Errorf("unable to run component before action: %w", err)
 	}
 
@@ -518,7 +518,7 @@ func assemblePackageComponent(ctx context.Context, component v1alpha1.ZarfCompon
 		}
 	}
 
-	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil, nil); err != nil {
+	if err := actions.Run(ctx, packagePath, onCreate.Defaults, onCreate.After, nil, nil, nil, false); err != nil {
 		return fmt.Errorf("unable to run component after action: %w", err)
 	}
 

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -114,7 +114,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 		}
 
 		err := func() error {
-			err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil, vals)
+			err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil, vals, nil, false)
 			if err != nil {
 				return fmt.Errorf("unable to run the before action: %w", err)
 			}
@@ -144,11 +144,11 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 				}
 			}
 
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil, vals)
+			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil, vals, nil, false)
 			if err != nil {
 				return fmt.Errorf("unable to run the after action: %w", err)
 			}
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil, vals)
+			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil, vals, nil, false)
 			if err != nil {
 				return fmt.Errorf("unable to run the success action: %w", err)
 			}
@@ -167,7 +167,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 			return nil
 		}()
 		if err != nil {
-			removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil, vals)
+			removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil, vals, nil, false)
 			if removeErr != nil {
 				return errors.Join(fmt.Errorf("unable to run the failure action: %w", err), removeErr)
 			}

--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/requirements"
+	"github.com/zarf-dev/zarf/src/internal/template"
 	"github.com/zarf-dev/zarf/src/pkg/feature"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/state"
@@ -114,7 +115,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 		}
 
 		err := func() error {
-			err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil, vals, nil, false)
+			err := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.Before, nil, vals, template.StateAccess{})
 			if err != nil {
 				return fmt.Errorf("unable to run the before action: %w", err)
 			}
@@ -144,11 +145,11 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 				}
 			}
 
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil, vals, nil, false)
+			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.After, nil, vals, template.StateAccess{})
 			if err != nil {
 				return fmt.Errorf("unable to run the after action: %w", err)
 			}
-			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil, vals, nil, false)
+			err = actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnSuccess, nil, vals, template.StateAccess{})
 			if err != nil {
 				return fmt.Errorf("unable to run the success action: %w", err)
 			}
@@ -167,7 +168,7 @@ func Remove(ctx context.Context, pkg v1alpha1.ZarfPackage, opts RemoveOptions) e
 			return nil
 		}()
 		if err != nil {
-			removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil, vals, nil, false)
+			removeErr := actions.Run(ctx, cwd, comp.Actions.OnRemove.Defaults, comp.Actions.OnRemove.OnFailure, nil, vals, template.StateAccess{})
 			if removeErr != nil {
 				return errors.Join(fmt.Errorf("unable to run the failure action: %w", err), removeErr)
 			}

--- a/src/pkg/schema/zarf-v1alpha1-schema.json
+++ b/src/pkg/schema/zarf-v1alpha1-schema.json
@@ -649,7 +649,7 @@
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
         },
         "stateAccess": {
-          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"artifactCredentials\", \"agentCerts\".",
+          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"agentCerts\".",
           "items": {
             "type": "string"
           },

--- a/src/pkg/schema/zarf-v1alpha1-schema.json
+++ b/src/pkg/schema/zarf-v1alpha1-schema.json
@@ -648,9 +648,12 @@
           "$ref": "#/$defs/DeprecatedZarfComponentScripts",
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
         },
-        "sensitiveStateAccess": {
-          "description": "Grants access to credential fields within .State during Go template processing",
-          "type": "boolean"
+        "stateAccess": {
+          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"artifactCredentials\", \"agentCerts\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/src/pkg/schema/zarf-v1alpha1-schema.json
+++ b/src/pkg/schema/zarf-v1alpha1-schema.json
@@ -647,6 +647,10 @@
         "scripts": {
           "$ref": "#/$defs/DeprecatedZarfComponentScripts",
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
+        },
+        "sensitiveStateAccess": {
+          "description": "Grants access to credential fields within .State during Go template processing",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
+	"github.com/zarf-dev/zarf/src/pkg/utils"
 )
 
 // Declares secrets and metadata keys and values.
@@ -353,6 +354,23 @@ func (ri RegistryInfo) IsConfigured() bool {
 // ShouldUseMTLS returns true if mTLS should be used for the registry connection.
 func (ri RegistryInfo) ShouldUseMTLS() bool {
 	return ri.MTLSStrategy != "" && ri.MTLSStrategy != MTLSStrategyNone
+}
+
+// Htpasswd returns an htpasswd-formatted string for the registry's push and pull users.
+// Returns an empty string for external registries.
+func (ri RegistryInfo) Htpasswd() (string, error) {
+	if !ri.IsInternal() {
+		return "", nil
+	}
+	pushUser, err := utils.GetHtpasswdString(ri.PushUsername, ri.PushPassword)
+	if err != nil {
+		return "", fmt.Errorf("generating htpasswd for push user: %w", err)
+	}
+	pullUser, err := utils.GetHtpasswdString(ri.PullUsername, ri.PullPassword)
+	if err != nil {
+		return "", fmt.Errorf("generating htpasswd for pull user: %w", err)
+	}
+	return fmt.Sprintf("%s\\n%s", pushUser, pullUser), nil
 }
 
 // CheckIfRegistryAddressOrCredsChanged compares two RegistryInfo structs and returns true if the creds or address changed

--- a/src/test/e2e/42_values_test.go
+++ b/src/test/e2e/42_values_test.go
@@ -63,6 +63,16 @@ func TestValues(t *testing.T) {
 	require.NoError(t, err, "unable to get processed template configmap")
 	require.Contains(t, kubectlOut, "processed=myValue")
 
+	// Verify public state fields were templated into the configmap (no sensitiveStateAccess needed)
+	kubectlOut, _, err = e2e.Kubectl(t, "get", "configmap", "test-state-configmap", "-o", "jsonpath='{.data.registryAddress}'")
+	require.NoError(t, err, "unable to get state configmap")
+	require.NotContains(t, kubectlOut, "{{", "registryAddress should have been templated")
+	require.NotEmpty(t, kubectlOut, "registryAddress should be non-empty")
+
+	kubectlOut, _, err = e2e.Kubectl(t, "get", "configmap", "test-state-configmap", "-o", "jsonpath='{.data.storageClass}'")
+	require.NoError(t, err, "unable to get state configmap")
+	require.NotContains(t, kubectlOut, "{{", "storageClass should have been templated")
+
 	// Remove the package with values
 	valuesFile := filepath.Join(src, "override-values.yaml")
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "test-values", "--confirm", "--features=\"values=true\"", "--values", valuesFile, "--set-values", "removeKey=custom-remove-value")
@@ -129,5 +139,24 @@ func TestValuesSchema(t *testing.T) {
 		require.Error(t, err, "expected error for invalid override values at deploy time")
 		// Check that the error message mentions validation failure
 		require.Contains(t, stdErr, "values validation failed", "error should mention schema validation failure")
+	})
+}
+
+func TestStateTemplates(t *testing.T) {
+	t.Log("E2E: State template access controls")
+
+	t.Run("sensitive fields are blocked without sensitiveStateAccess", func(t *testing.T) {
+		src := filepath.Join("src", "test", "packages", "42-values", "state-blocked")
+		tmpdir := t.TempDir()
+
+		stdOut, stdErr, err := e2e.Zarf(t, "package", "create", src, "-o", tmpdir, "--skip-sbom", "--confirm")
+		require.NoError(t, err, stdOut, stdErr)
+
+		packageName := fmt.Sprintf("zarf-package-test-state-blocked-%s.tar.zst", e2e.Arch)
+		path := filepath.Join(tmpdir, packageName)
+
+		_, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
+		require.Error(t, err, "deploy should fail when accessing sensitive state without sensitiveStateAccess")
+		require.Contains(t, stdErr, "PushPassword", "error should identify the inaccessible field")
 	})
 }

--- a/src/test/e2e/42_values_test.go
+++ b/src/test/e2e/42_values_test.go
@@ -63,7 +63,7 @@ func TestValues(t *testing.T) {
 	require.NoError(t, err, "unable to get processed template configmap")
 	require.Contains(t, kubectlOut, "processed=myValue")
 
-	// Verify public state fields were templated into the configmap (no sensitiveStateAccess needed)
+	// Verify public state fields were templated into the configmap (no stateAccess declaration needed)
 	kubectlOut, _, err = e2e.Kubectl(t, "get", "configmap", "test-state-configmap", "-o", "jsonpath='{.data.registryAddress}'")
 	require.NoError(t, err, "unable to get state configmap")
 	require.NotContains(t, kubectlOut, "{{", "registryAddress should have been templated")
@@ -145,7 +145,7 @@ func TestValuesSchema(t *testing.T) {
 func TestStateTemplates(t *testing.T) {
 	t.Log("E2E: State template access controls")
 
-	t.Run("sensitive fields are blocked without sensitiveStateAccess", func(t *testing.T) {
+	t.Run("sensitive fields are blocked without stateAccess", func(t *testing.T) {
 		src := filepath.Join("src", "test", "packages", "42-values", "state-blocked")
 		tmpdir := t.TempDir()
 
@@ -156,7 +156,7 @@ func TestStateTemplates(t *testing.T) {
 		path := filepath.Join(tmpdir, packageName)
 
 		_, stdErr, err = e2e.Zarf(t, "package", "deploy", path, "--confirm")
-		require.Error(t, err, "deploy should fail when accessing sensitive state without sensitiveStateAccess")
+		require.Error(t, err, "deploy should fail when accessing sensitive state without stateAccess")
 		require.Contains(t, stdErr, "PushPassword", "error should identify the inaccessible field")
 	})
 }

--- a/src/test/packages/42-values/state-blocked/blocked-configmap.yaml
+++ b/src/test/packages/42-values/state-blocked/blocked-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-state-blocked-configmap
+  namespace: default
+data:
+  password: "{{ .State.Registry.PushPassword }}"

--- a/src/test/packages/42-values/state-blocked/zarf.yaml
+++ b/src/test/packages/42-values/state-blocked/zarf.yaml
@@ -1,0 +1,13 @@
+kind: ZarfPackageConfig
+metadata:
+  name: test-state-blocked
+  description: Test package that verifies sensitive state fields are blocked without sensitiveStateAccess
+
+components:
+  - name: test-state-blocked-component
+    required: true
+    manifests:
+      - name: blocked-configmap
+        template: true
+        files:
+          - blocked-configmap.yaml

--- a/src/test/packages/42-values/state-blocked/zarf.yaml
+++ b/src/test/packages/42-values/state-blocked/zarf.yaml
@@ -1,7 +1,7 @@
 kind: ZarfPackageConfig
 metadata:
   name: test-state-blocked
-  description: Test package that verifies sensitive state fields are blocked without sensitiveStateAccess
+  description: Test package that verifies sensitive state fields are blocked without a stateAccess declaration
 
 components:
   - name: test-state-blocked-component

--- a/src/test/packages/42-values/state-configmap.yaml
+++ b/src/test/packages/42-values/state-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-state-configmap
+  namespace: default
+data:
+  registryAddress: "{{ .State.Registry.Address }}"
+  storageClass: "{{ .State.StorageClass }}"

--- a/src/test/packages/42-values/zarf.yaml
+++ b/src/test/packages/42-values/zarf.yaml
@@ -56,3 +56,23 @@ components:
         template: true
         files:
           - processed-template-configmap.yaml
+
+  - name: test-state-public
+    required: true
+    manifests:
+      - name: test-state-configmap
+        template: true
+        files:
+          - state-configmap.yaml
+
+  - name: test-state-sensitive
+    required: true
+    sensitiveStateAccess: true
+    actions:
+      onDeploy:
+        before:
+          # Verifies the sensitive field resolves to a non-empty value without
+          # writing the credential to any cluster resource. test -n exits non-zero
+          # if the string is empty, failing the action.
+          - cmd: "test -n \"{{ .State.Registry.PushPassword }}\""
+            template: true

--- a/src/test/packages/42-values/zarf.yaml
+++ b/src/test/packages/42-values/zarf.yaml
@@ -67,7 +67,8 @@ components:
 
   - name: test-state-sensitive
     required: true
-    sensitiveStateAccess: true
+    stateAccess:
+      - registryCredentials
     actions:
       onDeploy:
         before:

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -649,7 +649,7 @@
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
         },
         "stateAccess": {
-          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"artifactCredentials\", \"agentCerts\".",
+          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"agentCerts\".",
           "items": {
             "type": "string"
           },

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -648,9 +648,12 @@
           "$ref": "#/$defs/DeprecatedZarfComponentScripts",
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
         },
-        "sensitiveStateAccess": {
-          "description": "Grants access to credential fields within .State during Go template processing",
-          "type": "boolean"
+        "stateAccess": {
+          "description": "Groups of sensitive .State fields this component may access in Go templates (manifests, files, actions with template: true).\nValid values: \"registryCredentials\", \"gitCredentials\", \"artifactCredentials\", \"agentCerts\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/zarf.schema.json
+++ b/zarf.schema.json
@@ -647,6 +647,10 @@
         "scripts": {
           "$ref": "#/$defs/DeprecatedZarfComponentScripts",
           "description": "[Deprecated] (replaced by actions) Custom commands to run before or after package deployment. This will be removed in Zarf v1.0.0."
+        },
+        "sensitiveStateAccess": {
+          "description": "Grants access to credential fields within .State during Go template processing",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
## Description

Adds support for `{{ .State.<target>. }}` with an explicit field in the schema for components to opt-into sensitive state values.

**Breakng Change:** The actions `Run()` function signature has been modified. This only impact SDK users invoking that functionality. 

## Related Issue

Fixes #4226

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
