### PR TITLE
feat(injector): dynamically determine host based on IP family

### DIFF
--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -45,6 +45,8 @@ type ZarfInjectorOptions struct {
 	RegistryNodePort uint16
 	// InjectorNodePort, using uint16 allows for only valid ports; 0 lets Kubernetes choose
 	InjectorNodePort uint16
+	// IPFamily determines the injector listen address; defaults to IPv4 when unset
+	IPFamily state.IPFamily
 }
 
 // StartInjection initializes a Zarf injection into the cluster.
@@ -88,7 +90,7 @@ func (c *Cluster) StartInjection(ctx context.Context, tmpDir, imagesDir string, 
 		return "", 0, err
 	}
 
-	pod := buildInjectionPod(injectorNodeName, injectorImage, payloadCmNames, shasum, resReq, pkgName)
+	pod := buildInjectionPod(injectorNodeName, injectorImage, payloadCmNames, shasum, resReq, pkgName, opts.IPFamily)
 	_, err = c.Clientset.CoreV1().Pods(*pod.Namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 	if err != nil {
 		return "", 0, fmt.Errorf("error creating pod in cluster: %w", err)
@@ -532,7 +534,13 @@ func hasBlockingTaints(taints []corev1.Taint) bool {
 	return false
 }
 
-func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum string, resReq *v1ac.ResourceRequirementsApplyConfiguration, pkgName string) *v1ac.PodApplyConfiguration {
+func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum string, resReq *v1ac.ResourceRequirementsApplyConfiguration, pkgName string, ipFamily state.IPFamily) *v1ac.PodApplyConfiguration {
+	listenHost := "0.0.0.0"
+	if ipFamily == state.IPFamilyIPv6 {
+		listenHost = "[::]"
+	}
+	listenAddr := fmt.Sprintf("%s:%d", listenHost, 5000)
+
 	executeMode := int32(0777)
 	userID := int64(1000)
 	groupID := int64(2000)
@@ -600,7 +608,7 @@ func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum s
 						WithImage(image).
 						WithImagePullPolicy(corev1.PullIfNotPresent).
 						WithWorkingDir("/zarf-init").
-						WithCommand("/zarf-init/zarf-injector", shasum).
+						WithCommand("/zarf-init/zarf-injector", shasum, listenAddr).
 						WithVolumeMounts(volumeMounts...).
 						WithSecurityContext(
 							v1ac.SecurityContext().

--- a/src/pkg/cluster/injector_test.go
+++ b/src/pkg/cluster/injector_test.go
@@ -173,15 +173,20 @@ func TestBuildInjectionPod(t *testing.T) {
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
 			})
-	pod := buildInjectionPod("injection-node", "docker.io/library/ubuntu:latest", []string{"foo", "bar"}, "shasum", resReq, "test")
+	// An unset IP family defaults to IPv4.
+	pod := buildInjectionPod("injection-node", "docker.io/library/ubuntu:latest", []string{"foo", "bar"}, "shasum", resReq, "test", "")
 	require.Equal(t, "injector", *pod.Name)
 	require.Equal(t, "test", pod.Labels["zarf.dev/package"])
+	require.Equal(t, []string{"/zarf-init/zarf-injector", "shasum", "0.0.0.0:5000"}, pod.Spec.Containers[0].Command)
 	b, err := json.MarshalIndent(pod, "", "  ")
 	require.NoError(t, err)
 
 	expected, err := os.ReadFile("./testdata/expected-injection-pod.json")
 	require.NoError(t, err)
 	require.Equal(t, strings.TrimSpace(string(expected)), string(b))
+
+	ipv6Pod := buildInjectionPod("injection-node", "docker.io/library/ubuntu:latest", []string{"foo", "bar"}, "shasum", resReq, "test", state.IPFamilyIPv6)
+	require.Equal(t, []string{"/zarf-init/zarf-injector", "shasum", "[::]:5000"}, ipv6Pod.Spec.Containers[0].Command)
 }
 
 func setupCluster(t *testing.T, nodes []corev1.Node, pods []corev1.Pod) *Cluster {

--- a/src/pkg/cluster/testdata/expected-injection-pod.json
+++ b/src/pkg/cluster/testdata/expected-injection-pod.json
@@ -42,7 +42,8 @@
         "image": "docker.io/library/ubuntu:latest",
         "command": [
           "/zarf-init/zarf-injector",
-          "shasum"
+          "shasum",
+          "0.0.0.0:5000"
         ],
         "workingDir": "/zarf-init",
         "resources": {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -405,6 +405,7 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 			seedImage, seedPort, err := d.c.StartInjection(ctx, pkgLayout.DirPath(), pkgLayout.GetImageDirPath(), component.GetImages(), pkgLayout.Pkg.Metadata.Name, pkgLayout.Pkg.Metadata.Architecture, cluster.ZarfInjectorOptions{
 				InjectorNodePort: uint16(d.s.InjectorInfo.Port),
 				RegistryNodePort: uint16(d.s.RegistryInfo.Port),
+				IPFamily:         d.s.IPFamily,
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description

Once https://github.com/kubernetes/kubernetes/pull/138427 is merged the localhost NodePort injector will work on IPv6, this changes the injector command to change it's host depending on ip family. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
