### PR TITLE
chore: bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarf-dev/zarf
 
-go 1.26.0
+go 1.26.4
 
 // TODO (@AABRO): Pending merge into github.com/gojsonschema/gojsonschema (https://github.com/gojsonschema/gojsonschema/pull/5)
 replace github.com/xeipuuv/gojsonschema => github.com/defenseunicorns/gojsonschema v0.0.0-20231116163348-e00f069122d6


### PR DESCRIPTION
## Description

go stdlib has a number of bugs that are reachable by Zarf code. Many are a low risk but given that they are reachable and that we are are on `1.26` I am advocating to bump this version acknowledging that this will require all downstream consumers to bump as well. 

Working on an update in #3842 to include stdlib scanning and that should be available shortly. 

## Related Issue

No associated issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
