### PR TITLE
docs(search): load pages from currently selected version

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -8,9 +8,9 @@ import { remarkLinkRewrite } from "./src/plugins/remark-link-rewrite.ts";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { VERSION_SLUG } from "./src/lib/version.ts";
 
 const docsDir = fileURLToPath(new URL("./src/content/docs/", import.meta.url));
-const VERSION_SLUG = /^v\d+-\d+$/;
 
 // Archived versions staged by build-versions.mjs; absent in plain/dev builds.
 let versions: { ref: string; slug: string }[] = [];

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -117,6 +117,8 @@ export default defineConfig({
         SkipLink: "./src/components/SkipLink.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",
         Sidebar: "./src/components/Sidebar.astro",
+        Search: "./src/components/Search.astro",
+        MarkdownContent: "./src/components/MarkdownContent.astro",
       },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/zarf-dev/zarf' },

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -109,6 +109,21 @@ async function cleanStaged() {
   await fs.rm(schemaDir, { recursive: true, force: true });
 }
 
+async function disablePagefind(dir) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await disablePagefind(full);
+      continue;
+    }
+    if (!/\.(mdx?|MDX?)$/.test(entry.name)) continue;
+    const content = await fs.readFile(full, "utf8");
+    if (content.startsWith("---\n")) {
+      await fs.writeFile(full, "---\npagefind: false\n" + content.slice(4));
+    }
+  }
+}
+
 // Copy a tag's docs into `src/content/docs/<slug>/` and stage its generated
 // artifacts (examples, schema). Content renders with the current toolchain.
 async function stageVersion({ ref, slug }) {
@@ -131,6 +146,7 @@ async function stageVersion({ ref, slug }) {
       dstDir: path.join(dst, "ref/Examples"),
       ref,
     });
+    await disablePagefind(dst);
     await fs.mkdir(schemaDir, { recursive: true });
     await fs.cp(path.join(worktree, "zarf.schema.json"), path.join(schemaDir, `${slug}.json`));
   } finally {

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -109,21 +109,6 @@ async function cleanStaged() {
   await fs.rm(schemaDir, { recursive: true, force: true });
 }
 
-async function disablePagefind(dir) {
-  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      await disablePagefind(full);
-      continue;
-    }
-    if (!/\.(mdx?|MDX?)$/.test(entry.name)) continue;
-    const content = await fs.readFile(full, "utf8");
-    if (content.startsWith("---\n")) {
-      await fs.writeFile(full, "---\npagefind: false\n" + content.slice(4));
-    }
-  }
-}
-
 // Copy a tag's docs into `src/content/docs/<slug>/` and stage its generated
 // artifacts (examples, schema). Content renders with the current toolchain.
 async function stageVersion({ ref, slug }) {
@@ -146,7 +131,6 @@ async function stageVersion({ ref, slug }) {
       dstDir: path.join(dst, "ref/Examples"),
       ref,
     });
