### PR TITLE
feat: group verify flags in CLI help text

### DIFF
--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -67,6 +67,24 @@ func newPackageCommand() *cobra.Command {
 	return cmd
 }
 
+// flagGroupAnnotation is the pflag annotation key used to assign a flag to a named
+// usage section. Flags carrying this annotation are rendered under their group title
+// by the custom usage template instead of the default "Flags:" block.
+const flagGroupAnnotation = "zarf_flag_group"
+
+// verifyFlagGroupTitle is the usage section title for package verification flags.
+const verifyFlagGroupTitle = "Verification Flags"
+
+// annotateFlagGroup tags every flag in fs with the given usage-section title.
+func annotateFlagGroup(fs *pflag.FlagSet, title string) {
+	fs.VisitAll(func(f *pflag.Flag) {
+		err := fs.SetAnnotation(f.Name, flagGroupAnnotation, []string{title})
+		if err != nil {
+			panic(err)
+		}
+	})
+}
+
 // packageVerifyFlags holds all package signature and keyless verification flags.
 // Embed this in any command options struct that performs a package load operation.
 // To add a new verification flag in the future, add the field here and register it
@@ -1926,6 +1944,10 @@ func newPackageVerifyCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageVerifyFlagKey)
 	cmd.Flags().AddFlagSet(newKeylessVerifyFlagSet(v, &o.packageVerifyFlags))
+	err := cmd.Flags().SetAnnotation("key", flagGroupAnnotation, []string{verifyFlagGroupTitle})
+	if err != nil {
+		panic(err)
+	}
 	markVerifyFlagsMutuallyExclusive(cmd)
 
 	return cmd
@@ -2078,6 +2100,7 @@ func newKeylessVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagS
 	fs.BoolVar(&f.useSignedTimestamps, "use-signed-timestamps",
 		v.GetBool(VPkgUseSignedTimestamps), lang.CmdPackageVerifyFlagUseSignedTimestamps)
 
+	annotateFlagGroup(fs, verifyFlagGroupTitle)
 	return fs
 }
 
@@ -2093,6 +2116,7 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 			"Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
 
 	fs.AddFlagSet(newKeylessVerifyFlagSet(v, f))
+	annotateFlagGroup(fs, verifyFlagGroupTitle)
 	return fs
 }
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -211,6 +211,8 @@ func NewZarfCommand() *cobra.Command {
 		setupRootFlags(rootCmd)
 	}
 
+	setupGroupedFlagUsage(rootCmd)
+
 	return rootCmd
 }
 

--- a/src/cmd/usage.go
+++ b/src/cmd/usage.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package cmd contains the CLI commands for Zarf.
+package cmd
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// defaultFlagsSection is Cobra's default rendering of a command's local flags. We
+// match it verbatim in cmd.UsageTemplate()
+const defaultFlagsSection = "Flags:\n{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}"
+
+// groupedFlagsSection renders local flags in two parts: flags without a group
+// annotation, followed by one titled section per flag group (see flagGroupAnnotation).
+const groupedFlagsSection = "Flags:\n{{ungroupedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{groupedFlagSections .LocalFlags}}{{end}}"
+
+// setupGroupedFlagUsage registers the template helpers and installs a usage template
+// derived from Cobra's default by swapping in grouped-flag rendering. Cobra propagates
+// the template to all descendant commands.
+func setupGroupedFlagUsage(cmd *cobra.Command) {
+	cobra.AddTemplateFunc("ungroupedFlagUsages", ungroupedFlagUsages)
+	cobra.AddTemplateFunc("groupedFlagSections", groupedFlagSections)
+	cmd.SetUsageTemplate(groupedFlagUsageTemplate(cmd.UsageTemplate()))
+}
+
+func groupedFlagUsageTemplate(base string) string {
+	return strings.Replace(base, defaultFlagsSection, groupedFlagsSection, 1)
+}
+
+// ungroupedFlagUsages renders the usage block for every flag in fs that is not
+// assigned to a group, preserving Cobra's default column alignment.
+func ungroupedFlagUsages(fs *pflag.FlagSet) string {
+	ungrouped := pflag.NewFlagSet("", pflag.ContinueOnError)
+	fs.VisitAll(func(f *pflag.Flag) {
+		if _, ok := f.Annotations[flagGroupAnnotation]; !ok {
+			ungrouped.AddFlag(f)
+		}
+	})
+	return ungrouped.FlagUsages()
+}
+
+// groupedFlagSections renders one "<title>:" usage block per flag group present in
+// fs, ordered by title. It returns an empty string when no flags are grouped.
+func groupedFlagSections(fs *pflag.FlagSet) string {
+	var titles []string
+	fs.VisitAll(func(f *pflag.Flag) {
+		if vals := f.Annotations[flagGroupAnnotation]; len(vals) > 0 && !slices.Contains(titles, vals[0]) {
+			titles = append(titles, vals[0])
+		}
+	})
+	slices.Sort(titles)
+
+	var b strings.Builder
+	for _, title := range titles {
+		group := pflag.NewFlagSet("", pflag.ContinueOnError)
+		fs.VisitAll(func(f *pflag.Flag) {
+			if vals := f.Annotations[flagGroupAnnotation]; len(vals) > 0 && vals[0] == title {
+				group.AddFlag(f)
+			}
+		})
+		usages := strings.TrimRight(group.FlagUsages(), "\n")
+		if usages == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "\n\n%s:\n%s", title, usages)
+	}
+	return b.String()
+}

