### PR TITLE
feat(agent): add readiness probe

### DIFF
--- a/packages/zarf-agent/chart/templates/deployment.yaml
+++ b/packages/zarf-agent/chart/templates/deployment.yaml
@@ -38,6 +38,14 @@ spec:
               path: /healthz
               port: 8443
               scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2
           ports:
             - containerPort: 8443
           securityContext:

--- a/packages/zarf-agent/chart/templates/webhook.yaml
+++ b/packages/zarf-agent/chart/templates/webhook.yaml
@@ -42,6 +42,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-flux-ocirepo.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -115,6 +116,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-flux-gitrepo.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -152,6 +154,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-argocd-application.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -187,6 +190,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-argocd-applicationset.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -222,6 +226,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-argocd-repository.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -262,6 +267,7 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20
   - name: agent-argocd-appproject.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -297,3 +303,4 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
+    timeoutSeconds: 20

--- a/packages/zarf-agent/chart/templates/webhook.yaml
+++ b/packages/zarf-agent/chart/templates/webhook.yaml
@@ -42,7 +42,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-flux-ocirepo.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -116,7 +115,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-flux-gitrepo.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -154,7 +152,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-argocd-application.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -190,7 +187,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-argocd-applicationset.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -226,7 +222,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-argocd-repository.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -267,7 +262,6 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20
   - name: agent-argocd-appproject.zarf.dev
     namespaceSelector:
       matchExpressions:
@@ -303,4 +297,3 @@ webhooks:
       - "v1"
       - "v1beta1"
     sideEffects: None
-    timeoutSeconds: 20


### PR DESCRIPTION
## Description

I've seen the webhook timeout https://github.com/zarf-dev/zarf/actions/runs/27347872505/job/80801361476 recently in CI. It seems like it might be that the webhook has so little CPU that it's not able to complete the request in a normal amount of time. I'm not sure if the readinessprobe will help, but I don't think it will hurt

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
