### PR TITLE
feat(values)!: expose pkg built in

### DIFF
--- a/examples/values-templating/nginx-configmap.yaml
+++ b/examples/values-templating/nginx-configmap.yaml
@@ -81,6 +81,11 @@ data:
         <pre>IP family: {{ .State.IPFamily }}</pre>
         <pre>IPv6 only: {{ eq .State.IPFamily "ipv6" }}</pre>
 
+        <h3>Package values (via .Pkg)</h3>
+        <pre>Name: {{ .Pkg.Metadata.Name }}</pre>
+        <pre>CLI version during build: {{ .Pkg.Build.Version }}</pre>
+        <pre>Nginx Image: {{ range .Pkg.Components }}{{ if eq .Name "values-with-manifest" }}{{ index .Images 0 }}{{ end }}{{ end }}</pre>
+
         {{ .Values.site.footer }}
       </body>
     </html>

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -41,6 +41,7 @@ const (
 	objectKeyValues    = "Values"
 	objectKeyMetadata  = "Metadata"
 	objectKeyBuild     = "Build"
+	objectKeyPackage   = "Pkg"
 	objectKeyConstants = "Constants"
 	objectKeyVariables = "Variables"
 	objectKeyState     = "State"
@@ -96,6 +97,8 @@ func (o Objects) WithVariables(vars variables.SetVariableMap) Objects {
 // WithPackage takes a v1alpha1.ZarfPackage and makes Metadata, Constants, and Build available on the Objects map.
 func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
 	// Check for fields that should be set on pkg to see if the sub-obj is available
+	o[objectKeyPackage] = pkg
+
 	if pkg.Metadata.Name != "" {
 		o.WithMetadata(pkg.Metadata)
 	}

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -60,18 +60,6 @@ func (o Objects) WithValues(values value.Values) Objects {
 	return o
 }
 
-// WithMetadata takes the v1alpha1.ZarfMetadata section of a created package and makes it available in templating Objects.
-func (o Objects) WithMetadata(meta v1alpha1.ZarfMetadata) Objects {
-	o[objectKeyMetadata] = meta
-	return o
-}
-
-// WithBuild takes the v1alpha1.ZarfBuildData section of a created package and makes it available in templating Objects.
-func (o Objects) WithBuild(build v1alpha1.ZarfBuildData) Objects {
-	o[objectKeyBuild] = build
-	return o
-}
-
 // WithConstants Takes a slice of v1alpha1.Constants and unwraps it into the templating Objects map so constants can be
 // accessed in templates by their key name.
 func (o Objects) WithConstants(constants []v1alpha1.Constant) Objects {
@@ -94,21 +82,9 @@ func (o Objects) WithVariables(vars variables.SetVariableMap) Objects {
 	return o
 }
 
-// WithPackage takes a v1alpha1.ZarfPackage and makes Metadata, Constants, and Build available on the Objects map.
+// WithPackage makes a v1alpha1.ZarfPackage available on the Objects map.
 func (o Objects) WithPackage(pkg v1alpha1.ZarfPackage) Objects {
-	// Check for fields that should be set on pkg to see if the sub-obj is available
 	o[objectKeyPackage] = pkg
-
-	if pkg.Metadata.Name != "" {
-		o.WithMetadata(pkg.Metadata)
-	}
-	if pkg.Build.User != "" {
-		o.WithBuild(pkg.Build)
-	}
-	// Are any Constants set? Load them
-	if len(pkg.Constants) > 0 {
-		o.WithConstants(pkg.Constants)
-	}
 	return o
 }
 

--- a/src/internal/template/template.go
+++ b/src/internal/template/template.go
@@ -39,8 +39,6 @@ type Objects map[string]any
 
 const (
 	objectKeyValues    = "Values"
-	objectKeyMetadata  = "Metadata"
-	objectKeyBuild     = "Build"
 	objectKeyPackage   = "Pkg"
 	objectKeyConstants = "Constants"
 	objectKeyVariables = "Variables"

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -139,10 +139,6 @@ func TestObjects_WithPackage(t *testing.T) {
 			result := objects.WithPackage(tt.pkg)
 
 			require.Equal(t, tt.pkg, result[objectKeyPackage])
-			// WithPackage only exposes the package itself; it does not unwrap sub-objects.
-			require.NotContains(t, result, objectKeyMetadata)
-			require.NotContains(t, result, objectKeyBuild)
-			require.NotContains(t, result, objectKeyConstants)
 		})
 	}
 }

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -114,42 +114,22 @@ func TestObjects_WithValues(t *testing.T) {
 
 func TestObjects_WithPackage(t *testing.T) {
 	tests := []struct {
-		name              string
-		pkg               v1alpha1.ZarfPackage
-		expectMetadata    bool
-		expectBuild       bool
-		expectedConstants map[string]string
+		name string
+		pkg  v1alpha1.ZarfPackage
 	}{
 		{
-			name: "full package sets metadata, build, and constants",
+			name: "populated package",
 			pkg: v1alpha1.ZarfPackage{
 				Metadata: v1alpha1.ZarfMetadata{Name: "test-package", Version: "1.0.0"},
 				Build:    v1alpha1.ZarfBuildData{User: "test-user", Architecture: "amd64"},
 				Constants: []v1alpha1.Constant{
 					{Name: "APP_NAME", Value: "my-app"},
-					{Name: "VERSION", Value: "1.2.3"},
 				},
 			},
-			expectMetadata: true,
-			expectBuild:    true,
-			expectedConstants: map[string]string{
-				"APP_NAME": "my-app",
-				"VERSION":  "1.2.3",
-			},
 		},
 		{
-			name:           "empty metadata name omits metadata",
-			pkg:            v1alpha1.ZarfPackage{},
-			expectMetadata: false,
-			expectBuild:    false,
-		},
-		{
-			name: "empty build user omits build",
-			pkg: v1alpha1.ZarfPackage{
-				Metadata: v1alpha1.ZarfMetadata{Name: "test-package"},
-			},
-			expectMetadata: true,
-			expectBuild:    false,
+			name: "empty package",
+			pkg:  v1alpha1.ZarfPackage{},
 		},
 	}
 
@@ -159,24 +139,10 @@ func TestObjects_WithPackage(t *testing.T) {
 			result := objects.WithPackage(tt.pkg)
 
 			require.Equal(t, tt.pkg, result[objectKeyPackage])
-
-			if tt.expectMetadata {
-				require.Equal(t, tt.pkg.Metadata, result[objectKeyMetadata])
-			} else {
-				require.NotContains(t, result, objectKeyMetadata)
-			}
-
-			if tt.expectBuild {
-				require.Equal(t, tt.pkg.Build, result[objectKeyBuild])
-			} else {
-				require.NotContains(t, result, objectKeyBuild)
-			}
-
-			if tt.expectedConstants != nil {
-				require.Equal(t, tt.expectedConstants, result[objectKeyConstants])
-			} else {
-				require.NotContains(t, result, objectKeyConstants)
-			}
+			// WithPackage only exposes the package itself; it does not unwrap sub-objects.
+			require.NotContains(t, result, objectKeyMetadata)
+			require.NotContains(t, result, objectKeyBuild)
+			require.NotContains(t, result, objectKeyConstants)
 		})
 	}
 }

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -112,110 +112,71 @@ func TestObjects_WithValues(t *testing.T) {
 	}
 }
 
