### PR TITLE
chore: fix error message typo in packager load identifySource

### DIFF
--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -203,7 +203,7 @@ func identifySource(src string) (string, error) {
 	if state.DeployedPackageNameRegex(src) {
 		return "cluster", nil
 	}
-	return "", fmt.Errorf("unknown source %s. Did you for get the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
+	return "", fmt.Errorf("unknown source %s. Did you forget the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
 }
 
 // GetPackageFromSourceOrCluster retrieves a Zarf package from a source or cluster.


### PR DESCRIPTION
## Description

Small typo fix for error message in `src/pkg/packager/load.go` `identifySource()`:

"for get" -> "forget"

## Related Issue
n/a

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
