### PR TITLE
feat(verification)!: behavior updates for verification logic

### DIFF
--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -99,7 +99,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -99,7 +99,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -99,7 +99,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -99,7 +99,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -62,7 +62,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -62,7 +62,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -62,7 +62,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -62,7 +62,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -43,7 +43,7 @@ $ zarf package inspect definition my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -43,7 +43,7 @@ $ zarf package inspect definition my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -43,7 +43,7 @@ $ zarf package inspect definition my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -43,7 +43,7 @@ $ zarf package inspect definition my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -41,7 +41,7 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
       --output string                           Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -41,7 +41,7 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
       --output string                           Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -41,7 +41,7 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
       --output string                           Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -41,7 +41,7 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
       --output string                           Directory to extract documentation to (created under '<package-name>-documentation' subdirectory)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -43,7 +43,7 @@ $ zarf package inspect images my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -43,7 +43,7 @@ $ zarf package inspect images my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -43,7 +43,7 @@ $ zarf package inspect images my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -43,7 +43,7 @@ $ zarf package inspect images my-package
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -44,7 +44,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -44,7 +44,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -44,7 +44,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -44,7 +44,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -40,7 +40,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
       --output string                           Specify an output directory for the SBOMs from the created Zarf package
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -40,7 +40,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
       --output string                           Specify an output directory for the SBOMs from the created Zarf package
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -40,7 +40,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
       --output string                           Specify an output directory for the SBOMs from the created Zarf package
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -40,7 +40,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
       --output string                           Specify an output directory for the SBOMs from the created Zarf package
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -48,7 +48,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -48,7 +48,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -48,7 +48,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -48,7 +48,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -78,7 +78,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -78,7 +78,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -78,7 +78,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -78,7 +78,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -51,7 +51,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
   -t, --tag string                              The tag to be used in the OCI reference for the package in the registry
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
       --with-build-machine-info                 Include build machine information (hostname and username) in the package metadata
 ```
 

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -51,7 +51,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
   -t, --tag string                              The tag to be used in the OCI reference for the package in the registry
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
       --with-build-machine-info                 Include build machine information (hostname and username) in the package metadata
 ```
 

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -51,7 +51,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
   -t, --tag string                              The tag to be used in the OCI reference for the package in the registry
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
       --with-build-machine-info                 Include build machine information (hostname and username) in the package metadata
 ```
 

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -51,7 +51,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
   -t, --tag string                              The tag to be used in the OCI reference for the package in the registry
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
       --with-build-machine-info                 Include build machine information (hostname and username) in the package metadata
 ```
 

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -43,7 +43,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -43,7 +43,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -43,7 +43,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -43,7 +43,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
       --shasum string                           Shasum of the package to pull. Required if pulling a https package. A shasum can be retrieved using 'zarf dev sha256sum <url>'
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -51,7 +51,7 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          Path to values file(s) for removal actions
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -51,7 +51,7 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          Path to values file(s) for removal actions
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -51,7 +51,7 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          Path to values file(s) for removal actions
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -51,7 +51,7 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          Path to values file(s) for removal actions
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -67,7 +67,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -67,7 +67,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify                                  Verify the Zarf package signature
+      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -67,7 +67,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -67,7 +67,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode                       Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
+      --verify verifyMode[=always]              Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never. (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -67,7 +67,7 @@ func newInitCommand() *cobra.Command {
 		Long:    lang.CmdInitLong,
 		Example: lang.CmdInitExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -201,7 +201,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 
 	loadOpt := packager.LoadOptions{
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Filter:               filter,
 		Architecture:         config.GetArch(),
 		CachePath:            cachePath,

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -73,7 +73,7 @@ func newPackageCommand() *cobra.Command {
 // in newVerifyFlagSet / newKeylessVerifyFlagSet, then update buildVerifyBlobOptions.
 type packageVerifyFlags struct {
 	publicKeyPath               string
-	verify                      bool
+	verify                      verifyMode
 	skipSignatureValidation     bool // deprecated
 	certificateIdentity         string
 	certificateIdentityRegexp   string
@@ -287,7 +287,7 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 		Long:    lang.CmdPackageDeployLong,
 		Example: lang.CmdPackageDeployExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -356,7 +356,7 @@ func (o *packageDeployOptions) run(cmd *cobra.Command, args []string) (err error
 	loadOpt := packager.LoadOptions{
 		Shasum:               o.shasum,
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Filter:               filter,
 		Architecture:         config.GetArch(),
 		OCIConcurrency:       o.ociConcurrency,
@@ -528,7 +528,7 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 		Long:    lang.CmdPackageMirrorLong,
 		Example: lang.CmdPackageMirrorExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -567,14 +567,17 @@ func newPackageMirrorResourcesCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *packageMirrorResourcesOptions) preRun(cmd *cobra.Command, args []string) {
-	o.packageVerifyFlags.preRun(cmd, args)
+func (o *packageMirrorResourcesOptions) preRunE(cmd *cobra.Command, args []string) error {
+	if err := o.packageVerifyFlags.preRunE(cmd, args); err != nil {
+		return err
+	}
 
 	// post flag validation - perform both if neither were set
 	if !o.mirrorImages && !o.mirrorRepos {
 		o.mirrorImages = true
 		o.mirrorRepos = true
 	}
+	return nil
 }
 
 func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (err error) {
@@ -598,7 +601,7 @@ func (o *packageMirrorResourcesOptions) run(cmd *cobra.Command, args []string) (
 	loadOpt := packager.LoadOptions{
 		Shasum:               o.shasum,
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Filter:               filter,
 		Architecture:         config.GetArch(),
 		OCIConcurrency:       o.ociConcurrency,
@@ -790,7 +793,7 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 		Long:    "Creates, templates, and outputs the values-files to be sent to each chart. Does not consider values files builtin to charts",
 		Example: lang.CmdPackageInspectValuesFilesExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(cmd, args)
 		},
@@ -833,7 +836,7 @@ func (o *packageInspectValuesFilesOptions) run(cmd *cobra.Command, args []string
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		LayerTypes:           []zoci.LayerType{zoci.ComponentLayers},
 		Filter:               filters.BySelectState(o.components),
 		OCIConcurrency:       o.ociConcurrency,
@@ -896,7 +899,7 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 		Short:   "Template and output all manifests and charts in a package",
 		Example: lang.CmdPackageInspectManifestsExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(cmd, args)
 		},
@@ -939,7 +942,7 @@ func (o *packageInspectManifestsOptions) run(cmd *cobra.Command, args []string) 
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		LayerTypes:           []zoci.LayerType{zoci.ComponentLayers},
 		Filter:               filters.BySelectState(o.components),
 		OCIConcurrency:       o.ociConcurrency,
@@ -1004,7 +1007,7 @@ func newPackageInspectSBOMCommand(v *viper.Viper) *cobra.Command {
 		Short:   "Output the package SBOM (Software Bill Of Materials) to the specified directory",
 		Example: lang.CmdPackageInspectSBOMExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1031,7 +1034,7 @@ func (o *packageInspectSBOMOptions) run(cmd *cobra.Command, args []string) (err 
 	loadOpts := packager.LoadOptions{
 		Architecture:         config.GetArch(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		LayerTypes:           []zoci.LayerType{zoci.SbomLayers},
 		Filter:               filters.Empty(),
 		OCIConcurrency:       o.ociConcurrency,
@@ -1078,7 +1081,7 @@ func newPackageInspectImagesCommand(v *viper.Viper) *cobra.Command {
 		Short:   "List all container images contained in the package",
 		Example: lang.CmdPackageInspectImagesExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1104,7 +1107,7 @@ func (o *packageInspectImagesOptions) run(cmd *cobra.Command, args []string) err
 	v := getViper()
 	cluster, _ := cluster.New(ctx) //nolint: errcheck // package source may or may not be a cluster
 	loadOpts := packager.LoadOptions{
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
@@ -1150,7 +1153,7 @@ func newPackageInspectDocumentationCommand(v *viper.Viper) *cobra.Command {
 		Short:   "Extract documentation files from the package",
 		Example: lang.CmdPackageInspectDocumentationExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1174,7 +1177,7 @@ func (o *packageInspectDocumentationOptions) run(cmd *cobra.Command, args []stri
 
 	v := getViper()
 	loadOpts := packager.LoadOptions{
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
@@ -1212,7 +1215,7 @@ func newPackageInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 		Short:   "Displays the 'zarf.yaml' definition for the specified package",
 		Example: lang.CmdPackageInspectDefinitionExample,
 		Args:    cobra.MaximumNArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1238,7 +1241,7 @@ func (o *packageInspectDefinitionOptions) run(cmd *cobra.Command, args []string)
 	v := getViper()
 	cluster, _ := cluster.New(ctx) //nolint: errcheck // package source may or may not be a cluster
 	loadOpts := packager.LoadOptions{
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Architecture:         config.GetArch(),
 		Filter:               filters.Empty(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
@@ -1384,7 +1387,7 @@ func newPackageRemoveCommand(v *viper.Viper) *cobra.Command {
 		Short:             lang.CmdPackageRemoveShort,
 		Long:              lang.CmdPackageRemoveLong,
 		Example:           lang.CmdPackageRemoveExample,
-		PreRun:            o.preRun,
+		PreRunE:           o.preRunE,
 		RunE:              o.run,
 		ValidArgsFunction: getPackageCompletionArgs,
 	}
@@ -1425,7 +1428,7 @@ func (o *packageRemoveOptions) run(cmd *cobra.Command, args []string) error {
 	v := getViper()
 	c, _ := cluster.New(ctx) //nolint:errcheck
 	loadOpts := packager.LoadOptions{
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		Architecture:         config.GetArch(),
 		Filter:               filter,
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
@@ -1488,7 +1491,7 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 		Short:   lang.CmdPackagePublishShort,
 		Example: lang.CmdPackagePublishExample,
 		Args:    cobra.ExactArgs(2),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1579,7 +1582,7 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Establish default stance
-	verificationStrategy := getVerificationStrategy(o.verify)
+	verificationStrategy := o.verify.toStrategy()
 
 	if helpers.IsOCIURL(packageSource) && o.signingKeyPath != "" {
 		l.Info("pulling source package locally to sign", "reference", packageSource)
@@ -1654,7 +1657,7 @@ func newPackagePullCommand(v *viper.Viper) *cobra.Command {
 		Short:   lang.CmdPackagePullShort,
 		Example: lang.CmdPackagePullExample,
 		Args:    cobra.ExactArgs(1),
-		PreRun:  o.preRun,
+		PreRunE: o.preRunE,
 		RunE:    o.run,
 	}
 
@@ -1685,7 +1688,7 @@ func (o *packagePullOptions) run(cmd *cobra.Command, args []string) error {
 	v := getViper()
 	packagePath, err := packager.Pull(ctx, srcURL, outputDir, packager.PullOptions{
 		SHASum:               o.shasum,
-		VerificationStrategy: getVerificationStrategy(o.verify),
+		VerificationStrategy: o.verify.toStrategy(),
 		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 		Architecture:         config.GetArch(),
 		OCIConcurrency:       o.ociConcurrency,
@@ -1741,7 +1744,9 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVarP(&o.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageSignFlagKey)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
-	cmd.Flags().BoolVar(&o.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
+	o.verify = verifyModeIfPossible
+	cmd.Flags().VarP(&o.verify, "verify", "", lang.CmdPackageFlagVerify)
+	cmd.Flags().Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 
 	cmd.Flags().BoolVar(&o.keyless, "keyless", v.GetBool(VPkgSignKeyless), lang.CmdPackageSignFlagKeyless)
 	cmd.Flags().StringVar(&o.identityToken, "identity-token", v.GetString(VPkgSignIdentityToken), lang.CmdPackageSignFlagIdentityToken)
@@ -1828,7 +1833,7 @@ func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 
 	// To prevent a warning for package not being signed - we'll only run verification when enforced
 	if signed {
-		if o.verify {
+		if o.verify == verifyModeAlways {
 			verifyOpts := o.buildVerifyBlobOptions(cmd, getViper())
 			err = pkgLayout.VerifyPackageSignature(ctx, *verifyOpts)
 			if err != nil {
@@ -2044,11 +2049,47 @@ func getPackageCompletionArgs(cmd *cobra.Command, _ []string, _ string) ([]strin
 	return pkgCandidates, cobra.ShellCompDirectiveDefault
 }
 
-func getVerificationStrategy(verify bool) layout.VerificationStrategy {
-	if verify {
-		return layout.VerifyAlways
+// verifyMode is the value type for the --verify flag.
+type verifyMode string
+
+const (
+	verifyModeNever      verifyMode = "never"
+	verifyModeIfPossible verifyMode = "if-possible"
+	verifyModeAlways     verifyMode = "always"
+)
+
+// Set implements pflag.Value. Accepts the three canonical values and legacy bool strings.
+func (m *verifyMode) Set(s string) error {
+	switch verifyMode(s) {
+	case verifyModeNever, verifyModeIfPossible, verifyModeAlways:
+		*m = verifyMode(s)
+	// Accept legacy bool values from viper configs written before the enum was introduced.
+	case "true":
+		*m = verifyModeAlways
+	case "false":
+		*m = verifyModeIfPossible
+	default:
+		return fmt.Errorf("invalid --verify value %q (must be never, if-possible, or always)", s)
 	}
-	return layout.VerifyIfPossible
+	return nil
+}
+
+// String implements pflag.Value.
+func (m verifyMode) String() string { return string(m) }
+
+// Type implements pflag.Value.
+func (m verifyMode) Type() string { return "verifyMode" }
+
+// toStrategy converts the flag value to the layout.VerificationStrategy used internally.
+func (m verifyMode) toStrategy() layout.VerificationStrategy {
+	switch m {
+	case verifyModeNever:
+		return layout.VerifyNever
+	case verifyModeAlways:
+		return layout.VerifyAlways
+	default:
+		return layout.VerifyIfPossible
+	}
 }
 
 // newKeylessVerifyFlagSet creates a pflag.FlagSet containing only the 7 keyless
@@ -2086,11 +2127,12 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("verify", pflag.ContinueOnError)
 
 	fs.StringVarP(&f.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
-	fs.BoolVar(&f.verify, "verify", v.GetBool(VPkgVerify), lang.CmdPackageFlagVerify)
+	f.verify = verifyModeIfPossible
+	fs.VarP(&f.verify, "verify", "", lang.CmdPackageFlagVerify)
+	fs.Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 	fs.BoolVar(&f.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 	_ = fs.MarkDeprecated("skip-signature-validation",
-		"Signature verification now occurs on every execution, but is not enforced by default. "+
-			"Use --verify to enforce validation. This flag will be removed in Zarf v1.0.0.")
+		"Use --verify=never to skip signature validation. This flag will be removed in Zarf v1.0.0.")
 
 	fs.AddFlagSet(newKeylessVerifyFlagSet(v, f))
 	return fs
@@ -2144,14 +2186,25 @@ func (f *packageVerifyFlags) buildVerifyBlobOptions(cmd *cobra.Command, v *viper
 	return &opts
 }
 
-// preRun is the cobra PreRun handler for commands that embed packageVerifyFlags.
+// preRunE is the cobra PreRunE handler for commands that embed packageVerifyFlags.
 // It is promoted to embedding structs automatically, so no per-command wrapper is needed.
-func (f *packageVerifyFlags) preRun(cmd *cobra.Command, _ []string) {
-	if cmd.Flags().Changed("skip-signature-validation") {
-		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. " +
-			"Use --verify to enforce signature validation.")
-		if !cmd.Flags().Changed("verify") {
-			f.verify = !f.skipSignatureValidation
+func (f *packageVerifyFlags) preRunE(cmd *cobra.Command, _ []string) error {
+	v := getViper()
+	// Apply viper default for --verify when the flag was not set on the CLI.
+	// Accepts legacy bool values ("true"/"false") from existing configs.
+	if !cmd.Flags().Changed("verify") && v.IsSet(VPkgVerify) {
+		if err := f.verify.Set(v.GetString(VPkgVerify)); err != nil {
+			return fmt.Errorf("invalid package.verify config value %q: %w", v.GetString(VPkgVerify), err)
 		}
 	}
+	if cmd.Flags().Changed("skip-signature-validation") {
+		logger.Default().Warn("--skip-signature-validation is deprecated and will be removed in v1.0.0. " +
+			"Use --verify=never to skip signature validation.")
+		if !cmd.Flags().Changed("verify") {
+			if f.skipSignatureValidation {
+				f.verify = verifyModeNever
+			}
+		}
+	}
+	return nil
 }

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1764,6 +1764,7 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	o.verify = verifyModeIfPossible
 	cmd.Flags().VarP(&o.verify, "verify", "", lang.CmdPackageFlagVerify)
+	cmd.Flags().Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 
 	cmd.Flags().BoolVar(&o.keyless, "keyless", v.GetBool(VPkgSignKeyless), lang.CmdPackageSignFlagKeyless)
 	cmd.Flags().StringVar(&o.identityToken, "identity-token", v.GetString(VPkgSignIdentityToken), lang.CmdPackageSignFlagIdentityToken)
@@ -2151,6 +2152,7 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 	fs.StringVarP(&f.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	f.verify = verifyModeIfPossible
 	fs.VarP(&f.verify, "verify", "", lang.CmdPackageFlagVerify)
+	fs.Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 	fs.BoolVar(&f.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 	_ = fs.MarkDeprecated("skip-signature-validation",
 		"Use --verify=never to skip signature validation. This flag will be removed in Zarf v1.0.0.")

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1764,7 +1764,6 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	o.verify = verifyModeIfPossible
 	cmd.Flags().VarP(&o.verify, "verify", "", lang.CmdPackageFlagVerify)
-	cmd.Flags().Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 
 	cmd.Flags().BoolVar(&o.keyless, "keyless", v.GetBool(VPkgSignKeyless), lang.CmdPackageSignFlagKeyless)
 	cmd.Flags().StringVar(&o.identityToken, "identity-token", v.GetString(VPkgSignIdentityToken), lang.CmdPackageSignFlagIdentityToken)
@@ -2152,7 +2151,6 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 	fs.StringVarP(&f.publicKeyPath, "key", "k", v.GetString(VPkgPublicKey), lang.CmdPackageFlagFlagPublicKey)
 	f.verify = verifyModeIfPossible
 	fs.VarP(&f.verify, "verify", "", lang.CmdPackageFlagVerify)
-	fs.Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 	fs.BoolVar(&f.skipSignatureValidation, "skip-signature-validation", false, lang.CmdPackageFlagSkipSignatureValidation)
 	_ = fs.MarkDeprecated("skip-signature-validation",
 		"Use --verify=never to skip signature validation. This flag will be removed in Zarf v1.0.0.")

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -224,7 +224,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdPackageShort                       = "Zarf package commands for creating, deploying, and inspecting packages"
 	CmdPackageFlagConcurrency             = "Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries."
 	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
-	CmdPackageFlagVerify                  = "Signature verification mode: never, if-possible (default; tampered signatures always fail), or always. Bare --verify means always."
+	CmdPackageFlagVerify                  = "Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never."
 	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Use --verify=never instead. This flag will be removed in Zarf v1.0.0."
 	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes"
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -224,7 +224,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdPackageShort                       = "Zarf package commands for creating, deploying, and inspecting packages"
 	CmdPackageFlagConcurrency             = "Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries."
 	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
-	CmdPackageFlagVerify                  = "Signature verification mode (never|if-possible|always)."
+	CmdPackageFlagVerify                  = "Signature verification mode (always|if-possible|never)."
 	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Skip validating the signature of the Zarf package. Use --verify=never instead."
 	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes"
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -224,8 +224,8 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdPackageShort                       = "Zarf package commands for creating, deploying, and inspecting packages"
 	CmdPackageFlagConcurrency             = "Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries."
 	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
-	CmdPackageFlagVerify                  = "Verify the Zarf package signature"
-	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Skip validating the signature of the Zarf package"
+	CmdPackageFlagVerify                  = "Signature verification mode: never, if-possible (default; tampered signatures always fail), or always. Bare --verify means always."
+	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Use --verify=never instead. This flag will be removed in Zarf v1.0.0."
 	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes"
 
 	CmdPackageCreateShort = "Creates a Zarf package from a given directory or the current directory"

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -224,8 +224,8 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdPackageShort                       = "Zarf package commands for creating, deploying, and inspecting packages"
 	CmdPackageFlagConcurrency             = "Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries."
 	CmdPackageFlagFlagPublicKey           = "Path to public key file for validating signed packages"
-	CmdPackageFlagVerify                  = "Signature verification mode (never|if-possible|always). Tampered signatures are always fatal except with never."
-	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Use --verify=never instead. This flag will be removed in Zarf v1.0.0."
+	CmdPackageFlagVerify                  = "Signature verification mode (never|if-possible|always)."
+	CmdPackageFlagSkipSignatureValidation = "[Deprecated] Skip validating the signature of the Zarf package. Use --verify=never instead."
 	CmdPackageFlagRetries                 = "Number of retries to perform for Zarf operations like git/image pushes"
 
 	CmdPackageCreateShort = "Creates a Zarf package from a given directory or the current directory"

--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -67,6 +67,10 @@ const (
 	VerifyNever
 )
 
+// ErrNoVerificationMaterial is returned when there is nothing to verify against.
+// VerifyIfPossible tolerates this; all other verification errors are always fatal.
+var ErrNoVerificationMaterial = errors.New("no verification material available")
+
 // DirPath returns base directory of the package layout
 func (p *PackageLayout) DirPath() string {
 	return p.dirPath
@@ -137,15 +141,17 @@ func LoadFromDir(ctx context.Context, dirPath string, opts PackageLayoutOptions)
 		opts.VerifyBlobOptions = &defaults
 	}
 
-	if opts.VerificationStrategy < VerifyNever {
+	if opts.VerificationStrategy != VerifyNever {
 		verifyOptions := signing.DefaultVerifyBlobOptions()
 		if opts.VerifyBlobOptions != nil {
 			verifyOptions = *opts.VerifyBlobOptions
 		}
 		err = pkgLayout.VerifyPackageSignature(ctx, verifyOptions)
 		if err != nil {
-			if opts.VerificationStrategy == VerifyIfPossible {
-				l.Warn("package signature could not be verified:", "error", err.Error())
+			// VerifyIfPossible tolerates only "nothing to verify against".
+			// Tampered signatures and unsigned-with-material are always fatal.
+			if opts.VerificationStrategy == VerifyIfPossible && errors.Is(err, ErrNoVerificationMaterial) {
+				l.Warn("package signature not verified; continuing", "reason", err.Error())
 				return pkgLayout, nil
 			}
 			return nil, fmt.Errorf("signature verification failed: %w", err)
@@ -389,9 +395,10 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 	// Handle the case where the package is not signed
 	if !p.IsSigned() {
 		if hasVerificationMaterial {
+			// Providing material implies expecting a signature — always fatal.
 			return errors.New("verification material was provided but the package is not signed")
 		}
-		return errors.New("package is not signed - verification cannot be performed")
+		return fmt.Errorf("package is not signed - verification cannot be performed: %w", ErrNoVerificationMaterial)
 	}
 
 	// Check for bundle format signature (preferred). Parse it once for both method
@@ -405,17 +412,17 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 		switch bundleInfo.Method {
 		case signing.SigningMethodKeyless:
 			if !hasKeylessIdentity && !hasCert {
-				return errors.New("package was signed with keyless method; provide --certificate-identity + --certificate-oidc-issuer to verify")
+				return fmt.Errorf("package was signed with keyless method; provide --certificate-identity + --certificate-oidc-issuer to verify: %w", ErrNoVerificationMaterial)
 			}
 		case signing.SigningMethodKey:
 			if !hasKey && !hasCert {
-				return errors.New("package was signed with a key; provide --key to verify")
+				return fmt.Errorf("package was signed with a key; provide --key to verify: %w", ErrNoVerificationMaterial)
 			}
 		}
 	}
 
 	if !hasVerificationMaterial {
-		return errors.New("package is signed but no verification material was provided (--key, --certificate-identity + --certificate-oidc-issuer)")
+		return fmt.Errorf("package is signed but no verification material was provided (--key, --certificate-identity + --certificate-oidc-issuer): %w", ErrNoVerificationMaterial)
 	}
 
 	if hasBundleInfo {

--- a/src/pkg/packager/layout/package_test.go
+++ b/src/pkg/packager/layout/package_test.go
@@ -887,7 +887,8 @@ func TestPackageLayoutVerifyPackageSignature(t *testing.T) {
 		verifyOpts.Key = "" // Empty key
 
 		err = pkgLayout.VerifyPackageSignature(ctx, verifyOpts)
-		require.EqualError(t, err, "package was signed with a key; provide --key to verify")
+		require.ErrorIs(t, err, ErrNoVerificationMaterial)
+		require.Contains(t, err.Error(), "package was signed with a key; provide --key to verify")
 	})
 
 	t.Run("verification fails when signature is corrupted", func(t *testing.T) {
@@ -1434,7 +1435,7 @@ func TestLoadFromDir_VerificationStrategies(t *testing.T) {
 		require.Equal(t, "test-verification", pkgLayout.Pkg.Metadata.Name)
 	})
 
-	t.Run("VerifyIfPossible with signed package and wrong key warns but continues", func(t *testing.T) {
+	t.Run("VerifyIfPossible with signed package and wrong key fails", func(t *testing.T) {
 		pkgDir, _ := setupTestPackage(t, true)
 
 		opts := PackageLayoutOptions{
@@ -1442,13 +1443,14 @@ func TestLoadFromDir_VerificationStrategies(t *testing.T) {
 			VerifyBlobOptions:    verifyOptsFromKey("./testdata/nonexistent.pub"),
 		}
 
-		// Should warn but not fail
+		// Signed package + verification failure = always fatal, even under VerifyIfPossible.
 		pkgLayout, err := LoadFromDir(ctx, pkgDir, opts)
-		require.NoError(t, err)
-		require.NotNil(t, pkgLayout)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
+		require.Nil(t, pkgLayout)
 	})
 
-	t.Run("VerifyIfPossible with unsigned package warns but continues", func(t *testing.T) {
+	t.Run("VerifyIfPossible with unsigned package and material provided fails", func(t *testing.T) {
 		pkgDir, _ := setupTestPackage(t, false)
 
 		opts := PackageLayoutOptions{
@@ -1456,10 +1458,47 @@ func TestLoadFromDir_VerificationStrategies(t *testing.T) {
 			VerifyBlobOptions:    verifyOptsFromKey("./testdata/cosign.pub"),
 		}
 
-		// Should warn about unsigned package but not fail
+		// Providing a key against an unsigned package implies an expectation of a signature — always fatal.
+		pkgLayout, err := LoadFromDir(ctx, pkgDir, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
+		require.Nil(t, pkgLayout)
+	})
+
+	t.Run("VerifyIfPossible with unsigned package and no material warns but continues", func(t *testing.T) {
+		pkgDir, _ := setupTestPackage(t, false)
+
+		opts := PackageLayoutOptions{
+			VerificationStrategy: VerifyIfPossible,
+		}
+
+		// Unsigned package with no material = nothing to verify; tolerated under VerifyIfPossible.
 		pkgLayout, err := LoadFromDir(ctx, pkgDir, opts)
 		require.NoError(t, err)
 		require.NotNil(t, pkgLayout)
+	})
+
+	// Regression test for zarf-dev/zarf#4909: a tampered signature must always fail,
+	// even under the default VerifyIfPossible strategy.
+	t.Run("VerifyIfPossible with signed package and tampered zarf.yaml fails", func(t *testing.T) {
+		pkgDir, pubKeyPath := setupTestPackage(t, true)
+
+		// Tamper the signed artifact after signing: append a comment to keep the YAML
+		// parseable while changing the raw bytes so the cosign signature no longer matches.
+		yamlPath := filepath.Join(pkgDir, ZarfYAML)
+		original, err := os.ReadFile(yamlPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(yamlPath, append(original, []byte("\n# tampered\n")...), 0o644))
+
+		opts := PackageLayoutOptions{
+			VerificationStrategy: VerifyIfPossible,
+			VerifyBlobOptions:    verifyOptsFromKey(pubKeyPath),
+		}
+
+		pkgLayout, err := LoadFromDir(ctx, pkgDir, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
+		require.Nil(t, pkgLayout)
 	})
 
 	t.Run("VerifyAlways with signed package and valid key succeeds", func(t *testing.T) {
@@ -1580,13 +1619,29 @@ func TestLoadFromTar_VerificationStrategies(t *testing.T) {
 		require.Equal(t, "test", pkgLayout.Pkg.Metadata.Name)
 	})
 
-	t.Run("VerifyIfPossible warns but continues on unsigned tarball", func(t *testing.T) {
+	t.Run("VerifyIfPossible with unsigned tarball and material provided fails", func(t *testing.T) {
 		opts := PackageLayoutOptions{
 			VerificationStrategy: VerifyIfPossible,
 			VerifyBlobOptions:    verifyOptsFromKey("./testdata/cosign.pub"),
 		}
 
-		// Should succeed with warning since package is unsigned
+		// Providing a key against an unsigned package is always fatal.
+		pkgLayout, err := LoadFromTar(ctx, tarPath, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
+		if pkgLayout != nil {
+			t.Cleanup(func() {
+				require.NoError(t, pkgLayout.Cleanup())
+			})
+		}
+	})
+
+	t.Run("VerifyIfPossible with unsigned tarball and no material warns but continues", func(t *testing.T) {
+		opts := PackageLayoutOptions{
+			VerificationStrategy: VerifyIfPossible,
+		}
+
+		// Unsigned package with no material = nothing to verify; tolerated under VerifyIfPossible.
 		pkgLayout, err := LoadFromTar(ctx, tarPath, opts)
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -82,15 +82,24 @@ func TestLoadPackage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "test", pkgLayout.Pkg.Metadata.Name)
 
-		// VerifyIfPossible should warn but continue on unsigned package
+		// VerifyIfPossible with no material should warn but continue on unsigned package
 		opt = LoadOptions{
 			VerificationStrategy: layout.VerifyIfPossible,
-			VerifyBlobOptions:    &verifyOpts,
 			Filter:               filters.Empty(),
 		}
 		pkgLayout, err = LoadPackage(ctx, tarPath, opt)
 		require.NoError(t, err)
 		require.Equal(t, "test", pkgLayout.Pkg.Metadata.Name)
+
+		// VerifyIfPossible with a key against an unsigned package is always fatal
+		opt = LoadOptions{
+			VerificationStrategy: layout.VerifyIfPossible,
+			VerifyBlobOptions:    &verifyOpts,
+			Filter:               filters.Empty(),
+		}
+		_, err = LoadPackage(ctx, tarPath, opt)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
 
 		// VerifyAlways should fail on unsigned package
 		opt = LoadOptions{

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -50,7 +50,7 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 
 	simplePackageRef := fmt.Sprintf("oci://%s/simple-package:0.0.1", ref)
 	// fail to pull the package without providing the public key
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "--verify")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "--verify=always")
 	suite.Error(err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", publicKeyFlag, "-o", outputPath)
@@ -59,7 +59,7 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "-o", outputPath)
 	suite.NoError(err, stdOut, stdErr)
 
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", simplePackageRef, "--plain-http", "--verify")
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", simplePackageRef, "--plain-http", "--verify=always")
 	suite.Error(err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "sbom", simplePackageRef, "--plain-http", publicKeyFlag, "--output", suite.T().TempDir())

--- a/src/test/e2e/31_checksum_and_signature_test.go
+++ b/src/test/e2e/31_checksum_and_signature_test.go
@@ -41,7 +41,7 @@ func TestChecksumAndSignature(t *testing.T) {
 
 	/* Test operations during package deploy */
 	// Test that we get an error when trying to deploy a package without providing the public key
-	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, "--verify", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgName, "--verify=always", "--confirm")
 	require.Error(t, err, stdOut, stdErr)
 	require.Contains(t, stdErr, "package was signed with a key; provide --key to verify")
 

--- a/src/test/e2e/34_custom_init_package_test.go
+++ b/src/test/e2e/34_custom_init_package_test.go
@@ -36,7 +36,7 @@ func TestCustomInit(t *testing.T) {
 
 	/* Test operations during package deploy */
 	// Test that we get an error when trying to deploy a package without providing the public key
-	stdOut, stdErr, err = e2e.Zarf(t, "init", "--verify", "--confirm")
+	stdOut, stdErr, err = e2e.Zarf(t, "init", "--verify=always", "--confirm")
 	require.Error(t, err, stdOut, stdErr)
 	require.Contains(t, stdErr, "package was signed with a key; provide --key to verify")
 


### PR DESCRIPTION
## Description

This PR fixes two behaviors around Zarf signature verification:
1. On the CLI - `--verify` is now an enum representing `Verification Strategy`. The allowed options are `always|if-possible|never` with `if-possible` being the default. We retained the use of booleans for backwards compatibility.
2. Changes the verification behavior - A signed package that is provided verification material but for which the verification fails is now (correctly) an error. Additionally providing key material to the verification workflow for an unsigned package likely indicates intent to verify and is now a failure - this protects against signature stripping attacks. 

Behaviorally this is a breaking change but more of a correction. The `--verify` CLI flag is also being updated from a boolean to an enum but currently has backwards compatibility. I think this can go either way for being a true breaking change or doing so when the boolean optionality is removed.

## Related Issue

Fixes #4909

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
