### PR TITLE
feat(package): support verification on all CLI package load operations

### DIFF
--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -60,39 +60,46 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 ### Options
 
 ```
-      --adopt-existing-resources        Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
-      --agent-mutation-policy string    Controls agent mutation behavior: "all" mutates all resources by default, "labeled" mutates only resources labeled zarf.dev/agent: mutate (default "all")
-      --agent-tls-ca string             Path to a PEM-encoded CA certificate for the Zarf agent
-      --agent-tls-cert string           Path to a PEM-encoded TLS certificate for the Zarf agent
-      --agent-tls-key string            Path to a PEM-encoded TLS private key for the Zarf agent
-      --artifact-push-token string      [alpha] API Token for the push-user to access the artifact registry
-      --artifact-push-username string   [alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts.
-      --artifact-url string             [alpha] External artifact registry url to use for this Zarf cluster
-      --components string               Specify which optional components to install.  E.g. --components=git-server
-  -c, --confirm                         Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
-      --force-conflicts                 Force Helm to take ownership of conflicting fields during Server-Side Apply operations. Use when external tools (kubectl, HPAs, etc.) have modified resources.
-      --git-pull-password string        Password for the pull-only user to access the git server
-      --git-pull-username string        Username for pull-only access to the git server
-      --git-push-password string        Password for the push-user to access the git server
-      --git-push-username string        Username to access to the git server Zarf is configured to use. User must be able to create repositories via 'git push'
-      --git-url string                  External git server url to use for this Zarf cluster
-  -h, --help                            help for init
-      --injector-port int               The port that the injector will be exposed through. Affects the service nodeport in nodeport mode and pod hostport in proxy mode
-  -k, --key string                      Path to public key file for validating signed packages
-      --oci-concurrency int             Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --registry-mode string            How to access the registry (valid values: nodeport, proxy, external). Proxy mode is an alpha feature
-      --registry-port int               Port to access the internal registry. In nodeport mode this is a Kubernetes NodePort, in proxy mode it is a host port
-      --registry-pull-password string   Password for the pull-only user to access the registry
-      --registry-pull-username string   Username for pull-only access to the registry
-      --registry-push-password string   Password for the push-user to connect to the registry
-      --registry-push-username string   Username to access to the registry Zarf is configured to use
-      --registry-secret string          Internal registry secret value. Only used when --registry-url is not set.
-      --registry-url string             External registry url address to use for this Zarf cluster
-      --retries int                     Number of retries to perform for Zarf operations like git/image pushes (default 3)
-      --set-variables stringToString    Specify deployment variables to set on the command line (KEY=value) (default [])
-      --storage-class string            Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard
-      --timeout duration                Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
-      --verify                          Verify the Zarf package signature
+      --adopt-existing-resources                Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
+      --agent-mutation-policy string            Controls agent mutation behavior: "all" mutates all resources by default, "labeled" mutates only resources labeled zarf.dev/agent: mutate (default "all")
+      --agent-tls-ca string                     Path to a PEM-encoded CA certificate for the Zarf agent
+      --agent-tls-cert string                   Path to a PEM-encoded TLS certificate for the Zarf agent
+      --agent-tls-key string                    Path to a PEM-encoded TLS private key for the Zarf agent
+      --artifact-push-token string              [alpha] API Token for the push-user to access the artifact registry
+      --artifact-push-username string           [alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts.
+      --artifact-url string                     [alpha] External artifact registry url to use for this Zarf cluster
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       Specify which optional components to install.  E.g. --components=git-server
+  -c, --confirm                                 Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
+      --force-conflicts                         Force Helm to take ownership of conflicting fields during Server-Side Apply operations. Use when external tools (kubectl, HPAs, etc.) have modified resources.
+      --git-pull-password string                Password for the pull-only user to access the git server
+      --git-pull-username string                Username for pull-only access to the git server
+      --git-push-password string                Password for the push-user to access the git server
+      --git-push-username string                Username to access to the git server Zarf is configured to use. User must be able to create repositories via 'git push'
+      --git-url string                          External git server url to use for this Zarf cluster
+  -h, --help                                    help for init
+      --injector-port int                       The port that the injector will be exposed through. Affects the service nodeport in nodeport mode and pod hostport in proxy mode
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --registry-mode string                    How to access the registry (valid values: nodeport, proxy, external). Proxy mode is an alpha feature
+      --registry-port int                       Port to access the internal registry. In nodeport mode this is a Kubernetes NodePort, in proxy mode it is a host port
+      --registry-pull-password string           Password for the pull-only user to access the registry
+      --registry-pull-username string           Username for pull-only access to the registry
+      --registry-push-password string           Password for the push-user to connect to the registry
+      --registry-push-username string           Username to access to the registry Zarf is configured to use
+      --registry-secret string                  Internal registry secret value. Only used when --registry-url is not set.
+      --registry-url string                     External registry url address to use for this Zarf cluster
+      --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --storage-class string                    Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard
+      --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -22,22 +22,29 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-      --adopt-existing-resources       Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
-      --components string              Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported.
-  -c, --confirm                        Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
-      --connected                      Deploy without pushing images/repos; label resources to bypass the Zarf agent
-      --force-conflicts                Force Helm to take ownership of conflicting fields during Server-Side Apply operations. Use when external tools (kubectl, HPAs, etc.) have modified resources.
-  -h, --help                           help for deploy
-  -k, --key string                     Path to public key file for validating signed packages
-  -n, --namespace string               [Alpha] Override the namespace for package deployment. Requires the package to have only one distinct namespace defined.
-      --oci-concurrency int            Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --retries int                    Number of retries to perform for Zarf operations like git/image pushes (default 3)
-      --set-values stringToString      Specify deployment package values to set on the command line (key.path=value). (default [])
-      --set-variables stringToString   Specify deployment variables to set on the command line (KEY=value) (default [])
-      --shasum string                  Shasum of the package to deploy. Required if deploying a remote https package.
-      --timeout duration               Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
-  -v, --values strings                 [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                         Verify the Zarf package signature
+      --adopt-existing-resources                Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       Comma-separated list of components to deploy.  Adding this flag will skip the prompts for selected components.  Globbing component names with '*' and deselecting 'default' components with a leading '-' are also supported.
+  -c, --confirm                                 Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
+      --connected                               Deploy without pushing images/repos; label resources to bypass the Zarf agent
+      --force-conflicts                         Force Helm to take ownership of conflicting fields during Server-Side Apply operations. Use when external tools (kubectl, HPAs, etc.) have modified resources.
+  -h, --help                                    help for deploy
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+  -n, --namespace string                        [Alpha] Override the namespace for package deployment. Requires the package to have only one distinct namespace defined.
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --set-values stringToString               Specify deployment package values to set on the command line (key.path=value). (default [])
+      --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --shasum string                           Shasum of the package to deploy. Required if deploying a remote https package.
+      --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+  -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -17,11 +17,18 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-  -h, --help                  help for definition
-  -k, --key string            Path to public key file for validating signed packages
-  -n, --namespace string      [Alpha] Override the namespace for package inspection. Applicable only to packages deployed using the namespace flag.
-      --oci-concurrency int   Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --verify                Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -h, --help                                    help for definition
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+  -n, --namespace string                        [Alpha] Override the namespace for package inspection. Applicable only to packages deployed using the namespace flag.
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -17,12 +17,19 @@ zarf package inspect documentation [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-  -h, --help                  help for documentation
-  -k, --key string            Path to public key file for validating signed packages
-      --keys strings          Comma-separated list of documentation keys to extract (e.g., 'configuration,changelog')
-      --oci-concurrency int   Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --output string         Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
-      --verify                Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -h, --help                                    help for documentation
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --keys strings                            Comma-separated list of documentation keys to extract (e.g., 'configuration,changelog')
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --output string                           Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -17,11 +17,18 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
 ### Options
 
 ```
-  -h, --help                  help for images
-  -k, --key string            Path to public key file for validating signed packages
-  -n, --namespace string      [Alpha] Override the namespace for package inspection. Applicable only to packages deployed using the namespace flag.
-      --oci-concurrency int   Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --verify                Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -h, --help                                    help for images
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+  -n, --namespace string                        [Alpha] Override the namespace for package inspection. Applicable only to packages deployed using the namespace flag.
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -17,15 +17,22 @@ zarf package inspect manifests [ PACKAGE ] [flags]
 ### Options
 
 ```
-      --components string              comma separated list of components to show manifests for
-  -h, --help                           help for manifests
-  -k, --key string                     Path to public key file for validating signed packages
-      --kube-version string            Override the default helm template KubeVersion when performing a package chart template
-      --oci-concurrency int            Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --set-values stringToString      Specify deployment package values to set on the command line (key.path=value). (default [])
-      --set-variables stringToString   Specify deployment variables to set on the command line (KEY=value) (default [])
-  -v, --values strings                 [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                         Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       comma separated list of components to show manifests for
+  -h, --help                                    help for manifests
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --kube-version string                     Override the default helm template KubeVersion when performing a package chart template
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --set-values stringToString               Specify deployment package values to set on the command line (key.path=value). (default [])
+      --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+  -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -17,11 +17,18 @@ zarf package inspect sbom [ PACKAGE ] [flags]
 ### Options
 
 ```