-    await disablePagefind(dst);
     await fs.mkdir(schemaDir, { recursive: true });
     await fs.cp(path.join(worktree, "zarf.schema.json"), path.join(schemaDir, `${slug}.json`));
   } finally {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -24,7 +24,6 @@
         "linkinator": "^7.5.3",
         "markdownlint-cli2": "^0.20.0",
         "remark-gemoji": "^8.0.0",
-        "remark-gfm": "^4.0.1",
         "yaml": "^2.8.3"
       },
       "engines": {

--- a/site/src/components/MarkdownContent.astro
+++ b/site/src/components/MarkdownContent.astro
@@ -1,0 +1,11 @@
+---
+import Default from '@astrojs/starlight/components/MarkdownContent.astro';
+
+const VERSION_SLUG_PATTERN = /^v\d+-\d+$/;
+const version = Astro.url.pathname.split('/').find(s => VERSION_SLUG_PATTERN.test(s)) ?? 'current';
+---
+
+<Default {...Astro.props}>
+  <span data-pagefind-filter={`version:${version}`} aria-hidden="true" style="display:none" />
+  <slot />
+</Default>

--- a/site/src/components/MarkdownContent.astro
+++ b/site/src/components/MarkdownContent.astro
@@ -1,8 +1,8 @@
 ---
 import Default from '@astrojs/starlight/components/MarkdownContent.astro';
+import { versionFromPath } from '../lib/version.ts';
 
-const VERSION_SLUG_PATTERN = /^v\d+-\d+$/;
-const version = Astro.url.pathname.split('/').find(s => VERSION_SLUG_PATTERN.test(s)) ?? 'current';
+const version = versionFromPath(Astro.url.pathname);
 ---
 
 <Default {...Astro.props}>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -14,41 +14,27 @@ import Default from '@astrojs/starlight/components/Search.astro';
 
   const pageVersion = versionFromPath(window.location.pathname);
 
-  function activateVersionFilter(container: HTMLElement): boolean {
-    const input = container.querySelector(
-      `.pagefind-ui__filter-panel input[value="${pageVersion}"]`
-    ) as HTMLInputElement | null;
-    if (!input || input.checked) return false;
-    input.click();
-    return true;
+  // Pagefind lazy-loads its search UI and renders the version filter checkbox
+  // asynchronously, so we watch for it to appear. One click is enough: Pagefind
+  // holds the selection in its own state, which survives later searches and
+  // re-renders — so we disconnect once it's applied.
+  function scopeSearchToVersion(root: HTMLElement) {
+    const activate = () => {
+      const input = root.querySelector<HTMLInputElement>(
+        `.pagefind-ui__filter-panel input[value="${pageVersion}"]`
+      );
+      if (!input || input.checked) return false;
+      input.click();
+      return true;
+    };
+
+    if (activate()) return;
+    const observer = new MutationObserver(() => {
+      if (activate()) observer.disconnect();
+    });
+    observer.observe(root, { childList: true, subtree: true });
   }
 
-  function setupFilterBehavior(pagefindForm: Element) {
-    const pagefindContainer = (pagefindForm.closest('.pagefind-ui') ?? pagefindForm.parentElement ?? pagefindForm) as HTMLElement;
-
-    let isInjecting = false;
-    let filterTimer: ReturnType<typeof setTimeout> | undefined;
-
-    new MutationObserver(() => {
-      if (isInjecting) return;
-      clearTimeout(filterTimer);
-      filterTimer = setTimeout(() => {
-        isInjecting = true;
-        activateVersionFilter(pagefindContainer);
-        isInjecting = false;
-      }, 50);
-    }).observe(pagefindContainer, { childList: true, subtree: true });
-  }
-
-  let retries = 0;
-  function waitForPagefindUI() {
-    const pagefindForm = document.querySelector('.pagefind-ui__form');
-    if (pagefindForm) {
-      setupFilterBehavior(pagefindForm);
-    } else if (retries++ < 50) {
-      setTimeout(waitForPagefindUI, 100);
-    }
-  }
-
-  window.addEventListener('DOMContentLoaded', waitForPagefindUI);
+  const searchRoot = document.getElementById('starlight__search');
+  if (searchRoot) scopeSearchToVersion(searchRoot);
 </script>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -1,0 +1,75 @@
+---
+import Default from '@astrojs/starlight/components/Search.astro';
+---
+
+<Default />
+
+<style is:global>
+  /* Version filter panel is hidden — version scoping is applied programmatically. */
+  .pagefind-ui__filter-panel { display: none !important; }
+</style>
+
+<script>
+  const VERSION_SLUG_PATTERN = /^v\d+-\d+$/;
+
+  function detectPageVersion(path: string): string {
+    for (const seg of path.split('/')) {
+      if (VERSION_SLUG_PATTERN.test(seg)) return seg;
+    }
+    return 'current';
+  }
+
+  let pageVersion = detectPageVersion(window.location.pathname);
+  let activeObserver: MutationObserver | null = null;
+
+  function activateVersionFilter(container: HTMLElement): boolean {
+    const input = container.querySelector(
+      `.pagefind-ui__filter-panel input[value="${pageVersion}"]`
+    ) as HTMLInputElement | null;
+    if (!input || input.checked) return false;
+    input.click();
+    return true;
+  }
+
+  function setupFilterBehavior(pagefindForm: Element) {
+    const pagefindContainer = (pagefindForm.closest('.pagefind-ui') ?? pagefindForm.parentElement ?? pagefindForm) as HTMLElement;
+
+    let isInjecting = false;
+    let filterTimer: ReturnType<typeof setTimeout> | undefined;
+
+    activeObserver = new MutationObserver(() => {
+      if (isInjecting) return;
+      clearTimeout(filterTimer);
+      filterTimer = setTimeout(() => {
+        isInjecting = true;
+        activateVersionFilter(pagefindContainer);
+        isInjecting = false;
+      }, 50);
+    });
+
+    activeObserver.observe(pagefindContainer, { childList: true, subtree: true });
+  }
+
+  let retries = 0;
+  let waitTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function waitForPagefindUI() {
+    const pagefindForm = document.querySelector('.pagefind-ui__form');
+    if (pagefindForm) {
+      setupFilterBehavior(pagefindForm);
+    } else if (retries++ < 50) {
+      waitTimer = setTimeout(waitForPagefindUI, 100);
+    }
+  }
+
+  document.addEventListener('astro:page-load', () => {
+    pageVersion = detectPageVersion(window.location.pathname);
+    if (activeObserver) {
+      activeObserver.disconnect();
+      activeObserver = null;
+    }
+    clearTimeout(waitTimer);
+    retries = 0;
+    waitForPagefindUI();
+  });
+</script>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -12,15 +12,7 @@ import Default from '@astrojs/starlight/components/Search.astro';
 <script>
   const VERSION_SLUG_PATTERN = /^v\d+-\d+$/;
 
-  function detectPageVersion(path: string): string {
-    for (const seg of path.split('/')) {
-      if (VERSION_SLUG_PATTERN.test(seg)) return seg;
-    }
-    return 'current';
-  }
-
-  let pageVersion = detectPageVersion(window.location.pathname);
-  let activeObserver: MutationObserver | null = null;
+  const pageVersion = window.location.pathname.split('/').find(s => VERSION_SLUG_PATTERN.test(s)) ?? 'current';
 
   function activateVersionFilter(container: HTMLElement): boolean {
     const input = container.querySelector(
@@ -37,7 +29,7 @@ import Default from '@astrojs/starlight/components/Search.astro';
     let isInjecting = false;
     let filterTimer: ReturnType<typeof setTimeout> | undefined;
 
-    activeObserver = new MutationObserver(() => {
+    new MutationObserver(() => {
       if (isInjecting) return;
       clearTimeout(filterTimer);
       filterTimer = setTimeout(() => {
@@ -45,31 +37,18 @@ import Default from '@astrojs/starlight/components/Search.astro';
         activateVersionFilter(pagefindContainer);
         isInjecting = false;
       }, 50);
-    });
-
-    activeObserver.observe(pagefindContainer, { childList: true, subtree: true });
+    }).observe(pagefindContainer, { childList: true, subtree: true });
   }
 
   let retries = 0;
-  let waitTimer: ReturnType<typeof setTimeout> | undefined;
-
   function waitForPagefindUI() {
     const pagefindForm = document.querySelector('.pagefind-ui__form');
     if (pagefindForm) {
       setupFilterBehavior(pagefindForm);
     } else if (retries++ < 50) {
-      waitTimer = setTimeout(waitForPagefindUI, 100);
+      setTimeout(waitForPagefindUI, 100);
     }
   }
 
-  document.addEventListener('astro:page-load', () => {
-    pageVersion = detectPageVersion(window.location.pathname);
-    if (activeObserver) {
-      activeObserver.disconnect();
-      activeObserver = null;
-    }
-    clearTimeout(waitTimer);
-    retries = 0;
-    waitForPagefindUI();
-  });
+  window.addEventListener('DOMContentLoaded', waitForPagefindUI);
 </script>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -10,9 +10,9 @@ import Default from '@astrojs/starlight/components/Search.astro';
 </style>
 
 <script>
-  const VERSION_SLUG_PATTERN = /^v\d+-\d+$/;
+  import { versionFromPath } from '../lib/version.ts';
 
-  const pageVersion = window.location.pathname.split('/').find(s => VERSION_SLUG_PATTERN.test(s)) ?? 'current';
+  const pageVersion = versionFromPath(window.location.pathname);
 
   function activateVersionFilter(container: HTMLElement): boolean {
     const input = container.querySelector(

--- a/site/src/lib/version.ts
+++ b/site/src/lib/version.ts
@@ -1,0 +1,10 @@
+/** Matches an archived-version slug segment, e.g. "v0-76". */
+export const VERSION_SLUG = /^v\d+-\d+$/;
+
+/** Filter value used for the current (unversioned) docs checkout. */
+export const LATEST = "current";
+
+/** Resolve the docs version from a URL path, falling back to the current checkout. */
+export function versionFromPath(pathname: string): string {
+  return pathname.split("/").find((s) => VERSION_SLUG.test(s)) ?? LATEST;
+}


### PR DESCRIPTION
## Description
 
Right now there is a bug on the docs site where looking up any keyword shows results the same results for a bunch of different versions. We should instead only show the currently selected version

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
