### PR TITLE
chore(deps): introduce 7 day cooldown period for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
       - "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     groups:
       k8s:
         patterns:
@@ -26,10 +28,14 @@ updates:
           - "actions/*"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     ignore:
       # NOTE(mkcp): 09/08/25 These packages were compromised as part of a supply chain attack. Zarf was not affected and
       # many of the packages have been removed, but we are intentionally ignoring these versions as an extra layer of


### PR DESCRIPTION
## Description
As discussed in various places, we want to introduce a cooldown period to ensure we don't pull dependencies sooner than necessary. This also matches our previous cadence on dependency merges, so this only makes it more official.

## Related Issue

None

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
