### PR TITLE
feat: direct docker daemon pull

### DIFF
--- a/src/pkg/feature/feature.go
+++ b/src/pkg/feature/feature.go
@@ -203,10 +203,11 @@ func featuresToMap(fs []Feature) map[Name]Feature {
 // List of feature names
 const (
 	// AxolotlMode declares the "axolotl-mode" feature
-	AxolotlMode     Name = "axolotl-mode"
-	RegistryProxy   Name = "registry-proxy"
-	Values          Name = "values"
-	BundleSignature Name = "bundle-signature"
+	AxolotlMode            Name = "axolotl-mode"
+	RegistryProxy          Name = "registry-proxy"
+	Values                 Name = "values"
+	BundleSignature        Name = "bundle-signature"
+	DockerDaemonDirectPull Name = "docker-daemon-direct-pull"
 )
 
 func init() {
@@ -250,6 +251,17 @@ func init() {
 			Enabled:     true,
 			Since:       "v0.72.0",
 			Stage:       Alpha,
+		},
+		{
+			Name: DockerDaemonDirectPull,
+			Description: "When pulling images that only exist in the local Docker daemon, save them directly via the " +
+				"Docker engine's OCI image export instead of Crane, which is faster and simpler. The direct export is " +
+				"only used when the Docker engine is v25.0 or newer (released Jan 2024), the first version to export " +
+				"images in the OCI layout format; older engines automatically fall back to Crane. Disabling this " +
+				"feature forces the Crane path regardless of engine version.",
+			Enabled: true,
+			Since:   "v0.80.0",
+			Stage:   Alpha,
 		},
 	}
 

--- a/src/pkg/feature/feature.go
+++ b/src/pkg/feature/feature.go
@@ -254,14 +254,11 @@ func init() {
 		},
 		{
 			Name: DockerDaemonDirectPull,
-			Description: "When pulling images that only exist in the local Docker daemon, save them directly via the " +
-				"Docker engine's OCI image export instead of Crane, which is faster and simpler. The direct export is " +
-				"only used when the Docker engine is v25.0 or newer (released Jan 2024), the first version to export " +
-				"images in the OCI layout format; older engines automatically fall back to Crane. Disabling this " +
-				"feature forces the Crane path regardless of engine version.",
+			Description: "Saves images from the local Docker daemon directly via the engine's OCI image export " +
+				"disabling this feature falls back to pulling with Crane.",
 			Enabled: true,
 			Since:   "v0.80.0",
-			Stage:   Alpha,
+			Stage:   GA,
 		},
 	}
 

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	clayout "github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"golang.org/x/sync/errgroup"
@@ -347,10 +348,14 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 		err = errors.Join(err, os.RemoveAll(tmpDir))
 	}()
 
-	// Note: ImageSave accepts an ocispec.Platform, but the effect it would have on users without client API version
-	// 1.48 (released Feb 2025) is unclear. This could make the export more efficient in some cases, but we avoid it
-	// for now to give users more time to update.
-	imageReader, err := cli.ImageSave(ctx, []string{daemonImage.overridden.Reference})
+	// Passing a platform only has an effect on multi-platform images and requires client API version 1.48 (released
+	// Feb 2025); ImageSave errors if we send it to older clients, so we only set it when the negotiated version
+	// supports it.
+	var saveOpts []client.ImageSaveOption
+	if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.48") {
+		saveOpts = append(saveOpts, client.ImageSaveWithPlatforms(ocispec.Platform{Architecture: arch, OS: "linux"}))
+	}
+	imageReader, err := cli.ImageSave(ctx, []string{daemonImage.overridden.Reference}, saveOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to save image %s from docker daemon: %w", daemonImage.overridden.Reference, err)
 	}
@@ -370,8 +375,6 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 		return fmt.Errorf("failed to close tar file: %w", err)
 	}
 
