### PR TITLE
feat(lint): warn on images without a domain and archive images without .internal

### DIFF
--- a/site/src/content/docs/ref/components.mdx
+++ b/site/src/content/docs/ref/components.mdx
@@ -147,6 +147,8 @@ Another way to bring OCI images can into the package is via archives of [OCI lay
 
 An OCI layout can have any number of images, Zarf will pull all images that are listed in the sub-field `imageArchives.images`. If a listed image is not found in the archive then Zarf will error. In order for Zarf to find an image its [descriptor](https://specs.opencontainers.org/image-spec/descriptor/?v=v1.1.1) in the OCI-layout index.json must include the annotation "io.containerd.image.name" or "org.opencontainers.image.ref.name". `docker save` and `podman save` will automatically add at least one of these annotations.
 
+Locally-built images that are not pulled from a public registry should be referenced under the reserved [`.internal`](https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-24-07-2024-en#section2.b) top-level domain (for example `zarf.internal/my-app:1.0.0`). The `.internal` TLD will never resolve on the public internet, which avoids accidentally pulling an unexpected image if a registry reference is mistyped or rewriting fails. `zarf dev lint` emits a warning when an image archive image does not use a `.internal` domain.
+
 
 ```yaml
 - name: image-archive

--- a/src/pkg/lint/rules.go
+++ b/src/pkg/lint/rules.go
@@ -40,12 +40,50 @@ func isPinnedRepo(repo string) bool {
 	return (strings.Contains(repo, "@"))
 }
 
+// isTemplatedImage returns true if the image reference contains a Zarf template
+// or variable placeholder that has not yet been substituted.
+func isTemplatedImage(image string) bool {
+	return strings.Contains(image, v1alpha1.ZarfPackageTemplatePrefix) ||
+		strings.Contains(image, v1alpha1.ZarfPackageVariablePrefix)
+}
+
+// imageDomain returns the registry domain explicitly specified in the image
+// reference. An empty string is returned when the reference does not include a
+// domain, in which case the registry would default to docker.io. This mirrors
+// the domain detection used by the distribution/reference library.
+func imageDomain(image string) string {
+	image = strings.TrimPrefix(image, helpers.OCIURLPrefix)
+	i := strings.IndexRune(image, '/')
+	if i == -1 {
+		return ""
+	}
+	prefix := image[:i]
+	if strings.ContainsAny(prefix, ".:") || prefix == "localhost" || strings.ToLower(prefix) != prefix {
+		return prefix
+	}
+	return ""
+}
+
+// hasInternalDomain returns true if the image's registry domain uses the
+// reserved .internal top-level domain, which never resolves on the public
+// internet and is the recommended convention for locally-built images.
+func hasInternalDomain(image string) bool {
+	domain := imageDomain(image)
+	// Strip any port so domains such as zarf.internal:5000 are still matched.
+	if host, _, ok := strings.Cut(domain, ":"); ok {
+		domain = host
+	}
+	return strings.HasSuffix(domain, ".internal")
+}
+
 // CheckComponentValues runs lint rules validating values on component keys, should be run after templating
 func CheckComponentValues(c v1alpha1.ZarfComponent, i int) []PackageFinding {
 	var findings []PackageFinding
 	findings = append(findings, checkForUnpinnedRepos(c, i)...)
 	findings = append(findings, checkForUnpinnedImages(c, i)...)
 	findings = append(findings, checkForUnpinnedFiles(c, i)...)
+	findings = append(findings, checkForImagesWithoutDomain(c, i)...)
+	findings = append(findings, checkForImageArchivesWithoutInternalDomain(c, i)...)
 	return findings
 }
 
@@ -86,6 +124,44 @@ func checkForUnpinnedImages(c v1alpha1.ZarfComponent, i int) []PackageFinding {
 				Item:        image,
 				Severity:    SevWarn,
 			})
+		}
+	}
+	return findings
+}
+
+func checkForImagesWithoutDomain(c v1alpha1.ZarfComponent, i int) []PackageFinding {
+	var findings []PackageFinding
+	for j, image := range c.Images {
+		if isTemplatedImage(image) {
+			continue
+		}
+		if imageDomain(image) == "" {
+			findings = append(findings, PackageFinding{
+				YqPath:      fmt.Sprintf(".components.[%d].images.[%d]", i, j),
+				Description: "Image reference does not specify a registry domain",
+				Item:        image,
+				Severity:    SevWarn,
+			})
+		}
+	}
+	return findings
+}
+
+func checkForImageArchivesWithoutInternalDomain(c v1alpha1.ZarfComponent, i int) []PackageFinding {
+	var findings []PackageFinding
+	for j, archive := range c.ImageArchives {
+		for k, image := range archive.Images {
+			if isTemplatedImage(image) {
+				continue
+			}
+			if !hasInternalDomain(image) {
+				findings = append(findings, PackageFinding{
+					YqPath:      fmt.Sprintf(".components.[%d].imageArchives.[%d].images.[%d]", i, j, k),
+					Description: "Image archive image should use a .internal domain to avoid resolving to a public registry",
+					Item:        image,
+					Severity:    SevWarn,
+				})
+			}
 		}
 	}
 	return findings

--- a/src/pkg/lint/rules_test.go
+++ b/src/pkg/lint/rules_test.go
@@ -92,6 +92,66 @@ func TestUnpinnnedFileWarning(t *testing.T) {
 	require.Len(t, findings, 1)
 }
 
+func TestImagesWithoutDomain(t *testing.T) {
+	t.Parallel()
+	component := v1alpha1.ZarfComponent{Images: []string{
+		"myapp:1.0.0",
+		"library/myapp:1.0.0",
+		"docker.io/library/myapp:1.0.0",
+		"ghcr.io/zarf-dev/zarf:v0.1.0",
+		"localhost:5000/myapp:1.0.0",
+		"###ZARF_PKG_TMPL_IMAGE###",
+	}}
+	findings := checkForImagesWithoutDomain(component, 0)
+	expected := []PackageFinding{
+		{
+			Item:        "myapp:1.0.0",
+			Description: "Image reference does not specify a registry domain",
+			Severity:    SevWarn,
+			YqPath:      ".components.[0].images.[0]",
+		},
+		{
+			Item:        "library/myapp:1.0.0",
+			Description: "Image reference does not specify a registry domain",
+			Severity:    SevWarn,
+			YqPath:      ".components.[0].images.[1]",
+		},
+	}
+	require.Equal(t, expected, findings)
+}
+
+func TestImageArchivesWithoutInternalDomain(t *testing.T) {
+	t.Parallel()
+	component := v1alpha1.ZarfComponent{ImageArchives: []v1alpha1.ImageArchive{
+		{
+			Path: "images.tar",
+			Images: []string{
+				"zarf.internal/myapp:1.0.0",
+				"my.registry.internal:5000/myapp:1.0.0",
+				"myapp:1.0.0",
+				"docker.io/library/myapp:1.0.0",
+				"###ZARF_PKG_TMPL_IMAGE###",
+			},
+		},
+	}}
+	findings := checkForImageArchivesWithoutInternalDomain(component, 0)
+	expected := []PackageFinding{
+		{
+			Item:        "myapp:1.0.0",
+			Description: "Image archive image should use a .internal domain to avoid resolving to a public registry",
+			Severity:    SevWarn,
+			YqPath:      ".components.[0].imageArchives.[0].images.[2]",
+		},
+		{
+			Item:        "docker.io/library/myapp:1.0.0",
+			Description: "Image archive image should use a .internal domain to avoid resolving to a public registry",
+			Severity:    SevWarn,
+			YqPath:      ".components.[0].imageArchives.[0].images.[3]",
+		},
+	}
+	require.Equal(t, expected, findings)
+}
+
 func TestIsImagePinned(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/src/pkg/packager/lint_test.go
+++ b/src/pkg/packager/lint_test.go
@@ -28,6 +28,18 @@ func TestLintPackageWithImports(t *testing.T) {
 					Item:        "busybox:0.0.1",
 					Severity:    lint.SevWarn,
 				},
+				{
+					YqPath:      ".components.[0].images.[0]",
+					Description: "Image reference does not specify a registry domain",
+					Item:        "busybox:0.0.1",
+					Severity:    lint.SevWarn,
+				},
+				{
+					YqPath:      ".components.[0].images.[1]",
+					Description: "Image reference does not specify a registry domain",
+					Item:        "busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
+					Severity:    lint.SevWarn,
+				},
 			},
 		},
 		{
@@ -45,6 +57,18 @@ func TestLintPackageWithImports(t *testing.T) {
 					Item:        "busybox:1.0.0",
 					Severity:    lint.SevWarn,
 				},
+				{
+					YqPath:      ".components.[0].images.[0]",
+					Description: "Image reference does not specify a registry domain",
+					Item:        "busybox:1.0.0",
+					Severity:    lint.SevWarn,
+				},
+				{
+					YqPath:      ".components.[0].images.[1]",
+					Description: "Image reference does not specify a registry domain",
+					Item:        "busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
+					Severity:    lint.SevWarn,
+				},
 			},
 		},
 		{
@@ -57,6 +81,12 @@ func TestLintPackageWithImports(t *testing.T) {
 				{
 					YqPath:      ".components.[0].images.[0]",
 					Description: "Image not pinned with digest",
+					Item:        "image-in-good-flavor-component:unpinned",
+					Severity:    lint.SevWarn,
+				},
+				{
+					YqPath:      ".components.[0].images.[0]",
+					Description: "Image reference does not specify a registry domain",
 					Item:        "image-in-good-flavor-component:unpinned",
 					Severity:    lint.SevWarn,
 				},


### PR DESCRIPTION
## Description

Add two informational `zarf dev lint` findings to nudge users away from ambiguous image references that resolve to the public Docker Hub namespace:

- Emit an Info finding when a component image reference omits a registry domain (and would therefore default to docker.io).
- Emit an Info finding when an image archive image does not use the reserved .internal top-level domain, the recommended convention for locally-built images.

Introduces a new SevInfo severity (rendered blue in the findings table) and documents the .internal convention for image archives.

## Related Issue

Closes #4970

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