-func TestObjects_WithMetadata(t *testing.T) {
+func TestObjects_WithPackage(t *testing.T) {
 	tests := []struct {
-		name     string
-		metadata v1alpha1.ZarfMetadata
-		expected v1alpha1.ZarfMetadata
+		name              string
+		pkg               v1alpha1.ZarfPackage
+		expectMetadata    bool
+		expectBuild       bool
+		expectedConstants map[string]string
 	}{
 		{
-			name: "complete metadata",
-			metadata: v1alpha1.ZarfMetadata{
-				Name:        "test-package",
-				Description: "A test package",
-				Version:     "1.0.0",
+			name: "full package sets metadata, build, and constants",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "test-package", Version: "1.0.0"},
+				Build:    v1alpha1.ZarfBuildData{User: "test-user", Architecture: "amd64"},
+				Constants: []v1alpha1.Constant{
+					{Name: "APP_NAME", Value: "my-app"},
+					{Name: "VERSION", Value: "1.2.3"},
+				},
 			},
-			expected: v1alpha1.ZarfMetadata{
-				Name:        "test-package",
-				Description: "A test package",
-				Version:     "1.0.0",
-			},
-		},
-		{
-			name: "minimal metadata",
-			metadata: v1alpha1.ZarfMetadata{
-				Name: "minimal-package",
-			},
-			expected: v1alpha1.ZarfMetadata{
-				Name: "minimal-package",
+			expectMetadata: true,
+			expectBuild:    true,
+			expectedConstants: map[string]string{
+				"APP_NAME": "my-app",
+				"VERSION":  "1.2.3",
 			},
 		},
 		{
-			name: "metadata with URL and author",
-			metadata: v1alpha1.ZarfMetadata{
-				Name:        "example-package",
-				Description: "An example package for testing",
-				Version:     "2.1.0",
-				URL:         "https://example.com",
-				Authors:     "Test Author <test@example.com>",
+			name:           "empty metadata name omits metadata",
+			pkg:            v1alpha1.ZarfPackage{},
+			expectMetadata: false,
+			expectBuild:    false,
+		},
+		{
+			name: "empty build user omits build",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Name: "test-package"},
 			},
-			expected: v1alpha1.ZarfMetadata{
-				Name:        "example-package",
-				Description: "An example package for testing",
-				Version:     "2.1.0",
-				URL:         "https://example.com",
-				Authors:     "Test Author <test@example.com>",
-			},
+			expectMetadata: true,
+			expectBuild:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			objects := make(Objects)
-			result := objects.WithMetadata(tt.metadata)
-			require.Equal(t, tt.expected, result[objectKeyMetadata])
-		})
-	}
-}
+			result := objects.WithPackage(tt.pkg)
 