-	// The Docker daemon's OCI export is an image archive; once extracted it is handled exactly like
-	// any other image archive, including multi-platform indexes exported by the containerd image store.
 	dockerImageOCILayoutPath := filepath.Join(tmpDir, "docker-image-oci-layout")
 	if err := archive.Decompress(ctx, imageTarPath, dockerImageOCILayoutPath, archive.DecompressOpts{}); err != nil {
 		return fmt.Errorf("failed to extract image tar: %w", err)

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -397,7 +397,7 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 // Crane handles the older, pre-OCI-layout Docker export formats
 func craneSaveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
-	l.Debug("pulling image from the Docker Daemon with Crane SDK")
+	l.Warn("pulling from the Docker daemon using the legacy method. This method will be removed in Zarf v1.0. Upgrade Docker to >=v25.0.0 for continued daemon functionality")
 	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to make temp directory: %w", err)

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -300,7 +300,7 @@ func pullFromDockerDaemon(ctx context.Context, daemonImages []imageWithOverride,
 	for _, daemonImage := range daemonImages {
 		var pullErr error
 		if directPull {
-			pullErr = saveImageFromDockerDaemon(ctx, cli, dst, daemonImage, concurrency)
+			pullErr = saveImageFromDockerDaemon(ctx, cli, dst, daemonImage, arch, concurrency)
 		} else {
 			pullErr = craneSaveImageFromDockerDaemon(ctx, cli, dst, daemonImage, arch, concurrency)
 		}
@@ -337,7 +337,7 @@ func daemonSupportsOCIExport(ctx context.Context, cli *client.Client) bool {
 // saveImageFromDockerDaemon exports a single image from the Docker daemon via the engine's OCI image export
 // (the equivalent of `docker save`) and copies it into dst. This requires Docker engine v25.0+ (Feb 2024), the
 // first version to export images in the OCI layout format.
-func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, concurrency int) (err error) {
+func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
 	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
@@ -370,48 +370,28 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 		return fmt.Errorf("failed to close tar file: %w", err)
 	}
 
+	// The Docker daemon's OCI export is an image archive; once extracted it is handled exactly like
+	// any other image archive, including multi-platform indexes exported by the containerd image store.
 	dockerImageOCILayoutPath := filepath.Join(tmpDir, "docker-image-oci-layout")
 	if err := archive.Decompress(ctx, imageTarPath, dockerImageOCILayoutPath, archive.DecompressOpts{}); err != nil {
 		return fmt.Errorf("failed to extract image tar: %w", err)
 	}
-	idx, err := getIndexFromOCILayout(dockerImageOCILayoutPath)
+	manifests, err := getManifestsFromOCILayout(dockerImageOCILayoutPath)
 	if err != nil {
 		return err
 	}
 	// The export of a single image should always contain exactly one manifest.
-	if len(idx.Manifests) != 1 {
-		return fmt.Errorf("expected exactly one manifest in image export, found %d", len(idx.Manifests))
-	}
-	if idx.Manifests[0].Annotations == nil {
-		idx.Manifests[0].Annotations = map[string]string{}
-	}
-	// Set the ref name annotation so ORAS can resolve the image by its original reference.
-	idx.Manifests[0].Annotations[ocispec.AnnotationRefName] = daemonImage.original.Reference
-	if err := saveIndexToOCILayout(dockerImageOCILayoutPath, idx); err != nil {
-		return err
+	if len(manifests) != 1 {
+		return fmt.Errorf("expected exactly one manifest in image export, found %d", len(manifests))
 	}
 
 	dockerImageSrc, err := oci.NewWithContext(ctx, dockerImageOCILayoutPath)
 	if err != nil {
 		return fmt.Errorf("failed to create OCI store: %w", err)
 	}
-	desc, b, err := oras.FetchBytes(ctx, dockerImageSrc, daemonImage.original.Reference, oras.DefaultFetchBytesOptions)
-	if err != nil {
-		return fmt.Errorf("failed to get manifest from docker image source: %w", err)
-	}
-	if !IsManifest(desc.MediaType) {
-		return fmt.Errorf("expected to find image manifest instead found %s", desc.MediaType)
-	}
-	size, err := getSizeOfManifest(desc, b)
-	if err != nil {
+	l.Info("pulling image from docker daemon", "name", daemonImage.overridden.Reference)
+	if _, err := copyImageFromOCILayout(ctx, dockerImageSrc, dst, manifests[0].Digest.String(), daemonImage.original, arch, concurrency); err != nil {
 		return err
-	}
-	l.Info("pulling image from docker daemon", "name", daemonImage.overridden.Reference, "size", utils.ByteFormat(float64(size), 2))
-	copyOpts := oras.DefaultCopyOptions
-	copyOpts.Concurrency = concurrency
-	_, err = oras.Copy(ctx, dockerImageSrc, daemonImage.original.Reference, dst, "", copyOpts)
-	if err != nil {
-		return fmt.Errorf("failed to copy: %w", err)
 	}
 	return nil
 }

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -340,6 +340,7 @@ func daemonSupportsOCIExport(ctx context.Context, cli *client.Client) bool {
 // first version to export images in the OCI layout format.
 func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
+	l.Debug("pulling image from the Docker Daemon using Docker SDK")
 	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to make temp directory: %w", err)
@@ -404,6 +405,7 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 // user base has moved to Docker engine v25.0+ this can be removed in favor of saveImageFromDockerDaemon.
 func craneSaveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
+	l.Debug("pulling image from the Docker Daemon with Crane SDK")
 	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to make temp directory: %w", err)

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -294,9 +294,8 @@ func pullFromDockerDaemon(ctx context.Context, daemonImages []imageWithOverride,
 		err = errors.Join(err, cli.Close())
 	}()
 	// Saving images directly from the Docker daemon's OCI image export is faster and simpler than Crane, but it
-	// requires Docker engine v25.0+ (Jan 2024), the first version to export the OCI layout format. We only take the
-	// direct path when the feature is enabled (the default) and the daemon is new enough; otherwise we fall back to
-	// Crane, which handles the older export formats. The feature flag can be disabled to force the Crane path.
+	// requires Docker engine v25.0+, the first version to export the OCI layout format. For older versions
+	// or if the feature flag is disabled, we fall back to Crane.
 	directPull := feature.IsEnabled(feature.DockerDaemonDirectPull) && daemonSupportsOCIExport(ctx, cli)
 	for _, daemonImage := range daemonImages {
 		var pullErr error
@@ -315,29 +314,23 @@ func pullFromDockerDaemon(ctx context.Context, daemonImages []imageWithOverride,
 }
 
 // minDockerVersionForOCIExport is the first Docker engine version (released Jan 2024) to export images in the OCI
-// layout format via ImageSave. Older engines use legacy formats that require the Crane-based fallback.
+// layout format via ImageSave.
 var minDockerVersionForOCIExport = semver.MustParse("25.0.0")
 
-// daemonSupportsOCIExport reports whether the connected Docker daemon is new enough to export images in the OCI
-// layout format. If the version can't be determined or parsed, it returns false so the caller falls back to Crane.
 func daemonSupportsOCIExport(ctx context.Context, cli *client.Client) bool {
-	l := logger.From(ctx)
 	v, err := cli.ServerVersion(ctx, client.ServerVersionOptions{})
 	if err != nil {
-		l.Debug("unable to determine docker daemon version, using crane for daemon pull", "err", err)
 		return false
 	}
 	ver, err := semver.NewVersion(v.Version)
 	if err != nil {
-		l.Debug("unable to parse docker daemon version, using crane for daemon pull", "version", v.Version, "err", err)
 		return false
 	}
 	return !ver.LessThan(minDockerVersionForOCIExport)
 }
 
 // saveImageFromDockerDaemon exports a single image from the Docker daemon via the engine's OCI image export
-// (the equivalent of `docker save`) and copies it into dst. This requires Docker engine v25.0+ (Feb 2024), the
-// first version to export images in the OCI layout format.
+// (the equivalent of `docker save`) and copies it into dst.
 func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
 	l.Debug("pulling image from the Docker Daemon using Docker SDK")
@@ -401,8 +394,7 @@ func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci
 }
 
 // craneSaveImageFromDockerDaemon exports a single image from the Docker daemon using Crane and copies it into dst.
-// Crane handles the older, pre-OCI-layout Docker export formats whose extraction logic is quite complex. Once the
-// user base has moved to Docker engine v25.0+ this can be removed in favor of saveImageFromDockerDaemon.
+// Crane handles the older, pre-OCI-layout Docker export formats
 func craneSaveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
 	l := logger.From(ctx)
 	l.Debug("pulling image from the Docker Daemon with Crane SDK")

--- a/src/pkg/images/pull.go
+++ b/src/pkg/images/pull.go
@@ -8,12 +8,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	retry "github.com/avast/retry-go/v4"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/docker"
@@ -35,6 +37,8 @@ import (
 	orasCache "github.com/defenseunicorns/pkg/oci/cache"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/internal/dns"
+	"github.com/zarf-dev/zarf/src/pkg/archive"
+	"github.com/zarf-dev/zarf/src/pkg/feature"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
 	orasRemote "oras.land/oras-go/v2/registry/remote"
@@ -272,7 +276,6 @@ func getDockerEndpointHost() (string, error) {
 }
 
 func pullFromDockerDaemon(ctx context.Context, daemonImages []imageWithOverride, dst *oci.Store, arch string, concurrency int) (_ []PulledImage, err error) {
-	l := logger.From(ctx)
 	pulledImages := []PulledImage{}
 	dockerEndPointHost, err := getDockerEndpointHost()
 	if err != nil {
@@ -289,109 +292,225 @@ func pullFromDockerDaemon(ctx context.Context, daemonImages []imageWithOverride,
 	defer func() {
 		err = errors.Join(err, cli.Close())
 	}()
+	// Saving images directly from the Docker daemon's OCI image export is faster and simpler than Crane, but it
+	// requires Docker engine v25.0+ (Jan 2024), the first version to export the OCI layout format. We only take the
+	// direct path when the feature is enabled (the default) and the daemon is new enough; otherwise we fall back to
+	// Crane, which handles the older export formats. The feature flag can be disabled to force the Crane path.
+	directPull := feature.IsEnabled(feature.DockerDaemonDirectPull) && daemonSupportsOCIExport(ctx, cli)
 	for _, daemonImage := range daemonImages {
-		err := func() error {
-			// Pull the image into a Crane directory as the logic for extracting the earlier Docker formats is quite complex
-			// Docker starting saving images to the OCI layout format in Feb 2024 in engine version 25
-			// Once we feel the user base has updated we can remove Crane here by pulling from the daemon directly then calling oras.Copy
-			tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-			if err != nil {
-				return fmt.Errorf("failed to make temp directory: %w", err)
-			}
-			defer func() {
-				err = errors.Join(err, os.RemoveAll(tmpDir))
-			}()
-			reference, err := name.ParseReference(daemonImage.overridden.Reference)
-			if err != nil {
-				return fmt.Errorf("failed to parse reference: %w", err)
-			}
-			// Use unbuffered opener to avoid OOM Kill issues https://github.com/zarf-dev/zarf/issues/1214.
-			// This will also take forever to load large images.
-			img, err := daemon.Image(reference, daemon.WithUnbufferedOpener(), daemon.WithClient(cli))
-			if err != nil {
-				return fmt.Errorf("failed to load from docker daemon: %w", err)
-			}
-			cranePath, err := clayout.Write(tmpDir, empty.Index)
-			if err != nil {
-				return fmt.Errorf("failed to create OCI layout: %w", err)
-			}
-			if err := cranePath.WriteImage(img); err != nil {
-				return fmt.Errorf("failed to write docker image: %w", err)
-			}
-			annotations := map[string]string{
-				ocispec.AnnotationBaseImageName: daemonImage.original.Reference,
-				ocispec.AnnotationRefName:       daemonImage.original.Reference,
-			}
-			platform := &ocispec.Platform{
-				Architecture: arch,
-				OS:           "linux",
-			}
-			cranePlatform := cranev1.Platform{
-				OS:           platform.OS,
-				Architecture: platform.Architecture,
-			}
-			err = cranePath.AppendImage(img, clayout.WithAnnotations(annotations), clayout.WithPlatform(cranePlatform))
-			if err != nil {
-				return fmt.Errorf("failed to write image: %w", err)
-			}
-
-			// Needed because when pulling from the local docker daemon, while using the docker containerd runtime
-			// Crane incorrectly names the blob of the docker image config to a sha that does not match the contents
-			// https://github.com/zarf-dev/zarf/issues/2584
-			// This is a band aid fix while we wait for crane and or docker to create the permanent fix
-			blobDir := filepath.Join(tmpDir, "blobs", "sha256")
-			err = filepath.Walk(blobDir, func(path string, fi os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				if fi.IsDir() {
-					return nil
-				}
-				hash, err := helpers.GetSHA256OfFile(path)
-				if err != nil {
-					return err
-				}
-				newFile := filepath.Join(blobDir, hash)
-				return os.Rename(path, newFile)
-			})
-			if err != nil {
-				return err
-			}
-
-			dockerImageSrc, err := oci.NewWithContext(ctx, tmpDir)
-			if err != nil {
-				return fmt.Errorf("failed to create OCI store: %w", err)
-			}
-			fetchBytesOpts := oras.DefaultFetchBytesOptions
-			fetchBytesOpts.TargetPlatform = platform
-			desc, b, err := oras.FetchBytes(ctx, dockerImageSrc, daemonImage.original.Reference, fetchBytesOpts)
-			if err != nil {
-				return fmt.Errorf("failed to get manifest from docker image source: %w", err)
-			}
-			if !IsManifest(desc.MediaType) {
-				return fmt.Errorf("expected to find image manifest instead found %s", desc.MediaType)
-			}
-			pulledImages = append(pulledImages, PulledImage{Image: daemonImage.original})
-			size, err := getSizeOfManifest(desc, b)
-			if err != nil {
-				return err
-			}
-			l.Info("pulling image from docker daemon", "name", daemonImage.overridden.Reference, "size", utils.ByteFormat(float64(size), 2))
-			copyOpts := oras.DefaultCopyOptions
-			copyOpts.WithTargetPlatform(platform)
-			copyOpts.Concurrency = concurrency
-			_, err = oras.Copy(ctx, dockerImageSrc, daemonImage.original.Reference, dst, "", copyOpts)
-			if err != nil {
-				return fmt.Errorf("failed to copy: %w", err)
-			}
-			return nil
-		}()
-		if err != nil {
-			return nil, err
+		var pullErr error
+		if directPull {
+			pullErr = saveImageFromDockerDaemon(ctx, cli, dst, daemonImage, concurrency)
+		} else {
+			pullErr = craneSaveImageFromDockerDaemon(ctx, cli, dst, daemonImage, arch, concurrency)
 		}
+		if pullErr != nil {
+			return nil, pullErr
+		}
+		pulledImages = append(pulledImages, PulledImage{Image: daemonImage.original})
 	}
 
 	return pulledImages, nil
+}
+
+// minDockerVersionForOCIExport is the first Docker engine version (released Jan 2024) to export images in the OCI
+// layout format via ImageSave. Older engines use legacy formats that require the Crane-based fallback.
+var minDockerVersionForOCIExport = semver.MustParse("25.0.0")
+
+// daemonSupportsOCIExport reports whether the connected Docker daemon is new enough to export images in the OCI
+// layout format. If the version can't be determined or parsed, it returns false so the caller falls back to Crane.
+func daemonSupportsOCIExport(ctx context.Context, cli *client.Client) bool {
+	l := logger.From(ctx)
+	v, err := cli.ServerVersion(ctx, client.ServerVersionOptions{})
+	if err != nil {
+		l.Debug("unable to determine docker daemon version, using crane for daemon pull", "err", err)
+		return false
+	}
+	ver, err := semver.NewVersion(v.Version)
+	if err != nil {
+		l.Debug("unable to parse docker daemon version, using crane for daemon pull", "version", v.Version, "err", err)
+		return false
+	}
+	return !ver.LessThan(minDockerVersionForOCIExport)
+}
+
+// saveImageFromDockerDaemon exports a single image from the Docker daemon via the engine's OCI image export
+// (the equivalent of `docker save`) and copies it into dst. This requires Docker engine v25.0+ (Feb 2024), the
+// first version to export images in the OCI layout format.
+func saveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, concurrency int) (err error) {
+	l := logger.From(ctx)
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to make temp directory: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
+
+	// Note: ImageSave accepts an ocispec.Platform, but the effect it would have on users without client API version
+	// 1.48 (released Feb 2025) is unclear. This could make the export more efficient in some cases, but we avoid it
+	// for now to give users more time to update.
+	imageReader, err := cli.ImageSave(ctx, []string{daemonImage.overridden.Reference})
+	if err != nil {
+		return fmt.Errorf("failed to save image %s from docker daemon: %w", daemonImage.overridden.Reference, err)
+	}
+	defer func() {
+		err = errors.Join(err, imageReader.Close())
+	}()
+
+	imageTarPath := filepath.Join(tmpDir, "image.tar")
+	tarFile, err := os.Create(imageTarPath)
+	if err != nil {
+		return fmt.Errorf("failed to create tar file: %w", err)
+	}
+	if _, err := io.Copy(tarFile, imageReader); err != nil {
+		return errors.Join(fmt.Errorf("failed to write image to tar file: %w", err), tarFile.Close())
+	}
+	if err := tarFile.Close(); err != nil {
+		return fmt.Errorf("failed to close tar file: %w", err)
+	}
+
+	dockerImageOCILayoutPath := filepath.Join(tmpDir, "docker-image-oci-layout")
+	if err := archive.Decompress(ctx, imageTarPath, dockerImageOCILayoutPath, archive.DecompressOpts{}); err != nil {
+		return fmt.Errorf("failed to extract image tar: %w", err)
+	}
+	idx, err := getIndexFromOCILayout(dockerImageOCILayoutPath)
+	if err != nil {
+		return err
+	}
+	// The export of a single image should always contain exactly one manifest.
+	if len(idx.Manifests) != 1 {
+		return fmt.Errorf("expected exactly one manifest in image export, found %d", len(idx.Manifests))
+	}
+	if idx.Manifests[0].Annotations == nil {
+		idx.Manifests[0].Annotations = map[string]string{}
+	}
+	// Set the ref name annotation so ORAS can resolve the image by its original reference.
+	idx.Manifests[0].Annotations[ocispec.AnnotationRefName] = daemonImage.original.Reference
+	if err := saveIndexToOCILayout(dockerImageOCILayoutPath, idx); err != nil {
+		return err
+	}
+
+	dockerImageSrc, err := oci.NewWithContext(ctx, dockerImageOCILayoutPath)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI store: %w", err)
+	}
+	desc, b, err := oras.FetchBytes(ctx, dockerImageSrc, daemonImage.original.Reference, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return fmt.Errorf("failed to get manifest from docker image source: %w", err)
+	}
+	if !IsManifest(desc.MediaType) {
+		return fmt.Errorf("expected to find image manifest instead found %s", desc.MediaType)
+	}
+	size, err := getSizeOfManifest(desc, b)
+	if err != nil {
+		return err
+	}
+	l.Info("pulling image from docker daemon", "name", daemonImage.overridden.Reference, "size", utils.ByteFormat(float64(size), 2))
+	copyOpts := oras.DefaultCopyOptions
+	copyOpts.Concurrency = concurrency
+	_, err = oras.Copy(ctx, dockerImageSrc, daemonImage.original.Reference, dst, "", copyOpts)
+	if err != nil {
+		return fmt.Errorf("failed to copy: %w", err)
+	}
+	return nil
+}
+
+// craneSaveImageFromDockerDaemon exports a single image from the Docker daemon using Crane and copies it into dst.
+// Crane handles the older, pre-OCI-layout Docker export formats whose extraction logic is quite complex. Once the
+// user base has moved to Docker engine v25.0+ this can be removed in favor of saveImageFromDockerDaemon.
+func craneSaveImageFromDockerDaemon(ctx context.Context, cli *client.Client, dst *oci.Store, daemonImage imageWithOverride, arch string, concurrency int) (err error) {
+	l := logger.From(ctx)
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to make temp directory: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
+	reference, err := name.ParseReference(daemonImage.overridden.Reference)
+	if err != nil {
+		return fmt.Errorf("failed to parse reference: %w", err)
+	}
+	// Use unbuffered opener to avoid OOM Kill issues https://github.com/zarf-dev/zarf/issues/1214.
+	// This will also take forever to load large images.
+	img, err := daemon.Image(reference, daemon.WithUnbufferedOpener(), daemon.WithClient(cli))
+	if err != nil {
+		return fmt.Errorf("failed to load from docker daemon: %w", err)
+	}
+	cranePath, err := clayout.Write(tmpDir, empty.Index)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI layout: %w", err)
+	}
+	if err := cranePath.WriteImage(img); err != nil {
+		return fmt.Errorf("failed to write docker image: %w", err)
+	}
+	annotations := map[string]string{
+		ocispec.AnnotationBaseImageName: daemonImage.original.Reference,
+		ocispec.AnnotationRefName:       daemonImage.original.Reference,
+	}
+	platform := &ocispec.Platform{
+		Architecture: arch,
+		OS:           "linux",
+	}
+	cranePlatform := cranev1.Platform{
+		OS:           platform.OS,
+		Architecture: platform.Architecture,
+	}
+	err = cranePath.AppendImage(img, clayout.WithAnnotations(annotations), clayout.WithPlatform(cranePlatform))
+	if err != nil {
+		return fmt.Errorf("failed to write image: %w", err)
+	}
+
+	// Needed because when pulling from the local docker daemon, while using the docker containerd runtime
+	// Crane incorrectly names the blob of the docker image config to a sha that does not match the contents
+	// https://github.com/zarf-dev/zarf/issues/2584
+	// This is a band aid fix while we wait for crane and or docker to create the permanent fix
+	blobDir := filepath.Join(tmpDir, "blobs", "sha256")
+	err = filepath.Walk(blobDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		hash, err := helpers.GetSHA256OfFile(path)
+		if err != nil {
+			return err
+		}
+		newFile := filepath.Join(blobDir, hash)
+		return os.Rename(path, newFile)
+	})
+	if err != nil {
+		return err
+	}
+
+	dockerImageSrc, err := oci.NewWithContext(ctx, tmpDir)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI store: %w", err)
+	}
+	fetchBytesOpts := oras.DefaultFetchBytesOptions
+	fetchBytesOpts.TargetPlatform = platform
+	desc, b, err := oras.FetchBytes(ctx, dockerImageSrc, daemonImage.original.Reference, fetchBytesOpts)
+	if err != nil {
+		return fmt.Errorf("failed to get manifest from docker image source: %w", err)
+	}
+	if !IsManifest(desc.MediaType) {
+		return fmt.Errorf("expected to find image manifest instead found %s", desc.MediaType)
+	}
+	size, err := getSizeOfManifest(desc, b)
+	if err != nil {
+		return err
+	}
+	l.Info("pulling image from docker daemon", "name", daemonImage.overridden.Reference, "size", utils.ByteFormat(float64(size), 2))
+	copyOpts := oras.DefaultCopyOptions
+	copyOpts.WithTargetPlatform(platform)
+	copyOpts.Concurrency = concurrency
+	_, err = oras.Copy(ctx, dockerImageSrc, daemonImage.original.Reference, dst, "", copyOpts)
+	if err != nil {
+		return fmt.Errorf("failed to copy: %w", err)
+	}
+	return nil
 }
 
 func orasSave(ctx context.Context, imageInfo imagePullInfo, opts PullOptions, dst *oci.Store, client *auth.Client) error {

--- a/src/pkg/images/unpack.go
+++ b/src/pkg/images/unpack.go
@@ -145,30 +145,9 @@ func Unpack(ctx context.Context, imageArchive v1alpha1.ImageArchive, destDir str
 		}
 		requestedImages[manifestImg.Reference] = true
 
-		foundDesc, _, err := oras.FetchBytes(ctx, srcStore, manifestDesc.Digest.String(), oras.DefaultFetchBytesOptions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch manifest for %s: %w", imageName, err)
-		}
-
 		logger.From(ctx).Info("pulling image from archive", "image", manifestImg.Reference, "archive", imageArchive.Path)
-		// Mirror images.Pull: an index-digest reference preserves the full index, while a tag or
-		// manifest-digest reference is filtered down to a single platform manifest by oras.Copy.
-		var platform *ocispec.Platform
-		isIndexSha := manifestImg.Digest != "" && IsIndex(foundDesc.MediaType)
-		if IsIndex(foundDesc.MediaType) && !isIndexSha {
-			platform = &ocispec.Platform{Architecture: arch, OS: "linux"}
-		}
-		copyOpts := oras.DefaultCopyOptions
-		copyOpts.WithTargetPlatform(platform)
-		desc, err := oras.Copy(ctx, srcStore, manifestDesc.Digest.String(), dstStore, manifestImg.Reference, copyOpts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy image %s from archive %s: %w", manifestImg.Reference, imageArchive.Path, err)
-		}
-		// Tag the image with annotations so that Syft and ORAS can see them
-		desc = addNameAnnotationsToDesc(desc, manifestImg.Reference)
-		err = dstStore.Tag(ctx, desc, manifestImg.Reference)
-		if err != nil {
-			return nil, fmt.Errorf("failed to tag image: %w", err)
+		if _, err := copyImageFromOCILayout(ctx, srcStore, dstStore, manifestDesc.Digest.String(), manifestImg, arch, 0); err != nil {
+			return nil, fmt.Errorf("failed to pull image %s from archive %s: %w", manifestImg.Reference, imageArchive.Path, err)
 		}
 
 		pulledImages = append(pulledImages, PulledImage{Image: manifestImg})
@@ -183,6 +162,34 @@ func Unpack(ctx context.Context, imageArchive v1alpha1.ImageArchive, destDir str
 	}
 
 	return pulledImages, nil
+}
+
+func copyImageFromOCILayout(ctx context.Context, src oras.ReadOnlyTarget, dst *oci.Store, srcRef string, destImage transform.Image, arch string, concurrency int) (ocispec.Descriptor, error) {
+	desc, _, err := oras.FetchBytes(ctx, src, srcRef, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to fetch manifest for %s: %w", srcRef, err)
+	}
+
+	// Mirror images.Pull: an index-digest reference preserves the full index, while a tag or
+	// manifest-digest reference is filtered down to a single platform manifest by oras.Copy.
+	var platform *ocispec.Platform
+	isIndexSha := destImage.Digest != "" && IsIndex(desc.MediaType)
+	if IsIndex(desc.MediaType) && !isIndexSha {
+		platform = &ocispec.Platform{Architecture: arch, OS: "linux"}
+	}
+	copyOpts := oras.DefaultCopyOptions
+	copyOpts.Concurrency = concurrency
+	copyOpts.WithTargetPlatform(platform)
+	desc, err = oras.Copy(ctx, src, srcRef, dst, destImage.Reference, copyOpts)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to copy image %s: %w", destImage.Reference, err)
+	}
+	// Tag the image with annotations so that Syft and ORAS can see them
+	desc = addNameAnnotationsToDesc(desc, destImage.Reference)
+	if err := dst.Tag(ctx, desc, destImage.Reference); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to tag image: %w", err)
+	}
+	return desc, nil
 }
 
 func determineImageDirectory(dir string) (string, error) {


### PR DESCRIPTION
## Description

Direct pulling from Docker Daemon is far faster than the Crane SDK. In my experiments, a 1 GB image of random data took 44 seconds to pull with the Crane SDK and 11 with the Docker SDK, a 4x difference! 

Crane handles the legacy Docker formats which are complex, we already have most of the logic to handle an OCI format with Image archives, so we use Docker directly so long as it's using the newer format >v0.25.0.

Peak storage usage is higher with this PR 3x the image instead of 2x the image, but I believe this can be easily resolved in a follow up.

I added a feature flag "docker-daemon-direct-pull" so that if anything goes wrong user's have an escape hatch to go back to the Crane way of doing things, which we are keeping around until v1 so that users not up to date on their Docker Daemon can use the latest version of Zarf

## Related Issue

Fixes #4990 


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
