### PR TITLE
fix(flags): depecate --zarf-cache in favor of just --cache

### DIFF
--- a/site/src/content/docs/commands/zarf.md
+++ b/site/src/content/docs/commands/zarf.md
@@ -23,6 +23,7 @@ zarf COMMAND [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
   -h, --help                       help for zarf
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
@@ -31,7 +32,6 @@ zarf COMMAND [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion.md
+++ b/site/src/content/docs/commands/zarf_completion.md
@@ -26,6 +26,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -33,7 +34,6 @@ See each sub-command's help for details on how to use the generated script.
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_bash.md
+++ b/site/src/content/docs/commands/zarf_completion_bash.md
@@ -49,6 +49,7 @@ zarf completion bash
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -56,7 +57,6 @@ zarf completion bash
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_fish.md
+++ b/site/src/content/docs/commands/zarf_completion_fish.md
@@ -40,6 +40,7 @@ zarf completion fish [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -47,7 +48,6 @@ zarf completion fish [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_powershell.md
+++ b/site/src/content/docs/commands/zarf_completion_powershell.md
@@ -37,6 +37,7 @@ zarf completion powershell [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -44,7 +45,6 @@ zarf completion powershell [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_completion_zsh.md
+++ b/site/src/content/docs/commands/zarf_completion_zsh.md
@@ -51,6 +51,7 @@ zarf completion zsh [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -58,7 +59,6 @@ zarf completion zsh [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_connect.md
+++ b/site/src/content/docs/commands/zarf_connect.md
@@ -35,6 +35,7 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -42,7 +43,6 @@ zarf connect { REGISTRY | GIT | connect-name } [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_connect_list.md
+++ b/site/src/content/docs/commands/zarf_connect_list.md
@@ -24,6 +24,7 @@ zarf connect list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -31,7 +32,6 @@ zarf connect list [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_connect_resource.md
+++ b/site/src/content/docs/commands/zarf_connect_resource.md
@@ -41,6 +41,7 @@ zarf connect resource [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -48,7 +49,6 @@ zarf connect resource [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_destroy.md
+++ b/site/src/content/docs/commands/zarf_destroy.md
@@ -36,6 +36,7 @@ zarf destroy --confirm [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -43,7 +44,6 @@ zarf destroy --confirm [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev.md
+++ b/site/src/content/docs/commands/zarf_dev.md
@@ -20,6 +20,7 @@ Commands useful for developing packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Commands useful for developing packages
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -38,6 +38,7 @@ zarf dev deploy [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -45,7 +46,6 @@ zarf dev deploy [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -41,6 +41,7 @@ zarf dev find-images [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -48,7 +49,6 @@ zarf dev find-images [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_generate-config.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-config.md
@@ -33,6 +33,7 @@ zarf dev generate-config [ FILENAME ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -40,7 +41,6 @@ zarf dev generate-config [ FILENAME ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_generate-schema.md
+++ b/site/src/content/docs/commands/zarf_dev_generate-schema.md
@@ -28,6 +28,7 @@ zarf dev generate-schema [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -35,7 +36,6 @@ zarf dev generate-schema [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_generate.md
+++ b/site/src/content/docs/commands/zarf_dev_generate.md
@@ -35,6 +35,7 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -42,7 +43,6 @@ zarf dev generate podinfo --url https://github.com/stefanprodan/podinfo.git --ve
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_inspect.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect.md
@@ -20,6 +20,7 @@ Commands to gather information about a Zarf package using its package definition
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Commands to gather information about a Zarf package using its package definition
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_definition.md
@@ -30,6 +30,7 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -37,7 +38,6 @@ zarf dev inspect definition [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_manifests.md
@@ -30,6 +30,7 @@ zarf dev inspect manifests [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -37,7 +38,6 @@ zarf dev inspect manifests [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_dev_inspect_values-files.md
@@ -34,6 +34,7 @@ zarf dev inspect values-files [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -41,7 +42,6 @@ zarf dev inspect values-files [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_lint.md
+++ b/site/src/content/docs/commands/zarf_dev_lint.md
@@ -30,6 +30,7 @@ zarf dev lint [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -37,7 +38,6 @@ zarf dev lint [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_patch-git.md
+++ b/site/src/content/docs/commands/zarf_dev_patch-git.md
@@ -26,6 +26,7 @@ zarf dev patch-git HOST FILE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -33,7 +34,6 @@ zarf dev patch-git HOST FILE [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_dev_sha256sum.md
+++ b/site/src/content/docs/commands/zarf_dev_sha256sum.md
@@ -25,6 +25,7 @@ zarf dev sha256sum { FILE | URL } [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -32,7 +33,6 @@ zarf dev sha256sum { FILE | URL } [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -106,6 +106,7 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -113,7 +114,6 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -20,6 +20,7 @@ Zarf package commands for creating, deploying, and inspecting packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Zarf package commands for creating, deploying, and inspecting packages
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_create.md
+++ b/site/src/content/docs/commands/zarf_package_create.md
@@ -44,6 +44,7 @@ zarf package create [ DIRECTORY ] [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -51,7 +52,6 @@ zarf package create [ DIRECTORY ] [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -69,6 +69,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -76,7 +77,6 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect.md
+++ b/site/src/content/docs/commands/zarf_package_inspect.md
@@ -24,6 +24,7 @@ zarf package inspect [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -31,7 +32,6 @@ zarf package inspect [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -50,6 +50,7 @@ $ zarf package inspect definition my-package
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -57,7 +58,6 @@ $ zarf package inspect definition my-package
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_digest.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_digest.md
@@ -44,6 +44,7 @@ $ zarf package inspect digest my-package
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -51,7 +52,6 @@ $ zarf package inspect digest my-package
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -48,6 +48,7 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -55,7 +56,6 @@ $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -50,6 +50,7 @@ $ zarf package inspect images my-package
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -57,7 +58,6 @@ $ zarf package inspect images my-package
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -51,6 +51,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -58,7 +59,6 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -47,6 +47,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -54,7 +55,6 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -55,6 +55,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -62,7 +63,6 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -25,6 +25,7 @@ zarf package list [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -32,7 +33,6 @@ zarf package list [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -85,6 +85,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -92,7 +93,6 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -59,6 +59,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -66,7 +67,6 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_pull.md
+++ b/site/src/content/docs/commands/zarf_package_pull.md
@@ -50,6 +50,7 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -57,7 +58,6 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -58,6 +58,7 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -65,7 +66,6 @@ $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_sign.md
+++ b/site/src/content/docs/commands/zarf_package_sign.md
@@ -74,6 +74,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -81,7 +82,6 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_package_verify.md
+++ b/site/src/content/docs/commands/zarf_package_verify.md
@@ -52,6 +52,7 @@ $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -59,7 +60,6 @@ $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_say.md
+++ b/site/src/content/docs/commands/zarf_say.md
@@ -28,6 +28,7 @@ zarf say [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -35,7 +36,6 @@ zarf say [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools.md
+++ b/site/src/content/docs/commands/zarf_tools.md
@@ -20,6 +20,7 @@ Collection of additional tools to make airgap easier
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Collection of additional tools to make airgap easier
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver.md
@@ -20,6 +20,7 @@ Compresses/Decompresses generic archives, including Zarf packages
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Compresses/Decompresses generic archives, including Zarf packages
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_compress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_compress.md
@@ -24,6 +24,7 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -31,7 +32,6 @@ zarf tools archiver compress SOURCES ARCHIVE [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_decompress.md
@@ -25,6 +25,7 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -32,7 +33,6 @@ zarf tools archiver decompress ARCHIVE DESTINATION [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_archiver_version.md
+++ b/site/src/content/docs/commands/zarf_tools_archiver_version.md
@@ -24,6 +24,7 @@ zarf tools archiver version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -31,7 +32,6 @@ zarf tools archiver version [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_clear-cache.md
+++ b/site/src/content/docs/commands/zarf_tools_clear-cache.md
@@ -17,14 +17,14 @@ zarf tools clear-cache [flags]
 ### Options
 
 ```
-  -h, --help                help for clear-cache
-      --zarf-cache string   Specify the location of the Zarf artifact cache (images and git repositories) (default "~/.zarf-cache")
+  -h, --help   help for clear-cache
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")

--- a/site/src/content/docs/commands/zarf_tools_download-init.md
+++ b/site/src/content/docs/commands/zarf_tools_download-init.md
@@ -26,6 +26,7 @@ zarf tools download-init [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -33,7 +34,6 @@ zarf tools download-init [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_gen-key.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-key.md
@@ -24,6 +24,7 @@ zarf tools gen-key [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -31,7 +32,6 @@ zarf tools gen-key [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_gen-pki.md
+++ b/site/src/content/docs/commands/zarf_tools_gen-pki.md
@@ -38,6 +38,7 @@ zarf tools gen-pki HOST [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -45,7 +46,6 @@ zarf tools gen-pki HOST [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_get-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_get-creds.md
@@ -45,6 +45,7 @@ $ zarf tools get-creds artifact
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -52,7 +53,6 @@ $ zarf tools get-creds artifact
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_helm.md
+++ b/site/src/content/docs/commands/zarf_tools_helm.md
@@ -99,6 +99,7 @@ zarf tools helm [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_kubectl.md
+++ b/site/src/content/docs/commands/zarf_tools_kubectl.md
@@ -55,6 +55,7 @@ zarf tools kubectl [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string              Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString   Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --plain-http                Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_monitor.md
+++ b/site/src/content/docs/commands/zarf_tools_monitor.md
@@ -49,6 +49,7 @@ zarf tools monitor [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string              Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString   Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --plain-http                Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -23,6 +23,7 @@ Tools for working with container registries using go-containertools
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -37,6 +37,7 @@ $ zarf tools registry catalog reg.example.com
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -27,6 +27,7 @@ zarf tools registry copy SRC DST [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -36,6 +36,7 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -38,6 +38,7 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -45,6 +45,7 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -38,6 +38,7 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_manifest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_manifest.md
@@ -36,6 +36,7 @@ $ zarf tools registry manifest ghcr.io/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -27,6 +27,7 @@ zarf tools registry prune [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -39,6 +39,7 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -42,6 +42,7 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -31,6 +31,7 @@ zarf tools registry version [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
+      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom.md
@@ -78,6 +78,7 @@ zarf tools sbom [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_attest.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_attest.md
@@ -57,6 +57,7 @@ zarf tools sbom attest --output [FORMAT] <IMAGE> [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
@@ -19,6 +19,7 @@ Show available catalogers and configuration
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
@@ -27,6 +27,7 @@ zarf tools sbom cataloger list [OPTIONS] [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_config.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config.md
@@ -24,6 +24,7 @@ zarf tools sbom config [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
@@ -24,6 +24,7 @@ zarf tools sbom config locations [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_convert.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_convert.md
@@ -39,6 +39,7 @@ zarf tools sbom convert [SOURCE-SBOM] -o [FORMAT] [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_login.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_login.md
@@ -33,6 +33,7 @@ zarf tools sbom login [OPTIONS] [SERVER] [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_scan.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_scan.md
@@ -74,6 +74,7 @@ zarf tools sbom scan [SOURCE] [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_version.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_version.md
@@ -24,6 +24,7 @@ zarf tools sbom version [flags]
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_trusted-root.md
+++ b/site/src/content/docs/commands/zarf_tools_trusted-root.md
@@ -20,6 +20,7 @@ Tools for working with Sigstore trusted roots
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -27,7 +28,6 @@ Tools for working with Sigstore trusted roots
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_trusted-root_create.md
+++ b/site/src/content/docs/commands/zarf_tools_trusted-root_create.md
@@ -65,6 +65,7 @@ zarf tools trusted-root create [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -72,7 +73,6 @@ zarf tools trusted-root create [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -77,6 +77,7 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -84,7 +85,6 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_wait-for.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for.md
@@ -57,6 +57,7 @@ $ zarf tools wait-for http google.com success                           #  wait 
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -64,7 +65,6 @@ $ zarf tools wait-for http google.com success                           #  wait 
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_wait-for_network.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for_network.md
@@ -41,6 +41,7 @@ $ zarf tools wait-for network http google.com success                           
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -48,7 +49,6 @@ $ zarf tools wait-for network http google.com success                           
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_wait-for_resource.md
+++ b/site/src/content/docs/commands/zarf_tools_wait-for_resource.md
@@ -48,6 +48,7 @@ $ zarf tools wait-for resource sts test-sts '{.status.availableReplicas}'=23    
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -55,7 +56,6 @@ $ zarf tools wait-for resource sts test-sts '{.status.availableReplicas}'=23    
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/site/src/content/docs/commands/zarf_tools_yq.md
+++ b/site/src/content/docs/commands/zarf_tools_yq.md
@@ -90,6 +90,7 @@ zarf tools yq -P sample.json
 ### Options inherited from parent commands
 
 ```
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_yq_completion.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_completion.md
@@ -57,6 +57,7 @@ zarf tools yq completion [bash|zsh|fish|powershell]
 ### Options inherited from parent commands
 
 ```
+      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
@@ -53,6 +53,7 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
 ### Options inherited from parent commands
 
 ```
+      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval.md
@@ -55,6 +55,7 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 ### Options inherited from parent commands
 
 ```
+      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/site/src/content/docs/commands/zarf_version.md
+++ b/site/src/content/docs/commands/zarf_version.md
@@ -29,6 +29,7 @@ zarf version [flags]
 
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
+      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
@@ -36,7 +37,6 @@ zarf version [flags]
       --no-color                   Disable terminal color codes in logging and stdout prints.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --tmpdir string              Specify the temporary directory to use for intermediate files
-      --zarf-cache string          Specify the location of the Zarf cache directory (default "~/.zarf-cache")
 ```
 
 ### SEE ALSO

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -234,6 +234,8 @@ func setupRootFlags(rootCmd *cobra.Command) {
 	// Core functionality
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", vpr.GetString(VArchitecture), lang.RootCmdFlagArch)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", vpr.GetString(VZarfCache), lang.RootCmdFlagCachePath)
+	rootCmd.PersistentFlags().MarkDeprecated("zarf-cache", "use --cache instead")
+	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "cache", vpr.GetString(VZarfCache), lang.RootCmdFlagCachePath)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", vpr.GetString(VTmpDir), lang.RootCmdFlagTempDir)
 
 	// Security

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -481,8 +481,6 @@ func newClearCacheCommand() *cobra.Command {
 		RunE:    o.run,
 	}
 
-	cmd.Flags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", config.ZarfDefaultCachePath, lang.CmdToolsClearCacheFlagCachePath)
-
 	return cmd
 }
 


### PR DESCRIPTION
## Description

We've talked about it during one of the calls, that our `--zarf-cache` is pretty mouthful, and just `--cache` will be a  better choice. So this PR does just that. 

## Related Issue

None

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