--- a/src/cmd/usage_test.go
+++ b/src/cmd/usage_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUsageTemplateFlagsSectionMatchesCobra guards the assumption behind
+// groupedFlagUsageTemplate: that Cobra's default usage template still contains the
+// exact flags fragment we replace. If Cobra changes it, this fails so we re-sync
+// defaultFlagsSection rather than silently losing flag grouping.
+func TestUsageTemplateFlagsSectionMatchesCobra(t *testing.T) {
+	t.Parallel()
+
+	// Make sure Cobras default usage template hasn't changed
+	cobraDefault := (&cobra.Command{}).UsageTemplate()
+	require.Contains(t, cobraDefault, defaultFlagsSection)
+
+	got := groupedFlagUsageTemplate(cobraDefault)
+	require.Contains(t, got, groupedFlagsSection)
+	require.NotContains(t, got, defaultFlagsSection)
+}
+
+func TestVerifyFlagsAreGrouped(t *testing.T) {
+	t.Parallel()
+
+	v := newTestViper()
+	var f packageVerifyFlags
+	fs := newVerifyFlagSet(v, &f)
+
+	fs.VisitAll(func(flag *pflag.Flag) {
+		require.Equal(t, []string{verifyFlagGroupTitle}, flag.Annotations[flagGroupAnnotation],
+			"flag %q should belong to the verification group", flag.Name)
+	})
+}
+
+func TestGroupedFlagUsageRendering(t *testing.T) {
+	// Not parallel: setupGroupedFlagUsage registers template helpers via the global
+	// cobra.AddTemplateFunc, which is not safe to race with other tests.
+
+	v := newTestViper()
+	var f packageVerifyFlags
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("confirm", false, "an ungrouped flag")
+	cmd.Flags().AddFlagSet(newVerifyFlagSet(v, &f))
+
+	setupGroupedFlagUsage(cmd)
+	usage := cmd.UsageString()
+
+	flagsIdx := strings.Index(usage, "Flags:")
+	groupIdx := strings.Index(usage, verifyFlagGroupTitle+":")
+	require.NotEqual(t, -1, flagsIdx, "usage should have a Flags section")
+	require.Less(t, flagsIdx, groupIdx, "the grouped section should render after the ungrouped Flags block")
+
+	// Ungrouped flags render under the default "Flags:" heading; grouped flags only
+	// under their own titled section.
+	ungrouped := usage[flagsIdx:groupIdx]
+	require.Contains(t, ungrouped, "--confirm")
+	require.NotContains(t, ungrouped, "--certificate-identity")
+
+	grouped := usage[groupIdx:]
+	require.Contains(t, grouped, "--certificate-identity")
+	require.NotContains(t, grouped, "--confirm")
+}
+
+func TestGroupedFlagSectionsEmptyWithoutGroups(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Bool("confirm", false, "an ungrouped flag")
+
+	require.Empty(t, groupedFlagSections(fs))
+	require.Contains(t, ungroupedFlagUsages(fs), "--confirm")
+}


### PR DESCRIPTION
## Description

This groups verify flags which usually are spread throughout the command so it can be confusing to find the relevant flags.

before: 
<img width="2068" height="1006" alt="image" src="https://github.com/user-attachments/assets/e23d808c-0175-4577-b486-50246d020a9b" />


after: 
<img width="2068" height="1006" alt="image" src="https://github.com/user-attachments/assets/6bde86f3-a10f-4f45-98cb-9dc6882aaaf8" />
 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