-func TestObjects_WithBuild(t *testing.T) {
-	tests := []struct {
-		name     string
-		build    v1alpha1.ZarfBuildData
-		expected v1alpha1.ZarfBuildData
-	}{
-		{
-			name: "complete build data",
-			build: v1alpha1.ZarfBuildData{
-				User:         "test-user",
-				Architecture: "amd64",
-				Timestamp:    "2023-01-01T00:00:00Z",
-			},
-			expected: v1alpha1.ZarfBuildData{
-				User:         "test-user",
-				Architecture: "amd64",
-				Timestamp:    "2023-01-01T00:00:00Z",
-			},
-		},
-		{
-			name: "minimal build data",
-			build: v1alpha1.ZarfBuildData{
-				User: "minimal-user",
-			},
-			expected: v1alpha1.ZarfBuildData{
-				User: "minimal-user",
-			},
-		},
-		{
-			name: "arm64 architecture",
-			build: v1alpha1.ZarfBuildData{
-				User:         "arm-user",
-				Architecture: "arm64",
-				Timestamp:    "2023-12-01T10:30:00Z",
-			},
-			expected: v1alpha1.ZarfBuildData{
-				User:         "arm-user",
-				Architecture: "arm64",
-				Timestamp:    "2023-12-01T10:30:00Z",
-			},
-		},
-	}
+			require.Equal(t, tt.pkg, result[objectKeyPackage])
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			objects := make(Objects)
-			result := objects.WithBuild(tt.build)
-			require.Equal(t, tt.expected, result[objectKeyBuild])
+			if tt.expectMetadata {
+				require.Equal(t, tt.pkg.Metadata, result[objectKeyMetadata])
+			} else {
+				require.NotContains(t, result, objectKeyMetadata)
+			}
+
+			if tt.expectBuild {
+				require.Equal(t, tt.pkg.Build, result[objectKeyBuild])
+			} else {
+				require.NotContains(t, result, objectKeyBuild)
+			}
+
+			if tt.expectedConstants != nil {
+				require.Equal(t, tt.expectedConstants, result[objectKeyConstants])
+			} else {
+				require.NotContains(t, result, objectKeyConstants)
+			}
 		})
 	}
 }

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -137,7 +137,6 @@ func TestObjects_WithPackage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			objects := make(Objects)
 			result := objects.WithPackage(tt.pkg)
