### PR TITLE
ci: fix precommit linting of vendor directory

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,6 +87,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - vendor$
 formatters:
   enable:
     - goimports
@@ -97,3 +98,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - vendor$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,24 @@ repos:
       - id: end-of-file-fixer
         exclude: |
             (?x)^(
+                vendor/.*|
                 src/internal/packager/images/testdata/.*|
                 site/src/content/docs/commands/.*
             )$
       - id: fix-byte-order-marker
+        exclude: vendor/.*
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
-        exclude: site/src/content/docs/commands/.*
+        exclude: |
+            (?x)^(
+                vendor/.*|
+                site/src/content/docs/commands/.*
+            )$
   - repo: https://github.com/sirosen/texthooks
     rev: 72a68994497c827ced727b7c6b2567cfc5a96cb2  # 0.6.4
     hooks:
       - id: fix-smartquotes
+        exclude: vendor/.*
   - repo: local
     hooks:
       - id: check-docs-and-schema


### PR DESCRIPTION
## Description

Quick fix to precommit hook for vendor directory linting exclusions

See (for the same fix):
- https://github.com/zarf-dev/zarf/pull/5029/commits/a5f54c0f0c7379efb72e81be76a7a8cc834d3509
- https://github.com/zarf-dev/zarf/pull/5030/commits/1b44680ece8c2fbad6dad36ebfd4802e2eabae56

## Related Issue

no associated issue 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