-  -h, --help                  help for sbom
-  -k, --key string            Path to public key file for validating signed packages
-      --oci-concurrency int   Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --output string         Specify an output directory for the SBOMs from the created Zarf package
-      --verify                Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -h, --help                                    help for sbom
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --output string                           Specify an output directory for the SBOMs from the created Zarf package
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -21,15 +21,22 @@ zarf package inspect values-files [ PACKAGE ] [flags]
 ### Options
 
 ```
-      --components string              comma separated list of components to show values files for
-  -h, --help                           help for values-files
-  -k, --key string                     Path to public key file for validating signed packages
-      --kube-version string            Override the default helm template KubeVersion when performing a package chart template
-      --oci-concurrency int            Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --set-values stringToString      Specify deployment package values to set on the command line (key.path=value). (default [])
-      --set-variables stringToString   Specify deployment variables to set on the command line (KEY=value) (default [])
-  -v, --values strings                 [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                         Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       comma separated list of components to show values files for
+  -h, --help                                    help for values-files
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --kube-version string                     Override the default helm template KubeVersion when performing a package chart template
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --set-values stringToString               Specify deployment package values to set on the command line (key.path=value). (default [])
+      --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+  -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -52,23 +52,30 @@ $ zarf package mirror-resources <your-package.tar.zst> --repos \
 ### Options
 
 ```
-      --components string               Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
-  -c, --confirm                         Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
-      --git-push-password string        Password for the push-user to access the git server
-      --git-push-username string        Username to access to the git server Zarf is configured to use. User must be able to create repositories via 'git push' (default "zarf-git-user")
-      --git-url string                  External git server url to use for this Zarf cluster
-  -h, --help                            help for mirror-resources
-      --images                          mirror only the images
-  -k, --key string                      Path to public key file for validating signed packages
-      --no-img-checksum                 Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images.
-      --oci-concurrency int             Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --registry-push-password string   Password for the push-user to connect to the registry
-      --registry-push-username string   Username to access to the registry Zarf is configured to use (default "zarf-push")
-      --registry-url string             External registry url address to use for this Zarf cluster
-      --repos                           mirror only the git repositories
-      --retries int                     Number of retries to perform for Zarf operations like git/image pushes (default 3)
-      --shasum string                   Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
-      --verify                          Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
+  -c, --confirm                                 Confirms package deployment without prompting. ONLY use with packages you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes.
+      --git-push-password string                Password for the push-user to access the git server
+      --git-push-username string                Username to access to the git server Zarf is configured to use. User must be able to create repositories via 'git push' (default "zarf-git-user")
+      --git-url string                          External git server url to use for this Zarf cluster
+  -h, --help                                    help for mirror-resources
+      --images                                  mirror only the images
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --no-img-checksum                         Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images.
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --registry-push-password string           Password for the push-user to connect to the registry
+      --registry-push-username string           Username to access to the registry Zarf is configured to use (default "zarf-push")
+      --registry-url string                     External registry url address to use for this Zarf cluster
+      --repos                                   mirror only the git repositories
+      --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -32,17 +32,24 @@ $ zarf package publish my-package.tar oci://my-registry.com/my-namespace --tag v
 ### Options
 
 ```
-  -c, --confirm                   Confirms package publish without prompting. Skips prompt for the signing key password
-  -f, --flavor string             The flavor of components to include in the resulting package. The flavor will be appended to the package tag
-  -h, --help                      help for publish
-  -k, --key string                Path to public key file for validating signed packages
-      --oci-concurrency int       Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --retries int               Number of retries to perform for Zarf operations like git/image pushes (default 1)
-      --signing-key string        Private key for signing or re-signing packages with a new key. Accepts either a local file path or a Cosign-supported key provider
-      --signing-key-pass string   Password to the private key used for publishing packages
-  -t, --tag string                The tag to be used in the OCI reference for the package in the registry
-      --verify                    Verify the Zarf package signature
-      --with-build-machine-info   Include build machine information (hostname and username) in the package metadata
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -c, --confirm                                 Confirms package publish without prompting. Skips prompt for the signing key password
+  -f, --flavor string                           The flavor of components to include in the resulting package. The flavor will be appended to the package tag
+  -h, --help                                    help for publish
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 1)
+      --signing-key string                      Private key for signing or re-signing packages with a new key. Accepts either a local file path or a Cosign-supported key provider
+      --signing-key-pass string                 Password to the private key used for publishing packages
+  -t, --tag string                              The tag to be used in the OCI reference for the package in the registry
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
+      --with-build-machine-info                 Include build machine information (hostname and username) in the package metadata
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -31,12 +31,19 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
 ### Options
 
 ```
-  -h, --help                      help for pull
-  -k, --key string                Path to public key file for validating signed packages
-      --oci-concurrency int       Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-  -o, --output-directory string   Specify the output directory for the pulled Zarf package
-      --shasum string             Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
-      --verify                    Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+  -h, --help                                    help for pull
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+  -o, --output-directory string                 Specify the output directory for the pulled Zarf package
+      --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -21,15 +21,22 @@ zarf package remove { PACKAGE_SOURCE | PACKAGE_NAME } --confirm [flags]
 ### Options
 
 ```
-      --components string           Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
-  -c, --confirm                     Confirms the removal action
-  -h, --help                        help for remove
-  -k, --key string                  Path to public key file for validating signed packages
-  -n, --namespace string            [Alpha] Override the namespace for package removal. Applicable only to packages deployed using the namespace flag.
-      --oci-concurrency int         Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --set-values stringToString   Specify deployment package values to set on the command line (key.path=value). (default [])
-  -v, --values strings              Path to values file(s) for removal actions
-      --verify                      Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --components string                       Comma-separated list of components to remove.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported.
+  -c, --confirm                                 Confirms the removal action
+  -h, --help                                    help for remove
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Path to public key file for validating signed packages
+  -n, --namespace string                        [Alpha] Override the namespace for package removal. Applicable only to packages deployed using the namespace flag.
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --set-values stringToString               Specify deployment package values to set on the command line (key.path=value). (default [])
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+  -v, --values strings                          Path to values file(s) for removal actions
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -42,25 +42,32 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
 ### Options
 
 ```