-
 			require.Equal(t, tt.pkg, result[objectKeyPackage])
 		})
 	}

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -671,7 +671,6 @@ func (d *deployer) installManifests(ctx context.Context, pkgLayout *layout.Packa
 				l.Debug("start manifest template", "manifest", manifest.Name, "path", path)
 				objs, err := template.NewObjects(d.vals).
 					WithPackage(pkgLayout.Pkg).
-					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(d.vc.GetSetVariableMap()).
 					WithConstants(d.vc.GetConstants()).
 					WithState(template.StateAccess{State: d.s, AccessKeys: component.StateAccess})
@@ -882,7 +881,6 @@ func processComponentFiles(ctx context.Context, pkgLayout *layout.PackageLayout,
 				l.Debug("templates enabled, processing file", "name", file.Target)
 				objs, err := template.NewObjects(values).
 					WithPackage(pkgLayout.Pkg).
-					WithBuild(pkgLayout.Pkg.Build).
 					WithVariables(variableConfig.GetSetVariableMap()).
 					WithConstants(variableConfig.GetConstants()).
 					WithState(stateAccess)

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -183,7 +183,6 @@ func InspectPackageResources(ctx context.Context, pkgLayout *layout.PackageLayou
 					if manifest.IsTemplate() {
 						objs, err := tmpl.NewObjects(vals).
 							WithPackage(pkgLayout.Pkg).
-							WithBuild(pkgLayout.Pkg.Build).
 							WithVariables(variableConfig.GetSetVariableMap()).
 							WithConstants(variableConfig.GetConstants()).
 							WithState(tmpl.StateAccess{State: s, AccessKeys: component.StateAccess})
@@ -235,7 +234,6 @@ func templateValuesFiles(ctx context.Context, chart v1alpha1.ZarfChart, valuesDi
 	// Build objs once — inputs don't vary per file and WithState may invoke bcrypt.
 	objs, err := tmpl.NewObjects(opts.vals).
 		WithPackage(opts.pkg).
-		WithBuild(opts.pkg.Build).
 		WithVariables(opts.variableConfig.GetSetVariableMap()).
 		WithConstants(opts.variableConfig.GetConstants()).
 		WithState(tmpl.StateAccess{State: opts.s, AccessKeys: opts.stateAccess})
@@ -407,6 +405,7 @@ func getTemplatedManifests(ctx context.Context, manifest v1alpha1.ZarfManifest, 
 			objs, err := tmpl.NewObjects(vals).
 				WithPackage(pkg).
 				WithVariables(variableConfig.GetSetVariableMap()).
+				WithConstants(variableConfig.GetConstants()).
 				WithState(stateAccess)
 			if err != nil {
 				return fmt.Errorf("error building state template objects: %w", err)


### PR DESCRIPTION
## Description

This exposes a pkg built-in with the entire Zarf package object. This removes the `.Metadata` and `.Build` built-ins, in favor of `{{ .Pkg.Metadata }}` instead of `{{ .Metadata }}`. Because these features were never documented, and values is an alpha feature behind a feature flag, I believe this breaking change is okay.

I did not add {{ .Pkg }} to actions, {{ .Metadata }} and {{ .Build }} are also not available in actions, I believe this can be a follow up, I want us to consider which actions these should apply to. 

Relates to #4878

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
