### PR TITLE
feat(ci): add zizmor static analysis for Actions/workflows

### DIFF
--- a/.github/workflows/scan-zizmor.yml
+++ b/.github/workflows/scan-zizmor.yml
@@ -1,0 +1,49 @@
+name: Validate Zizmor
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: ["main"]
+  schedule:
+    # Weekly, Monday 04:27 UTC. Off the :00 mark and clear of the other
+    # scheduled scans (CodeQL Fri 02:32, Scorecard Sat 01:30).
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Upload SARIF to the code-scanning dashboard (push / schedule only).
+      security-events: write
+      # zizmor's online audits read workflow/action metadata via the API.
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Advisory for now: zizmor reports findings but does not fail the build.
+      # The repo currently has a backlog of findings that are being remediated
+      # in severity-ordered follow-up PRs (see zarf-dev/zarf#4849). Once that
+      # backlog is cleared, drop `continue-on-error` so this becomes a gate.
+      - name: Run zizmor (advisory)
+        run: pipx run zizmor==1.26.1 --format sarif .github/ > zizmor.sarif
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Skip on pull_request: forked-PR tokens are read-only and cannot write
+      # security events, which would fail the upload. The dashboard stays
+      # current via push-to-main and the weekly schedule (mirrors scorecard.yaml).
+      - name: Upload SARIF to code scanning
+        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/workflows/test-import.yaml
+++ b/.github/workflows/test-import.yaml
@@ -27,12 +27,13 @@ jobs:
           cd $(mktemp -d)
           echo "$GO_MAIN" > main.go
           go mod init github.com/zarf-dev/test-import
-          go mod edit -replace github.com/zarf-dev/zarf=github.com/${{ github.event.pull_request.head.repo.full_name }}@${COMMIT_SHA:0:12}
+          go mod edit -replace github.com/zarf-dev/zarf=github.com/${HEAD_REPO}@${COMMIT_SHA:0:12}
           go mod tidy
           cat go.mod | grep -q ${COMMIT_SHA:0:12}
           go run main.go
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GO_MAIN: |
             package main
 


### PR DESCRIPTION
Closes #4849

## What

Integrates [zizmor](https://github.com/zizmorcore/zizmor) as static analysis for GitHub Actions and workflows, giving the project a deterministic source of truth for new supply-chain/CI findings — both on change and on a periodic schedule, as the issue requested.

### `.github/workflows/scan-zizmor.yml` (new)
- Follows the existing `scan-*.yml` convention: triggers on `pull_request`, `merge_group`, `push` to `main`, and a **weekly** schedule (Mon 04:27 UTC, clear of the CodeQL/Scorecard slots).
- Uploads SARIF to the **code-scanning dashboard** on `push`/`schedule`. Upload is skipped on `pull_request` because forked-PR tokens are read-only and cannot write security events — the same reason `scorecard.yaml` avoids `pull_request`. The dashboard stays current via push-to-main and the weekly run.
- zizmor is pinned to **v1.26.1** (run via `pipx run`), mirroring how `scan-lint.yml` pins golangci-lint by version. No new third-party action is introduced — it reuses the `actions/checkout` and `github/codeql-action/upload-sarif` SHAs already in the repo.
- **Advisory for now** (`continue-on-error`): see below.

### `test-import.yaml` (fix)
Remediates the one genuinely **attacker-controllable** finding so it doesn't land in the dashboard backlog: the workflow interpolated `github.event.pull_request.head.repo.full_name` (a forked-PR repo name) directly into a `run:` block (`template-injection`, High/High). Moved it into the existing `env:` block as `HEAD_REPO` and referenced it as a shell variable — the exact indirection the file already uses for `COMMIT_SHA`. Behavior is unchanged.

## Why advisory first

The maintainer asked to remediate findings **highest-severity-first across multiple PRs**, and noted: _"once the current findings are remediated then I think CI makes a good case."_

A baseline run (zizmor v1.26.1, `.github/`) surfaces **12 remaining High** findings after this PR's fix — several in **release-critical** workflows:

| Audit | Count | Notes |
|---|---|---|
| `template-injection` | 6 | `inputs.*` / `github.actor` in `nightly-eks.yml`, `nightly-release.yaml`, `release.yml`, `packages/action.yaml` — safe env-indirection fixes |
| `github-app` | 2 | `release-please.yml`, `release.yml` — `create-github-app-token` w/o scoped `permission-*`; the second scopes a **cross-repo** `homebrew-tap` token used by GoReleaser (only verifiable at release time) |
| `cache-poisoning` | 4 | Low **confidence**; `setup-go` caching in release/publish workflows |

(plus ~38 Medium and 1 Low, mostly `artipacked`/`excessive-permissions`).

Rather than land a large, release-risky diff in one go, this PR establishes the scanner + dashboard now and **does not block merges**. The remaining findings are visible in code scanning and will be remediated in **severity-ordered follow-up PRs**, each with reasoning about impact. Once the backlog is cleared, dropping `continue-on-error` from the run step turns this into a merge gate.

## Verification

Run locally with the same pinned version:

```bash
pipx run zizmor==1.26.1 .github/                       # full report
pipx run zizmor==1.26.1 --format sarif .github/ > z.sarif   # SARIF (valid 2.1.0)
```

- `scan-zizmor.yml` is itself clean under zizmor (sets `persist-credentials: false`).
- `test-import.yaml` no longer reports `template-injection`; the `go.mod` replace directive expands to the identical string.