### PR TITLE
docs: update Azure KeyVault URL for package signing

### DIFF
--- a/site/src/content/docs/ref/package-signing.mdx
+++ b/site/src/content/docs/ref/package-signing.mdx
@@ -75,7 +75,7 @@ Requires `gcloud` authentication and appropriate IAM roles. The key must be an a
 
 ```bash
 zarf package sign zarf-package-example-amd64.tar.zst \
-  --signing-key azurekms://VAULT_NAME.vault.azure.net/keys/KEY_NAME/KEY_VERSION
+  --signing-key azurekms://VAULT_NAME.vault.azure.net/KEY_NAME/KEY_VERSION
 ```
 
 Requires Azure CLI authentication and appropriate access policies. The key must be an asymmetric signing key.


### PR DESCRIPTION
Removed path 'keys' from Azure KeyVault URL

## Description

When following the docs to sign a package using Azure KeyVault, the specified URL is not correct. If followed, an error occurs:

```
Error: kms get: kms specification should be in the format azurekms://[VAULT_NAME][VAULT_URL]/[KEY_NAME]/[VERSION (optional)]
```

The solution is to not include `keys` after the vault URL.
...

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