-      --confirm                   Skip the interactive confirmation prompt before uploading to the Rekor transparency log (equivalent to cosign --yes).
-      --fulcio-auth-flow string   Fulcio OAuth flow: normal (browser), device (device code), token, client_credentials
-      --fulcio-url string         Fulcio certificate authority URL. Override for private Sigstore deployments. (default "https://fulcio.sigstore.dev")
-  -h, --help                      help for sign
-      --identity-token string     Pre-acquired OIDC identity token (or path to a file containing one) for non-interactive keyless signing
-  -k, --key string                Public key to verify the existing signature before re-signing (optional)
-      --keyless                   Sign without a private key using Sigstore's keyless flow (Fulcio/OIDC)
-      --oci-concurrency int       Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
-      --oidc-client-id string     OIDC client ID used when requesting an identity token. Override for private Sigstore deployments. (default "sigstore")
-      --oidc-issuer string        OIDC issuer URL used to obtain an identity token for keyless signing. Override for private Sigstore deployments. (default "https://oauth2.sigstore.dev/auth")
-  -o, --output string             Output destination for the signed package. Can be a local directory or an OCI registry URL (oci://). Default: same directory as source package for files, current directory for OCI sources
-      --overwrite                 Overwrite an existing signature if the package is already signed
-      --rekor-url string          Rekor transparency log URL. Override for private Sigstore deployments. (default "https://rekor.sigstore.dev")
-      --retries int               Number of retries to perform for Zarf operations like git/image pushes (default 3)
-      --signing-key string        Private key for signing packages. Accepts either a local file path or a Cosign-supported key provider (awskms://, gcpkms://, azurekms://, hashivault://)
-      --signing-key-pass string   Password for encrypted private key
-      --tlog-upload               Upload the signature to the Rekor transparency log. Auto-enabled when --keyless is set (allows for keyless signatures to remain verifiable past the ~10 minute Fulcio certificate validity window).
-      --tsa-server-url string     RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
-      --verify                    Verify the Zarf package signature
+      --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
+      --certificate-identity-regexp string      Regex variant of --certificate-identity
+      --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com
+      --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
+      --confirm                                 Skip the interactive confirmation prompt before uploading to the Rekor transparency log (equivalent to cosign --yes).
+      --fulcio-auth-flow string                 Fulcio OAuth flow: normal (browser), device (device code), token, client_credentials
+      --fulcio-url string                       Fulcio certificate authority URL. Override for private Sigstore deployments. (default "https://fulcio.sigstore.dev")
+  -h, --help                                    help for sign
+      --identity-token string                   Pre-acquired OIDC identity token (or path to a file containing one) for non-interactive keyless signing
+      --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
+  -k, --key string                              Public key to verify the existing signature before re-signing (optional)
+      --keyless                                 Sign without a private key using Sigstore's keyless flow (Fulcio/OIDC)
+      --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
+      --oidc-client-id string                   OIDC client ID used when requesting an identity token. Override for private Sigstore deployments. (default "sigstore")
+      --oidc-issuer string                      OIDC issuer URL used to obtain an identity token for keyless signing. Override for private Sigstore deployments. (default "https://oauth2.sigstore.dev/auth")
+  -o, --output string                           Output destination for the signed package. Can be a local directory or an OCI registry URL (oci://). Default: same directory as source package for files, current directory for OCI sources
+      --overwrite                               Overwrite an existing signature if the package is already signed
+      --rekor-url string                        Rekor transparency log URL. Override for private Sigstore deployments. (default "https://rekor.sigstore.dev")
+      --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --signing-key string                      Private key for signing packages. Accepts either a local file path or a Cosign-supported key provider (awskms://, gcpkms://, azurekms://, hashivault://)
+      --signing-key-pass string                 Password for encrypted private key
+      --tlog-upload                             Upload the signature to the Rekor transparency log. Auto-enabled when --keyless is set (allows for keyless signatures to remain verifiable past the ~10 minute Fulcio certificate validity window).
+      --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
+      --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
+      --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_verify.md
+++ b/site/src/content/docs/commands/zarf_package_verify.md
@@ -39,11 +39,10 @@ $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst
       --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
   -h, --help                                    help for verify
       --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
-  -k, --key string                              Path to public key file for validating signed packages
+  -k, --key string                              Public key for signature verification
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_verify.md
+++ b/site/src/content/docs/commands/zarf_package_verify.md
@@ -39,10 +39,11 @@ $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst
       --certificate-oidc-issuer-regexp string   Regex variant of --certificate-oidc-issuer
   -h, --help                                    help for verify
       --insecure-ignore-tlog                    Skip Rekor transparency log inclusion verification. Default true for air-gap. Auto-disabled when keyless identity flags are set (keyless signatures require Rekor inclusion proof to remain verifiable past certificate expiry). (default true)
-  -k, --key string                              Public key for signature verification
+  -k, --key string                              Path to public key file for validating signed packages
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+      --verify                                  Verify the Zarf package signature
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -143,10 +143,6 @@ func newInitCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *initOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -125,8 +125,7 @@ func newInitCommand() *cobra.Command {
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 
 	// Agent TLS flags must all be provided together
 	cmd.MarkFlagsRequiredTogether("agent-tls-ca", "agent-tls-cert", "agent-tls-key")

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -37,26 +37,24 @@ import (
 )
 
 type initOptions struct {
-	setVariables            map[string]string
-	optionalComponents      string
-	storageClass            string
-	gitServer               state.GitServerInfo
-	registryInfo            state.RegistryInfo
-	artifactServer          state.ArtifactServerInfo
-	injectorPort            int
-	adoptExistingResources  bool
-	forceConflicts          bool
-	timeout                 time.Duration
-	retries                 int
-	publicKeyPath           string
-	verify                  bool
-	skipSignatureValidation bool
-	confirm                 bool
-	ociConcurrency          int
-	agentTLSCAPath          string
-	agentTLSCertPath        string
-	agentTLSKeyPath         string
-	agentMutationPolicy     string
+	setVariables           map[string]string
+	optionalComponents     string
+	storageClass           string
+	gitServer              state.GitServerInfo
+	registryInfo           state.RegistryInfo
+	artifactServer         state.ArtifactServerInfo
+	injectorPort           int
+	adoptExistingResources bool
+	forceConflicts         bool
+	timeout                time.Duration
+	retries                int
+	confirm                bool
+	ociConcurrency         int
+	agentTLSCAPath         string
+	agentTLSCertPath       string
+	agentTLSKeyPath        string
+	agentMutationPolicy    string
+	packageVerifyFlags
 }
 
 func newInitCommand() *cobra.Command {
@@ -126,14 +124,9 @@ func newInitCommand() *cobra.Command {
 	cmd.Flags().DurationVar(&o.timeout, "timeout", v.GetDuration(VPkgDeployTimeout), lang.CmdPackageDeployFlagTimeout)
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 
 	// Agent TLS flags must all be provided together
 	cmd.MarkFlagsRequiredTogether("agent-tls-ca", "agent-tls-cert", "agent-tls-key")
@@ -151,16 +144,7 @@ func newInitCommand() *cobra.Command {
 }
 
 func (o *initOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *initOptions) run(cmd *cobra.Command, args []string) error {
@@ -221,7 +205,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	loadOpt := packager.LoadOptions{
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Filter:               filter,
 		Architecture:         config.GetArch(),

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1914,7 +1914,8 @@ func newPackageVerifyCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageVerifyFlagKey)
+	cmd.Flags().AddFlagSet(newKeylessVerifyFlagSet(v, &o.packageVerifyFlags))
 	markVerifyFlagsMutuallyExclusive(cmd)
 
 	return cmd
@@ -2071,9 +2072,6 @@ func newKeylessVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagS
 }
 
 // newVerifyFlagSet creates a pflag.FlagSet containing all 10 package verification flags
-// (--key, --verify, deprecated --skip-signature-validation, plus the 7 keyless flags).
-// Add to a command with cmd.Flags().AddFlagSet(newVerifyFlagSet(v, f)) then call
-// markVerifyFlagsMutuallyExclusive(cmd).
 func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("verify", pflag.ContinueOnError)
 

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -23,6 +23,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"oras.land/oras-go/v2/registry"
 
@@ -64,6 +65,23 @@ func newPackageCommand() *cobra.Command {
 	cmd.AddCommand(newPackageVerifyCommand(v))
 
 	return cmd
+}
+
+// packageVerifyFlags holds all package signature and keyless verification flags.
+// Embed this in any command options struct that performs a package load operation.
+// To add a new verification flag in the future, add the field here and register it
+// in newVerifyFlagSet / newKeylessVerifyFlagSet, then update buildVerifyBlobOptions.
+type packageVerifyFlags struct {
+	publicKeyPath               string
+	verify                      bool
+	skipSignatureValidation     bool // deprecated
+	certificateIdentity         string
+	certificateIdentityRegexp   string
+	certificateOIDCIssuer       string
+	certificateOIDCIssuerRegexp string
+	trustedRoot                 string
+	insecureIgnoreTlog          bool
+	useSignedTimestamps         bool
 }
 
 type packageCreateOptions struct {
@@ -242,23 +260,21 @@ func (o *packageCreateOptions) run(ctx context.Context, args []string) error {
 }
 
 type packageDeployOptions struct {
-	valuesFiles             []string
-	namespaceOverride       string
-	confirm                 bool
-	adoptExistingResources  bool
-	connected               bool
-	forceConflicts          bool
-	timeout                 time.Duration
-	retries                 int
-	setVariables            map[string]string
-	setValues               map[string]string
-	optionalComponents      string
-	shasum                  string
-	verify                  bool
-	skipSignatureValidation bool
-	skipVersionCheck        bool
-	ociConcurrency          int
-	publicKeyPath           string
+	valuesFiles            []string
+	namespaceOverride      string
+	confirm                bool
+	adoptExistingResources bool
+	connected              bool
+	forceConflicts         bool
+	timeout                time.Duration
+	retries                int
+	setVariables           map[string]string
+	setValues              map[string]string
+	optionalComponents     string
+	shasum                 string
+	skipVersionCheck       bool
+	ociConcurrency         int
+	packageVerifyFlags
 }
 
 func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
@@ -277,7 +293,6 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 	// Always require confirm flag (no viper)
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, lang.CmdPackageDeployFlagConfirm)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 
 	// Always require adopt-existing-resources flag (no viper)
 	cmd.Flags().BoolVar(&o.adoptExistingResources, "adopt-existing-resources", false, lang.CmdPackageDeployFlagAdoptExistingResources)
@@ -294,28 +309,15 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVar(&o.optionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageDeployFlagComponents)
 	cmd.Flags().StringVar(&o.shasum, "shasum", v.GetString(VPkgDeployShasum), lang.CmdPackageDeployFlagShasum)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", v.GetString(VPkgDeployNamespace), lang.CmdPackageDeployFlagNamespace)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when deploying the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark flag skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageDeployOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageDeployOptions) run(cmd *cobra.Command, args []string) (err error) {
@@ -357,7 +359,7 @@ func (o *packageDeployOptions) run(cmd *cobra.Command, args []string) (err error
 
 	loadOpt := packager.LoadOptions{
 		Shasum:               o.shasum,
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Filter:               filter,
 		Architecture:         config.GetArch(),
@@ -507,19 +509,17 @@ func getPackageYAMLHints(pkg v1alpha1.ZarfPackage, setVariables map[string]strin
 }
 
 type packageMirrorResourcesOptions struct {
-	mirrorImages            bool
-	mirrorRepos             bool
-	confirm                 bool
-	shasum                  string
-	noImgChecksum           bool
-	verify                  bool
-	skipSignatureValidation bool
-	retries                 int
-	optionalComponents      string
-	gitServer               state.GitServerInfo
-	registryInfo            state.RegistryInfo
-	ociConcurrency          int
-	publicKeyPath           string
+	mirrorImages       bool
+	mirrorRepos        bool
+	confirm            bool
+	shasum             string
+	noImgChecksum      bool
+	retries            int
+	optionalComponents string
+	gitServer          state.GitServerInfo
+	registryInfo       state.RegistryInfo
+	ociConcurrency     int
+	packageVerifyFlags
 }
 
 func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
@@ -544,17 +544,12 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 	// Always require confirm flag (no viper)
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, lang.CmdPackageDeployFlagConfirm)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().BoolVar(&o.noImgChecksum, "no-img-checksum", false, lang.CmdPackageMirrorFlagNoChecksum)
 
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	cmd.Flags().StringVar(&o.optionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageMirrorFlagComponents)
@@ -578,16 +573,7 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 }
 
 func (o *packageMirrorResourcesOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 
 	// post flag validation - perform both if neither were set
 	if !o.mirrorImages && !o.mirrorRepos {
@@ -613,9 +599,10 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 		return err
 	}
 
+	v := getViper()
 	loadOpt := packager.LoadOptions{
 		Shasum:               o.shasum,
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Filter:               filter,
 		Architecture:         config.GetArch(),
@@ -731,16 +718,14 @@ func newPackageInspectCommand(v *viper.Viper) *cobra.Command {
 }
 
 type packageInspectValuesFilesOptions struct {
-	verify                  bool
-	skipSignatureValidation bool
-	components              string
-	kubeVersion             string
-	setVariables            map[string]string
-	valuesFiles             []string
-	setValues               map[string]string
-	outputWriter            io.Writer
-	ociConcurrency          int
-	publicKeyPath           string
+	components     string
+	kubeVersion    string
+	setVariables   map[string]string
+	valuesFiles    []string
+	setValues      map[string]string
+	outputWriter   io.Writer
+	ociConcurrency int
+	packageVerifyFlags
 }
 
 func newPackageInspectValuesFilesOptions() *packageInspectValuesFilesOptions {
@@ -758,15 +743,11 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 		Args:   cobra.MaximumNArgs(1),
 		PreRun: o.preRun,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return o.run(ctx, args)
+			return o.run(cmd, args)
 		},
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().StringVar(&o.components, "components", "", "comma separated list of components to show values files for")
 	cmd.Flags().StringVar(&o.kubeVersion, "kube-version", "", lang.CmdDevFlagKubeVersion)
 	cmd.Flags().StringToStringVar(&o.setVariables, "set", v.GetStringMapString(VPkgDeploySet), "Alias for --set-variables")
@@ -774,27 +755,17 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectValuesFilesOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
-func (o *packageInspectValuesFilesOptions) run(ctx context.Context, args []string) (err error) {
+func (o *packageInspectValuesFilesOptions) run(cmd *cobra.Command, args []string) (err error) {
+	ctx := cmd.Context()
 	src, err := choosePackage(ctx, args)
 	if err != nil {
 		return err
@@ -817,7 +788,7 @@ func (o *packageInspectValuesFilesOptions) run(ctx context.Context, args []strin
 
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		LayerTypes:           []zoci.LayerType{zoci.ComponentLayers},
 		Filter:               filters.BySelectState(o.components),
@@ -858,16 +829,14 @@ func (o *packageInspectValuesFilesOptions) run(ctx context.Context, args []strin
 }
 
 type packageInspectManifestsOptions struct {
-	verify                  bool
-	skipSignatureValidation bool
-	components              string
-	kubeVersion             string
-	setVariables            map[string]string
-	valuesFiles             []string
-	setValues               map[string]string
-	outputWriter            io.Writer
-	ociConcurrency          int
-	publicKeyPath           string
+	components     string
+	kubeVersion    string
+	setVariables   map[string]string
+	valuesFiles    []string
+	setValues      map[string]string
+	outputWriter   io.Writer
+	ociConcurrency int
+	packageVerifyFlags
 }
 
 func newPackageInspectManifestsOptions() *packageInspectManifestsOptions {
@@ -884,15 +853,11 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 		Args:   cobra.MaximumNArgs(1),
 		PreRun: o.preRun,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return o.run(ctx, args)
+			return o.run(cmd, args)
 		},
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().StringVar(&o.components, "components", "", "comma separated list of components to show manifests for")
 	cmd.Flags().StringVar(&o.kubeVersion, "kube-version", "", lang.CmdDevFlagKubeVersion)
 	cmd.Flags().StringToStringVar(&o.setVariables, "set", v.GetStringMapString(VPkgDeploySet), "Alias for --set-variables")
@@ -900,27 +865,17 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectManifestsOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
-func (o *packageInspectManifestsOptions) run(ctx context.Context, args []string) (err error) {
+func (o *packageInspectManifestsOptions) run(cmd *cobra.Command, args []string) (err error) {
+	ctx := cmd.Context()
 	src, err := choosePackage(ctx, args)
 	if err != nil {
 		return err
@@ -943,7 +898,7 @@ func (o *packageInspectManifestsOptions) run(ctx context.Context, args []string)
 
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		LayerTypes:           []zoci.LayerType{zoci.ComponentLayers},
 		Filter:               filters.BySelectState(o.components),
@@ -990,17 +945,14 @@ func (o *packageInspectManifestsOptions) run(ctx context.Context, args []string)
 
 // packageInspectSBOMOptions holds the command-line options for 'package inspect sbom' sub-command.
 type packageInspectSBOMOptions struct {
-	verify                  bool
-	skipSignatureValidation bool
-	outputDir               string
-	ociConcurrency          int
-	publicKeyPath           string
+	outputDir      string
+	ociConcurrency int
+	packageVerifyFlags
 }
 
 func newPackageInspectSBOMOptions() *packageInspectSBOMOptions {
 	return &packageInspectSBOMOptions{
 		outputDir: "",
-		verify:    false,
 	}
 }
 
@@ -1016,28 +968,14 @@ func newPackageInspectSBOMCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().StringVar(&o.outputDir, "output", o.outputDir, lang.CmdPackageCreateFlagSbomOut)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectSBOMOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 // run performs the execution of 'package inspect sbom' sub-command.
@@ -1053,9 +991,10 @@ func (o *packageInspectSBOMOptions) run(cmd *cobra.Command, args []string) (err 
 		return err
 	}
 
+	v := getViper()
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		LayerTypes:           []zoci.LayerType{zoci.SbomLayers},
 		Filter:               filters.Empty(),
@@ -1087,17 +1026,13 @@ func (o *packageInspectSBOMOptions) run(cmd *cobra.Command, args []string) (err 
 }
 
 type packageInspectImagesOptions struct {
-	namespaceOverride       string
-	verify                  bool
-	skipSignatureValidation bool
-	ociConcurrency          int
-	publicKeyPath           string
+	namespaceOverride string
+	ociConcurrency    int
+	packageVerifyFlags
 }
 
 func newPackageInspectImagesOptions() *packageInspectImagesOptions {
-	return &packageInspectImagesOptions{
-		verify: false,
-	}
+	return &packageInspectImagesOptions{}
 }
 
 func newPackageInspectImagesCommand(v *viper.Viper) *cobra.Command {
@@ -1111,28 +1046,14 @@ func newPackageInspectImagesCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", o.namespaceOverride, lang.CmdPackageInspectFlagNamespace)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectImagesOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageInspectImagesOptions) run(cmd *cobra.Command, args []string) error {
@@ -1148,12 +1069,13 @@ func (o *packageInspectImagesOptions) run(cmd *cobra.Command, args []string) err
 		return err
 	}
 
+	v := getViper()
 	cluster, _ := cluster.New(ctx) //nolint: errcheck // package source may or may not be a cluster
 	loadOpts := packager.LoadOptions{
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		OCIConcurrency:       o.ociConcurrency,
 		RemoteOptions:        defaultRemoteOptions(),
 		CachePath:            cachePath,
@@ -1179,12 +1101,10 @@ func (o *packageInspectImagesOptions) run(cmd *cobra.Command, args []string) err
 }
 
 type packageInspectDocumentationOptions struct {
-	skipSignatureValidation bool
-	keys                    []string
-	outputDir               string
-	ociConcurrency          int
-	publicKeyPath           string
-	verify                  bool
+	keys           []string
+	outputDir      string
+	ociConcurrency int
+	packageVerifyFlags
 }
 
 func newPackageInspectDocumentationOptions() *packageInspectDocumentationOptions {
@@ -1202,29 +1122,15 @@ func newPackageInspectDocumentationCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
 	cmd.Flags().StringSliceVar(&o.keys, "keys", []string{}, "Comma-separated list of documentation keys to extract (e.g., 'configuration,changelog')")
 	cmd.Flags().StringVar(&o.outputDir, "output", o.outputDir, "Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)")
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectDocumentationOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageInspectDocumentationOptions) run(cmd *cobra.Command, args []string) (err error) {
@@ -1238,11 +1144,12 @@ func (o *packageInspectDocumentationOptions) run(cmd *cobra.Command, args []stri
 		return err
 	}
 
+	v := getViper()
 	loadOpts := packager.LoadOptions{
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		OCIConcurrency:       o.ociConcurrency,
 		RemoteOptions:        defaultRemoteOptions(),
 		CachePath:            cachePath,
@@ -1261,17 +1168,13 @@ func (o *packageInspectDocumentationOptions) run(cmd *cobra.Command, args []stri
 }
 
 type packageInspectDefinitionOptions struct {
-	namespaceOverride       string
-	verify                  bool
-	skipSignatureValidation bool
-	ociConcurrency          int
-	publicKeyPath           string
+	namespaceOverride string
+	ociConcurrency    int
+	packageVerifyFlags
 }
 
 func newPackageInspectDefinitionOptions() *packageInspectDefinitionOptions {
-	return &packageInspectDefinitionOptions{
-		verify: false,
-	}
+	return &packageInspectDefinitionOptions{}
 }
 
 func newPackageInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
@@ -1285,28 +1188,14 @@ func newPackageInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", o.namespaceOverride, lang.CmdPackageInspectFlagNamespace)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", o.skipSignatureValidation, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageInspectDefinitionOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageInspectDefinitionOptions) run(cmd *cobra.Command, args []string) error {
@@ -1322,12 +1211,13 @@ func (o *packageInspectDefinitionOptions) run(cmd *cobra.Command, args []string)
 		return err
 	}
 
+	v := getViper()
 	cluster, _ := cluster.New(ctx) //nolint: errcheck // package source may or may not be a cluster
 	loadOpts := packager.LoadOptions{
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		OCIConcurrency:       o.ociConcurrency,
 		RemoteOptions:        defaultRemoteOptions(),
 		CachePath:            cachePath,
@@ -1450,16 +1340,14 @@ func (o *packageListOptions) run(ctx context.Context) error {
 }
 
 type packageRemoveOptions struct {
-	namespaceOverride       string
-	confirm                 bool
-	optionalComponents      string
-	verify                  bool
-	skipSignatureValidation bool
-	skipVersionCheck        bool
-	ociConcurrency          int
-	publicKeyPath           string
-	valuesFiles             []string
-	setValues               map[string]string
+	namespaceOverride  string
+	confirm            bool
+	optionalComponents string
+	skipVersionCheck   bool
+	ociConcurrency     int
+	valuesFiles        []string
+	setValues          map[string]string
+	packageVerifyFlags
 }
 
 func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
@@ -1477,34 +1365,20 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, lang.CmdPackageRemoveFlagConfirm)
 	cmd.Flags().StringVar(&o.optionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageRemoveFlagComponents)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", v.GetString(VPkgDeployNamespace), lang.CmdPackageRemoveFlagNamespace)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when removing the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", []string{}, lang.CmdPackageRemoveFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgRemoveSetValues), lang.CmdPackageDeployFlagSetValues)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packageRemoveOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
@@ -1528,12 +1402,13 @@ func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	v := getViper()
 	c, _ := cluster.New(ctx) //nolint:errcheck
 	loadOpts := packager.LoadOptions{
 		VerificationStrategy: getVerificationStrategy(o.verify),
 		Architecture:         config.GetArch(),
 		Filter:               filter,
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		OCIConcurrency:       o.ociConcurrency,
 		RemoteOptions:        defaultRemoteOptions(),
 		CachePath:            cachePath,
@@ -1572,18 +1447,16 @@ func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
 }
 
 type packagePublishOptions struct {
-	flavor                  string
-	retries                 int
-	signingKeyPath          string
-	signingKeyPassword      string
-	verify                  bool
-	skipSignatureValidation bool
-	confirm                 bool
-	ociConcurrency          int
-	publicKeyPath           string
-	skipVersionCheck        bool
-	withBuildMachineInfo    bool
-	tag                     string
+	flavor               string
+	retries              int
+	signingKeyPath       string
+	signingKeyPassword   string
+	confirm              bool
+	ociConcurrency       int
+	skipVersionCheck     bool
+	withBuildMachineInfo bool
+	tag                  string
+	packageVerifyFlags
 }
 
 func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
@@ -1600,11 +1473,8 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	cmd.Flags().StringVar(&o.signingKeyPath, "signing-key", v.GetString(VPkgPublishSigningKey), lang.CmdPackagePublishFlagSigningKey)
 	cmd.Flags().StringVar(&o.signingKeyPassword, "signing-key-pass", v.GetString(VPkgPublishSigningKeyPassword), lang.CmdPackagePublishFlagSigningKeyPassword)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
 	cmd.Flags().StringVarP(&o.flavor, "flavor", "f", v.GetString(VPkgCreateFlavor), lang.CmdPackagePublishFlagFlavor)
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgPublishRetries), lang.CmdPackageFlagRetries)
 	cmd.Flags().StringVarP(&o.tag, "tag", "t", "", lang.CmdPackagePublishFlagTag)
@@ -1612,30 +1482,20 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when publishing the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 	cmd.Flags().BoolVar(&o.withBuildMachineInfo, "with-build-machine-info", v.GetBool(VPkgPublishWithBuildMachineInfo), lang.CmdPackageCreateFlagWithBuildMachineInfo)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
 }
 
 func (o *packagePublishOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	packageSource := args[0]
 	ctx := cmd.Context()
 	l := logger.From(ctx)
+	v := getViper()
 
 	if !helpers.IsOCIURL(args[1]) {
 		return errors.New("registry must be prefixed with 'oci://'")
@@ -1718,7 +1578,7 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 
 		packagePath, err := packager.Pull(ctx, packageSource, tmpdir, packager.PullOptions{
 			VerificationStrategy: verificationStrategy,
-			VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+			VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 			Architecture:         config.GetArch(),
 			OCIConcurrency:       o.ociConcurrency,
 			RemoteOptions:        defaultRemoteOptions(),
@@ -1731,7 +1591,7 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	loadOpt := packager.LoadOptions{
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		VerificationStrategy: verificationStrategy,
 		Filter:               filters.Empty(),
 		Architecture:         config.GetArch(),
@@ -1765,12 +1625,10 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 }
 
 type packagePullOptions struct {
-	shasum                  string
-	outputDirectory         string
-	skipSignatureValidation bool
-	verify                  bool
-	ociConcurrency          int
-	publicKeyPath           string
+	shasum          string
+	outputDirectory string
+	ociConcurrency  int
+	packageVerifyFlags
 }
 
 func newPackagePullCommand(v *viper.Viper) *cobra.Command {
@@ -1786,30 +1644,16 @@ func newPackagePullCommand(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().StringVarP(&o.outputDirectory, "output-directory", "o", v.GetString(VPkgPullOutputDir), lang.CmdPackagePullFlagOutputDirectory)
-	cmd.Flags().BoolVar(&o.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
-	errSig := cmd.Flags().MarkDeprecated("skip-signature-validation", "Signature verification now occurs on every execution, but is not enforced by default. Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
-	if errSig != nil {
-		logger.Default().Debug("unable to mark skip-signature-validation", "error", errSig)
-	}
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 
 	return cmd
 }
 
 func (o *packagePullOptions) preRun(cmd *cobra.Command, _ []string) {
-	// Handle deprecated --skip-signature-validation flag for backwards compatibility
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. Use --verify to enforce signature validation.")
-
-		if cmd.Flags().Changed("verify") {
-			return
-		}
-
-		o.verify = !o.skipSignatureValidation
-	}
+	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packagePullOptions) run(cmd *cobra.Command, args []string) error {
@@ -1828,10 +1672,11 @@ func (o *packagePullOptions) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	v := getViper()
 	packagePath, err := packager.Pull(ctx, srcURL, outputDir, packager.PullOptions{
 		SHASum:               o.shasum,
 		VerificationStrategy: getVerificationStrategy(o.verify),
-		VerifyBlobOptions:    verifyBlobOptionsFromKeyPath(o.publicKeyPath),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		Architecture:         config.GetArch(),
 		OCIConcurrency:       o.ociConcurrency,
 		RemoteOptions:        defaultRemoteOptions(),
@@ -1845,15 +1690,12 @@ func (o *packagePullOptions) run(cmd *cobra.Command, args []string) error {
 }
 
 type packageSignOptions struct {
-	v                  *viper.Viper
 	signingKeyPath     string
 	signingKeyPassword string
-	publicKeyPath      string
 	overwrite          bool
 	output             string
 	ociConcurrency     int
 	retries            int
-	verify             bool
 	// Keyless signing flags. Each is hand-rolled and individually opted-in;
 	// new cosign flags will not appear here automatically on dependency bumps.
 	keyless        bool
@@ -1866,10 +1708,11 @@ type packageSignOptions struct {
 	tlogUpload     bool
 	confirm        bool
 	tsaServerURL   string
+	packageVerifyFlags
 }
 
 func newPackageSignCommand(v *viper.Viper) *cobra.Command {
-	o := &packageSignOptions{v: v}
+	o := &packageSignOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "sign PACKAGE_SOURCE",
@@ -1900,6 +1743,8 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().BoolVar(&o.tlogUpload, "tlog-upload", v.GetBool(VPkgSignTlogUpload), lang.CmdPackageSignFlagTlogUpload)
 	cmd.Flags().BoolVar(&o.confirm, "confirm", false, lang.CmdPackageSignFlagConfirm)
 	cmd.Flags().StringVar(&o.tsaServerURL, "tsa-server-url", v.GetString(VPkgSignTSAServerURL), lang.CmdPackageSignFlagTSAServerURL)
+	cmd.Flags().AddFlagSet(newKeylessVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 
 	cmd.MarkFlagsMutuallyExclusive("keyless", "signing-key")
 
@@ -1974,7 +1819,7 @@ func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 	// To prevent a warning for package not being signed - we'll only run verification when enforced
 	if signed {
 		if o.verify {
-			verifyOpts := verifyBlobOptionsFromKeyPath(o.publicKeyPath)
+			verifyOpts := o.buildVerifyBlobOptions(cmd, getViper())
 			err = pkgLayout.VerifyPackageSignature(ctx, *verifyOpts)
 			if err != nil {
 				return err
@@ -2011,7 +1856,7 @@ func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 	// the signature is unverifiable past expiry. Default --tlog-upload=true for
 	// keyless unless the user explicitly opted out via CLI flag, env var, or config file.
 	if o.keyless {
-		tlogExplicit := cmd.Flags().Changed("tlog-upload") || o.v.IsSet(VPkgSignTlogUpload)
+		tlogExplicit := cmd.Flags().Changed("tlog-upload") || getViper().IsSet(VPkgSignTlogUpload)
 		if !tlogExplicit {
 			signOpts.TlogUpload = true
 		}
@@ -2051,21 +1896,12 @@ func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 }
 
 type packageVerifyOptions struct {
-	v              *viper.Viper
-	publicKeyPath  string
 	ociConcurrency int
-	// Keyless verify flags. Each is hand-rolled and individually opted-in.
-	certificateIdentity         string
-	certificateIdentityRegexp   string
-	certificateOIDCIssuer       string
-	certificateOIDCIssuerRegexp string
-	trustedRoot                 string
-	insecureIgnoreTlog          bool
-	useSignedTimestamps         bool
+	packageVerifyFlags
 }
 
 func newPackageVerifyCommand(v *viper.Viper) *cobra.Command {
-	o := &packageVerifyOptions{v: v}
+	o := &packageVerifyOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "verify PACKAGE_SOURCE",
@@ -2077,28 +1913,9 @@ func newPackageVerifyCommand(v *viper.Viper) *cobra.Command {
 		RunE:    o.run,
 	}
 
-	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageVerifyFlagKey)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-
-	cmd.Flags().StringVar(&o.certificateIdentity, "certificate-identity", v.GetString(VPkgCertificateIdentity), lang.CmdPackageVerifyFlagCertificateIdentity)
-	cmd.Flags().StringVar(&o.certificateIdentityRegexp, "certificate-identity-regexp", v.GetString(VPkgCertificateIdentityRegexp), lang.CmdPackageVerifyFlagCertificateIdentityRegexp)
-	cmd.Flags().StringVar(&o.certificateOIDCIssuer, "certificate-oidc-issuer", v.GetString(VPkgCertificateOIDCIssuer), lang.CmdPackageVerifyFlagCertificateOIDCIssuer)
-	cmd.Flags().StringVar(&o.certificateOIDCIssuerRegexp, "certificate-oidc-issuer-regexp", v.GetString(VPkgCertificateOIDCIssuerRegexp), lang.CmdPackageVerifyFlagCertificateOIDCIssuerRegexp)
-	cmd.Flags().StringVar(&o.trustedRoot, "trusted-root", v.GetString(VPkgTrustedRoot), lang.CmdPackageVerifyFlagTrustedRoot)
-	// Airgap default is true; only apply viper value when the user explicitly configured it
-	ignoreTlogDefault := true
-	if v.IsSet(VPkgInsecureIgnoreTlog) {
-		ignoreTlogDefault = v.GetBool(VPkgInsecureIgnoreTlog)
-	}
-	cmd.Flags().BoolVar(&o.insecureIgnoreTlog, "insecure-ignore-tlog", ignoreTlogDefault, lang.CmdPackageVerifyFlagInsecureIgnoreTlog)
-	cmd.Flags().BoolVar(&o.useSignedTimestamps, "use-signed-timestamps", v.GetBool(VPkgUseSignedTimestamps), lang.CmdPackageVerifyFlagUseSignedTimestamps)
-
-	cmd.MarkFlagsMutuallyExclusive("key", "certificate-identity")
-	cmd.MarkFlagsMutuallyExclusive("key", "certificate-identity-regexp")
-	cmd.MarkFlagsMutuallyExclusive("key", "certificate-oidc-issuer")
-	cmd.MarkFlagsMutuallyExclusive("key", "certificate-oidc-issuer-regexp")
-	cmd.MarkFlagsMutuallyExclusive("certificate-identity", "certificate-identity-regexp")
-	cmd.MarkFlagsMutuallyExclusive("certificate-oidc-issuer", "certificate-oidc-issuer-regexp")
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
+	markVerifyFlagsMutuallyExclusive(cmd)
 
 	return cmd
 }
@@ -2115,30 +1932,8 @@ func (o *packageVerifyOptions) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Load the package with verification enabled
-	// The verify command always uses strict verification (VerifyAlways)
-	// This will error if: signed package without key, or unsigned package with key
-	verifyOpts := signing.DefaultVerifyBlobOptions()
-	verifyOpts.Key = o.publicKeyPath
-	verifyOpts.CertVerify.CertIdentity = o.certificateIdentity
-	verifyOpts.CertVerify.CertIdentityRegexp = o.certificateIdentityRegexp
-	verifyOpts.CertVerify.CertOidcIssuer = o.certificateOIDCIssuer
-	verifyOpts.CertVerify.CertOidcIssuerRegexp = o.certificateOIDCIssuerRegexp
-	verifyOpts.CommonVerifyOptions.TrustedRootPath = o.trustedRoot
-	verifyOpts.CommonVerifyOptions.IgnoreTlog = o.insecureIgnoreTlog
-	verifyOpts.CommonVerifyOptions.UseSignedTimestamps = o.useSignedTimestamps
-
-	// When a keyless identity is provided, require tlog verification by default so the
-	// inclusion proof establishes when the signature was made (offline/airgap compatible
-	// with bundle outputs). Honor any explicit override from CLI flag, env var, or config.
-	hasKeylessIdentity := o.certificateIdentity != "" || o.certificateIdentityRegexp != ""
-	tlogExplicit := cmd.Flags().Changed("insecure-ignore-tlog") || o.v.IsSet(VPkgInsecureIgnoreTlog)
-	if hasKeylessIdentity && !tlogExplicit {
-		verifyOpts.CommonVerifyOptions.IgnoreTlog = false
-	}
-
 	loadOpts := packager.LoadOptions{
-		VerifyBlobOptions:    &verifyOpts,
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, getViper()),
 		VerificationStrategy: layout.VerifyAlways, // Always enforce strict verification
 		Filter:               filters.Empty(),
 		Architecture:         config.GetArch(),
@@ -2245,8 +2040,101 @@ func getVerificationStrategy(verify bool) layout.VerificationStrategy {
 	return layout.VerifyIfPossible
 }
 
-func verifyBlobOptionsFromKeyPath(keyPath string) *signing.VerifyBlobOptions {
+// newKeylessVerifyFlagSet creates a pflag.FlagSet containing only the 7 keyless
+// verification flags (certificate identity/issuer, trusted root, tlog, timestamps).
+// Used by newVerifyFlagSet and directly by the sign command, which registers --key
+// separately with a command-specific usage string.
+func newKeylessVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("keyless-verify", pflag.ContinueOnError)
+
+	fs.StringVar(&f.certificateIdentity, "certificate-identity",
+		v.GetString(VPkgCertificateIdentity), lang.CmdPackageVerifyFlagCertificateIdentity)
+	fs.StringVar(&f.certificateIdentityRegexp, "certificate-identity-regexp",
+		v.GetString(VPkgCertificateIdentityRegexp), lang.CmdPackageVerifyFlagCertificateIdentityRegexp)
+	fs.StringVar(&f.certificateOIDCIssuer, "certificate-oidc-issuer",
+		v.GetString(VPkgCertificateOIDCIssuer), lang.CmdPackageVerifyFlagCertificateOIDCIssuer)
+	fs.StringVar(&f.certificateOIDCIssuerRegexp, "certificate-oidc-issuer-regexp",
+		v.GetString(VPkgCertificateOIDCIssuerRegexp), lang.CmdPackageVerifyFlagCertificateOIDCIssuerRegexp)
+	fs.StringVar(&f.trustedRoot, "trusted-root",
+		v.GetString(VPkgTrustedRoot), lang.CmdPackageVerifyFlagTrustedRoot)
+
+	ignoreTlogDefault := true
+	if v.IsSet(VPkgInsecureIgnoreTlog) {
+		ignoreTlogDefault = v.GetBool(VPkgInsecureIgnoreTlog)
+	}
+	fs.BoolVar(&f.insecureIgnoreTlog, "insecure-ignore-tlog", ignoreTlogDefault,
+		lang.CmdPackageVerifyFlagInsecureIgnoreTlog)
+	fs.BoolVar(&f.useSignedTimestamps, "use-signed-timestamps",
+		v.GetBool(VPkgUseSignedTimestamps), lang.CmdPackageVerifyFlagUseSignedTimestamps)
+
+	return fs
+}
+
+// newVerifyFlagSet creates a pflag.FlagSet containing all 10 package verification flags
+// (--key, --verify, deprecated --skip-signature-validation, plus the 7 keyless flags).
+// Add to a command with cmd.Flags().AddFlagSet(newVerifyFlagSet(v, f)) then call
+// markVerifyFlagsMutuallyExclusive(cmd).
+func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("verify", pflag.ContinueOnError)
+
+	fs.StringVarP(&f.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
+	fs.BoolVar(&f.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
+	fs.BoolVar(&f.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
+	_ = fs.MarkDeprecated("skip-signature-validation",
+		"Signature verification now occurs on every execution, but is not enforced by default. "+
+			"Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
+
+	fs.AddFlagSet(newKeylessVerifyFlagSet(v, f))
+	return fs
+}
+
+// markVerifyFlagsMutuallyExclusive registers --key vs keyless flag mutual exclusions on cmd.
+// Must be called after cmd.Flags().AddFlagSet so all flags are present on the command.
+func markVerifyFlagsMutuallyExclusive(cmd *cobra.Command) {
+	cmd.MarkFlagsMutuallyExclusive("key", "certificate-identity")
+	cmd.MarkFlagsMutuallyExclusive("key", "certificate-identity-regexp")
+	cmd.MarkFlagsMutuallyExclusive("key", "certificate-oidc-issuer")
+	cmd.MarkFlagsMutuallyExclusive("key", "certificate-oidc-issuer-regexp")
+	cmd.MarkFlagsMutuallyExclusive("certificate-identity", "certificate-identity-regexp")
+	cmd.MarkFlagsMutuallyExclusive("certificate-oidc-issuer", "certificate-oidc-issuer-regexp")
+}
+
+// buildVerifyBlobOptions builds signing.VerifyBlobOptions from the verification flags,
+// applying the tlog auto-disable logic for keyless identity verification.
+func (f *packageVerifyFlags) buildVerifyBlobOptions(cmd *cobra.Command, v *viper.Viper) *signing.VerifyBlobOptions {
 	opts := signing.DefaultVerifyBlobOptions()
-	opts.Key = keyPath
+	opts.Key = f.publicKeyPath
+	opts.CertVerify.CertIdentity = f.certificateIdentity
+	opts.CertVerify.CertIdentityRegexp = f.certificateIdentityRegexp
+	opts.CertVerify.CertOidcIssuer = f.certificateOIDCIssuer
+	opts.CertVerify.CertOidcIssuerRegexp = f.certificateOIDCIssuerRegexp
+	opts.CommonVerifyOptions.TrustedRootPath = f.trustedRoot
+	opts.CommonVerifyOptions.IgnoreTlog = f.insecureIgnoreTlog
+	opts.CommonVerifyOptions.UseSignedTimestamps = f.useSignedTimestamps
+
+	// When a keyless identity is provided, require tlog verification by default so the
+	// inclusion proof establishes when the signature was made. Honor any explicit override.
+	// cmd may be nil when run() is called directly (e.g. from tests); in that case only
+	// the viper config path is checked for an explicit override.
+	hasKeylessIdentity := f.certificateIdentity != "" || f.certificateIdentityRegexp != ""
+	tlogExplicit := v.IsSet(VPkgInsecureIgnoreTlog)
+	if cmd != nil {
+		tlogExplicit = tlogExplicit || cmd.Flags().Changed("insecure-ignore-tlog")
+	}
+	if hasKeylessIdentity && !tlogExplicit {
+		opts.CommonVerifyOptions.IgnoreTlog = false
+	}
 	return &opts
+}
+
+// handleDeprecatedSkipSignatureValidation handles the deprecated --skip-signature-validation flag.
+// Call this in preRun for commands that embed packageVerifyFlags.
+func (f *packageVerifyFlags) handleDeprecatedSkipSignatureValidation(cmd *cobra.Command) {
+	if cmd.Flags().Changed("skip-signature-validation") {
+		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. " +
+			"Use --verify to enforce signature validation.")
+		if !cmd.Flags().Changed("verify") {
+			f.verify = !f.skipSignatureValidation
+		}
+	}
 }

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -316,10 +316,6 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageDeployOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *packageDeployOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
 	packageSource, err := choosePackage(ctx, args)
@@ -572,8 +568,8 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageMirrorResourcesOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
+func (o *packageMirrorResourcesOptions) preRun(cmd *cobra.Command, args []string) {
+	o.packageVerifyFlags.preRun(cmd, args)
 
 	// post flag validation - perform both if neither were set
 	if !o.mirrorImages && !o.mirrorRepos {
@@ -760,10 +756,6 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageInspectValuesFilesOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *packageInspectValuesFilesOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
 	src, err := choosePackage(ctx, args)
@@ -870,10 +862,6 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageInspectManifestsOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *packageInspectManifestsOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
 	src, err := choosePackage(ctx, args)
@@ -974,10 +962,6 @@ func newPackageInspectSBOMCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageInspectSBOMOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 // run performs the execution of 'package inspect sbom' sub-command.
 func (o *packageInspectSBOMOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
@@ -1050,10 +1034,6 @@ func newPackageInspectImagesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
 	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
-}
-
-func (o *packageInspectImagesOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageInspectImagesOptions) run(cmd *cobra.Command, args []string) error {
@@ -1129,10 +1109,6 @@ func newPackageInspectDocumentationCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageInspectDocumentationOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *packageInspectDocumentationOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
 	src, err := choosePackage(ctx, args)
@@ -1192,10 +1168,6 @@ func newPackageInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
 	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
-}
-
-func (o *packageInspectDefinitionOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packageInspectDefinitionOptions) run(cmd *cobra.Command, args []string) error {
@@ -1377,10 +1349,6 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageRemoveOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
-}
-
 func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	packageSource, err := choosePackage(ctx, args)
@@ -1485,10 +1453,6 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
 	markVerifyFlagsMutuallyExclusive(cmd)
 	return cmd
-}
-
-func (o *packagePublishOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
@@ -1650,10 +1614,6 @@ func newPackagePullCommand(v *viper.Viper) *cobra.Command {
 	markVerifyFlagsMutuallyExclusive(cmd)
 
 	return cmd
-}
-
-func (o *packagePullOptions) preRun(cmd *cobra.Command, _ []string) {
-	o.handleDeprecatedSkipSignatureValidation(cmd)
 }
 
 func (o *packagePullOptions) run(cmd *cobra.Command, args []string) error {
@@ -2125,9 +2085,9 @@ func (f *packageVerifyFlags) buildVerifyBlobOptions(cmd *cobra.Command, v *viper
 	return &opts
 }
 
-// handleDeprecatedSkipSignatureValidation handles the deprecated --skip-signature-validation flag.
-// Call this in preRun for commands that embed packageVerifyFlags.
-func (f *packageVerifyFlags) handleDeprecatedSkipSignatureValidation(cmd *cobra.Command) {
+// preRun is the cobra PreRun handler for commands that embed packageVerifyFlags.
+// It is promoted to embedding structs automatically, so no per-command wrapper is needed.
+func (f *packageVerifyFlags) preRun(cmd *cobra.Command, _ []string) {
 	if cmd.Flags().Changed("skip-signature-validation") {
 		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. " +
 			"Use --verify to enforce signature validation.")

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -311,8 +311,7 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", v.GetString(VPkgDeployNamespace), lang.CmdPackageDeployFlagNamespace)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when deploying the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -544,8 +543,7 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().BoolVar(&o.noImgChecksum, "no-img-checksum", false, lang.CmdPackageMirrorFlagNoChecksum)
 
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	cmd.Flags().StringVar(&o.optionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageMirrorFlagComponents)
@@ -751,8 +749,7 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -857,8 +854,7 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -957,8 +953,7 @@ func newPackageInspectSBOMCommand(v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVar(&o.outputDir, "output", o.outputDir, lang.CmdPackageCreateFlagSbomOut)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1031,8 +1026,7 @@ func newPackageInspectImagesCommand(v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", o.namespaceOverride, lang.CmdPackageInspectFlagNamespace)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1104,8 +1098,7 @@ func newPackageInspectDocumentationCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringSliceVar(&o.keys, "keys", []string{}, "Comma-separated list of documentation keys to extract (e.g., 'configuration,changelog')")
 	cmd.Flags().StringVar(&o.outputDir, "output", o.outputDir, "Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)")
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1165,8 +1158,7 @@ func newPackageInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", o.namespaceOverride, lang.CmdPackageInspectFlagNamespace)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1344,8 +1336,7 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", []string{}, lang.CmdPackageRemoveFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgRemoveSetValues), lang.CmdPackageDeployFlagSetValues)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1450,8 +1441,7 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when publishing the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 	cmd.Flags().BoolVar(&o.withBuildMachineInfo, "with-build-machine-info", v.GetBool(VPkgPublishWithBuildMachineInfo), lang.CmdPackageCreateFlagWithBuildMachineInfo)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
 
@@ -1610,8 +1600,7 @@ func newPackagePullCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().StringVarP(&o.outputDirectory, "output-directory", "o", v.GetString(VPkgPullOutputDir), lang.CmdPackagePullFlagOutputDirectory)
-	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &o.packageVerifyFlags))
-	markVerifyFlagsMutuallyExclusive(cmd)
+	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 
 	return cmd
 }
@@ -2044,6 +2033,15 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 
 	fs.AddFlagSet(newKeylessVerifyFlagSet(v, f))
 	return fs
+}
+
+// addVerifyFlags registers the full verification flag set on cmd and marks the
+// key/keyless flags mutually exclusive. Use this for all commands that load packages.
+// The sign and verify commands are exceptions — they register --key manually and use
+// newKeylessVerifyFlagSet directly, then call markVerifyFlagsMutuallyExclusive themselves.
+func addVerifyFlags(cmd *cobra.Command, v *viper.Viper, f *packageVerifyFlags) {
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, f))
+	markVerifyFlagsMutuallyExclusive(cmd)
 }
 
 // markVerifyFlagsMutuallyExclusive registers --key vs keyless flag mutual exclusions on cmd.

--- a/src/cmd/package_test.go
+++ b/src/cmd/package_test.go
@@ -677,3 +677,69 @@ func TestVerifyInsecureIgnoreTlogEnvRespected(t *testing.T) {
 	f := cmd.Flags().Lookup("insecure-ignore-tlog")
 	require.Equal(t, "false", f.DefValue, "env var must flow through to flag default")
 }
+
+func TestBuildVerifyBlobOptions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		identity        string
+		identityRegexp  string
+		flagTlogChanged bool // simulate --insecure-ignore-tlog being explicitly passed
+		viperTlogSet    bool // simulate ZARF_PACKAGE_INSECURE_IGNORE_TLOG env var
+		wantIgnoreTlog  bool
+	}{
+		{
+			name:           "no identity: IgnoreTlog stays at flag default (true)",
+			wantIgnoreTlog: true,
+		},
+		{
+			name:           "identity set, no explicit override: tlog forced on",
+			identity:       "user@example.com",
+			wantIgnoreTlog: false,
+		},
+		{
+			name:           "identity regexp set, no explicit override: tlog forced on",
+			identityRegexp: ".*@example\\.com",
+			wantIgnoreTlog: false,
+		},
+		{
+			name:            "identity set, flag explicitly changed: override honored",
+			identity:        "user@example.com",
+			flagTlogChanged: true,
+			wantIgnoreTlog:  true,
+		},
+		{
+			name:           "identity set, viper key set: override honored",
+			identity:       "user@example.com",
+			viperTlogSet:   true,
+			wantIgnoreTlog: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := newTestViper()
+			if tc.viperTlogSet {
+				v.Set(VPkgInsecureIgnoreTlog, true)
+			}
+
+			// Use a real command with the verify flag set registered so that
+			// cmd.Flags().Changed works correctly.
+			var f packageVerifyFlags
+			cmd := &cobra.Command{}
+			cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &f))
+
+			f.certificateIdentity = tc.identity
+			f.certificateIdentityRegexp = tc.identityRegexp
+
+			if tc.flagTlogChanged {
+				require.NoError(t, cmd.Flags().Set("insecure-ignore-tlog", "true"))
+			}
+
+			opts := f.buildVerifyBlobOptions(cmd, v)
+			require.Equal(t, tc.wantIgnoreTlog, opts.CommonVerifyOptions.IgnoreTlog)
+		})
+	}
+}

--- a/src/cmd/package_test.go
+++ b/src/cmd/package_test.go
@@ -229,7 +229,9 @@ func TestPackageInspectManifests(t *testing.T) {
 				components:   tc.components,
 			}
 			packagePath := filepath.Join(tmpdir, fmt.Sprintf("zarf-package-%s-%s.tar.zst", tc.packageName, config.GetArch()))
-			err = opts.run(context.Background(), []string{packagePath})
+			testCmd := &cobra.Command{}
+			testCmd.SetContext(context.Background())
+			err = opts.run(testCmd, []string{packagePath})
 			if tc.expectedErr != "" {
 				require.ErrorContains(t, err, tc.expectedErr)
 				return
@@ -391,7 +393,9 @@ func checkPackageValuesInspectFiles(t *testing.T, tc ValuesFilesTestData) {
 		components:   tc.components,
 	}
 	packagePath := filepath.Join(tmpdir, fmt.Sprintf("zarf-package-%s-%s.tar.zst", tc.packageName, config.GetArch()))
-	err = opts.run(context.Background(), []string{packagePath})
+	testCmd := &cobra.Command{}
+	testCmd.SetContext(context.Background())
+	err = opts.run(testCmd, []string{packagePath})
 	if tc.expectedErr != "" {
 		require.ErrorContains(t, err, tc.expectedErr)
 		return


### PR DESCRIPTION
## Description

Given the core load operations for a built package have always accepted `VerifyBlobOptions`, SDK use has supported the newer keyless verification. Current CLI operations do not yet support the use of Keyless verification material and related options. 

This PR looks to enable CLI support for keyless verification options on all package load commands. This takes the stance of trying to reduce code duplcation where possible but ultimately configures the flags on each command. This feels like the more correct approach when compared to the alternative of persistent flags inherited given that not all commands use the globals similarly (IE package verify).  

## Related Issue

Fixes #4917

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
