### PR TITLE
ci: additional agent logs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -213,7 +213,6 @@ jobs:
 
         # These logs were added to find the cause of https://github.com/zarf-dev/zarf/issues/4986
       - name: get agent info
-        if: failure()
         run: |
           echo "***** Describing agent pods *****"
           kubectl describe pod -l app=agent-hook -n zarf

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -213,6 +213,7 @@ jobs:
 
         # These logs were added to find the cause of https://github.com/zarf-dev/zarf/issues/4986
       - name: get agent info
+        if: always()
         run: |
           echo "***** Describing agent pods *****"
           kubectl describe pod -l app=agent-hook -n zarf

--- a/src/internal/agent/http/admission/handler.go
+++ b/src/internal/agent/http/admission/handler.go
@@ -38,6 +38,7 @@ func NewHandler() *Handler {
 func (h *Handler) Serve(ctx context.Context, hook operations.Hook) http.HandlerFunc {
 	l := logger.From(ctx)
 	return func(w http.ResponseWriter, r *http.Request) {
+		l.Debug("received admission request", "method", r.Method, "path", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		if r.Method != http.MethodPost {
 			http.Error(w, lang.AgentErrInvalidMethod, http.StatusMethodNotAllowed)

--- a/src/test/e2e/98_agent_mutation_mode_test.go
+++ b/src/test/e2e/98_agent_mutation_mode_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,17 +46,17 @@ func TestAgentMutationPolicy(t *testing.T) {
 	_, stdErr, err = e2e.Zarf(t, "init", initPackagePath, "--agent-mutation-policy=labeled", "--confirm")
 	require.NoError(t, err, stdErr)
 
-	// Snapshot what the API server can route to right after init, while the webhook is first created.
-	// This will let us check if the endpoint slices have an address and if .endpoints.address[x].conditions.ready: true
-	_, _, err = e2e.Kubectl(t, "get", "endpointslices", "-n", "zarf", "-l", "kubernetes.io/service-name=agent-hook", "-o", "yaml")
-	require.NoError(t, err)
-
 	// Create and run a pod in the unlabeled ns
 	_, _, err = e2e.Kubectl(t, "create", "namespace", nsName)
 	require.NoError(t, err)
 
-	_, _, err = e2e.Kubectl(t, "run", podName, "-n", nsName,
-		"--image=ghcr.io/zarf-dev/images/alpine:3.21.3", "--restart=Never", "--", "sleep", "100")
+	// Sometimes the agent flakes, it's possible it's going to the old agent pod just before it finishes terminating
+	// Adding a retry here to test this hypothesis
+	err = retry.Do(func() error {
+		_, _, err := e2e.Kubectl(t, "run", podName, "-n", nsName,
+			"--image=ghcr.io/zarf-dev/images/alpine:3.21.3", "--restart=Never", "--", "sleep", "100")
+		return err
+	}, retry.Attempts(2))
 	require.NoError(t, err)
 
 	// The agent must not have rewritten the image — it should still point to the original registry.

--- a/src/test/e2e/98_agent_mutation_mode_test.go
+++ b/src/test/e2e/98_agent_mutation_mode_test.go
@@ -45,6 +45,11 @@ func TestAgentMutationPolicy(t *testing.T) {
 	_, stdErr, err = e2e.Zarf(t, "init", initPackagePath, "--agent-mutation-policy=labeled", "--confirm")
 	require.NoError(t, err, stdErr)
 
+	// Snapshot what the API server can route to right after init, while the webhook is first created.
+	// This will let us check if the endpoint slices have an address and if .endpoints.address[x].conditions.ready: true
+	_, _, err = e2e.Kubectl(t, "get", "endpointslices", "-n", "zarf", "-l", "kubernetes.io/service-name=agent-hook", "-o", "yaml")
+	require.NoError(t, err)
+
 	// Create and run a pod in the unlabeled ns
 	_, _, err = e2e.Kubectl(t, "create", "namespace", nsName)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

I think this may have to do with endpoint slices being slow to create when the system is under CPU pressure, 
Relates to #4986

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
