### PR TITLE
feat: deprecate artifact server

### DIFF
--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -50,9 +50,6 @@ $ zarf init --registry-push-password={PASSWORD} --registry-push-username={USERNA
 # Initializing w/ an external git server:
 $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}
 
-# Initializing w/ an external artifact server:
-$ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNAME} --artifact-url={URL}
-
 # NOTE: Not specifying a pull username/password will use the push user for pulling as well.
 
 ```

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -65,9 +65,6 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
       --agent-tls-ca string                     Path to a PEM-encoded CA certificate for the Zarf agent
       --agent-tls-cert string                   Path to a PEM-encoded TLS certificate for the Zarf agent
       --agent-tls-key string                    Path to a PEM-encoded TLS private key for the Zarf agent
-      --artifact-push-token string              [alpha] API Token for the push-user to access the artifact registry
-      --artifact-push-username string           [alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts.
-      --artifact-url string                     [alpha] External artifact registry url to use for this Zarf cluster
       --certificate-identity string             Required identity claim in the signing certificate (keyless verify). Example: signer@example.com or https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main
       --certificate-identity-regexp string      Regex variant of --certificate-identity
       --certificate-oidc-issuer string          Required OIDC issuer claim in the signing certificate (keyless verify). Example: https://github.com/login/oauth or https://token.actions.githubusercontent.com

--- a/site/src/content/docs/commands/zarf_tools_update-creds.md
+++ b/site/src/content/docs/commands/zarf_tools_update-creds.md
@@ -55,9 +55,6 @@ $ zarf tools update-creds artifact --artifact-push-username={USERNAME} --artifac
       --agent-tls-ca string             Path to a PEM-encoded CA certificate for the Zarf agent
       --agent-tls-cert string           Path to a PEM-encoded TLS certificate for the Zarf agent
       --agent-tls-key string            Path to a PEM-encoded TLS private key for the Zarf agent
-      --artifact-push-token string      [alpha] API Token for the push-user to access the artifact registry
-      --artifact-push-username string   [alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts.
-      --artifact-url string             [alpha] External artifact registry url to use for this Zarf cluster
   -c, --confirm                         Confirm updating credentials without prompting
       --force-conflicts                 Force Helm to take ownership of conflicting fields during Server-Side Apply operations. Use when external tools (kubectl, HPAs, etc.) have modified resources.
       --git-pull-password string        Password for the pull-only user to access the git server

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -110,9 +110,9 @@ func newInitCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.artifactServer.Address, "artifact-url", v.GetString(VInitArtifactURL), lang.CmdInitFlagArtifactURL)
 	cmd.Flags().StringVar(&o.artifactServer.PushUsername, "artifact-push-username", v.GetString(VInitArtifactPushUser), lang.CmdInitFlagArtifactPushUser)
 	cmd.Flags().StringVar(&o.artifactServer.PushToken, "artifact-push-token", v.GetString(VInitArtifactPushToken), lang.CmdInitFlagArtifactPushToken)
-	_ = cmd.Flags().MarkDeprecated("artifact-url", lang.CmdInitFlagArtifactDeprecated)
-	_ = cmd.Flags().MarkDeprecated("artifact-push-username", lang.CmdInitFlagArtifactDeprecated)
-	_ = cmd.Flags().MarkDeprecated("artifact-push-token", lang.CmdInitFlagArtifactDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-url", lang.ArtifactServerDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-username", lang.ArtifactServerDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-token", lang.ArtifactServerDeprecated)
 
 	// Flags for providing user-managed agent TLS certificates
 	cmd.Flags().StringVar(&o.agentTLSCAPath, "agent-tls-ca", v.GetString(VInitAgentTLSCA), "Path to a PEM-encoded CA certificate for the Zarf agent")

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -110,6 +110,9 @@ func newInitCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.artifactServer.Address, "artifact-url", v.GetString(VInitArtifactURL), lang.CmdInitFlagArtifactURL)
 	cmd.Flags().StringVar(&o.artifactServer.PushUsername, "artifact-push-username", v.GetString(VInitArtifactPushUser), lang.CmdInitFlagArtifactPushUser)
 	cmd.Flags().StringVar(&o.artifactServer.PushToken, "artifact-push-token", v.GetString(VInitArtifactPushToken), lang.CmdInitFlagArtifactPushToken)
+	_ = cmd.Flags().MarkDeprecated("artifact-url", lang.CmdInitFlagArtifactDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-username", lang.CmdInitFlagArtifactDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-token", lang.CmdInitFlagArtifactDeprecated)
 
 	// Flags for providing user-managed agent TLS certificates
 	cmd.Flags().StringVar(&o.agentTLSCAPath, "agent-tls-ca", v.GetString(VInitAgentTLSCA), "Path to a PEM-encoded CA certificate for the Zarf agent")

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -104,7 +104,7 @@ func (o *getCredsOptions) run(ctx context.Context, args []string) error {
 	}
 
 	if s.ArtifactServer.IsConfigured() {
-		logger.From(ctx).Warn(lang.CmdToolsGetCredsArtifactDeprecated)
+		logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
 	}
 
 	if len(args) > 0 {
@@ -270,6 +270,9 @@ func newUpdateCredsCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVar(&o.artifactServer.Address, "artifact-url", v.GetString(VInitArtifactURL), lang.CmdInitFlagArtifactURL)
 	cmd.Flags().StringVar(&o.artifactServer.PushUsername, "artifact-push-username", v.GetString(VInitArtifactPushUser), lang.CmdInitFlagArtifactPushUser)
 	cmd.Flags().StringVar(&o.artifactServer.PushToken, "artifact-push-token", v.GetString(VInitArtifactPushToken), lang.CmdInitFlagArtifactPushToken)
+	_ = cmd.Flags().MarkDeprecated("artifact-url", lang.ArtifactServerDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-username", lang.ArtifactServerDeprecated)
+	_ = cmd.Flags().MarkDeprecated("artifact-push-token", lang.ArtifactServerDeprecated)
 
 	// Flags for providing user-managed agent TLS certificates
 	cmd.Flags().StringVar(&o.agentTLSCAPath, "agent-tls-ca", "", "Path to a PEM-encoded CA certificate for the Zarf agent")
@@ -311,6 +314,11 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string) error {
 	if oldState.Distro == "" {
 		return errors.New("zarf state secret did not load properly")
 	}
+
+	if services.Has(state.ArtifactKey) && oldState.ArtifactServer.IsConfigured() {
+		l.Warn(lang.ArtifactServerDeprecated)
+	}
+
 	opts := state.MergeOptions{
 		GitServer:      o.gitServer,
 		RegistryInfo:   o.registryInfo,

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -106,9 +106,6 @@ func (o *getCredsOptions) run(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		// If a component name is provided, only show that component's credentials
 		// Printing both the pterm output and slogger for now
-		if strings.EqualFold(args[0], artifactKey) {
-			logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
-		}
 		printComponentCredential(ctx, s, args[0], o.outputWriter)
 		return nil
 	}
@@ -214,6 +211,7 @@ func printComponentCredential(ctx context.Context, s *state.State, componentName
 		l.Info("Git server (read-only) password", "username", s.GitServer.PullUsername)
 		fmt.Fprintln(out, s.GitServer.PullPassword)
 	case artifactKey:
+		logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
 		l.Info("artifact server token", "username", s.ArtifactServer.PushUsername)
 		fmt.Fprintln(out, s.ArtifactServer.PushToken)
 	case registryKey:

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -103,15 +103,18 @@ func (o *getCredsOptions) run(ctx context.Context, args []string) error {
 		return errors.New("state.Distro empty, did not load from cluster")
 	}
 
-	if s.ArtifactServer.IsConfigured() {
-		logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
-	}
-
 	if len(args) > 0 {
 		// If a component name is provided, only show that component's credentials
 		// Printing both the pterm output and slogger for now
+		if strings.EqualFold(args[0], artifactKey) {
+			logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
+		}
 		printComponentCredential(ctx, s, args[0], o.outputWriter)
 		return nil
+	}
+
+	if s.ArtifactServer.IsConfigured() {
+		logger.From(ctx).Warn(lang.ArtifactServerDeprecated)
 	}
 	return printCredentialTable(s, o.outputFormat, o.outputWriter)
 }

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -103,6 +103,10 @@ func (o *getCredsOptions) run(ctx context.Context, args []string) error {
 		return errors.New("state.Distro empty, did not load from cluster")
 	}
 
+	if s.ArtifactServer.IsConfigured() {
+		logger.From(ctx).Warn(lang.CmdToolsGetCredsArtifactDeprecated)
+	}
+
 	if len(args) > 0 {
 		// If a component name is provided, only show that component's credentials
 		// Printing both the pterm output and slogger for now

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -13,9 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
-	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,88 +99,6 @@ func TestGetCreds(t *testing.T) {
 			}
 			if tt.outputFormat == outputYAML {
 				require.YAMLEq(t, string(b), buf.String())
-			}
-		})
-	}
-}
-
-func TestGetCredsArtifactDeprecationWarning(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name               string
-		args               []string
-		artifactConfigured bool
-		expectWarning      bool
-	}{
-		{
-			name:               "no args with artifact server configured warns",
-			artifactConfigured: true,
-			expectWarning:      true,
-		},
-		{
-			name:               "no args without artifact server does not warn",
-			artifactConfigured: false,
-			expectWarning:      false,
-		},
-		{
-			name:               "artifact key warns",
-			args:               []string{artifactKey},
-			artifactConfigured: true,
-			expectWarning:      true,
-		},
-		{
-			name:               "registry key does not warn even when artifact configured",
-			args:               []string{registryKey},
-			artifactConfigured: true,
-			expectWarning:      false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			logBuf := new(bytes.Buffer)
-			log, err := logger.New(logger.Config{
-				Level:       logger.Warn,
-				Format:      logger.FormatConsole,
-				Destination: logBuf,
-			})
-			require.NoError(t, err)
-			ctx := logger.WithContext(context.Background(), log)
-
-			c := &cluster.Cluster{
-				Clientset: fake.NewClientset(),
-			}
-			s := &state.State{Distro: "test"}
-			if tt.artifactConfigured {
-				s.ArtifactServer = state.ArtifactServerInfo{Address: "https://git-server.com"}
-			}
-			b, err := json.Marshal(s)
-			require.NoError(t, err)
-			secret := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      state.ZarfStateSecretName,
-					Namespace: state.ZarfNamespaceName,
-				},
-				Data: map[string][]byte{
-					state.ZarfStateDataKey: b,
-				},
-			}
-			_, err = c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &secret, metav1.CreateOptions{})
-			require.NoError(t, err)
-
-			getCredsOpts := getCredsOptions{
-				outputFormat: outputTable,
-				outputWriter: new(bytes.Buffer),
-				cluster:      c,
-			}
-			err = getCredsOpts.run(ctx, tt.args)
-			require.NoError(t, err)
-
-			if tt.expectWarning {
-				require.Contains(t, logBuf.String(), lang.ArtifactServerDeprecated)
-			} else {
-				require.NotContains(t, logBuf.String(), lang.ArtifactServerDeprecated)
 			}
 		})
 	}

--- a/src/cmd/zarf_tools_test.go
+++ b/src/cmd/zarf_tools_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,6 +101,88 @@ func TestGetCreds(t *testing.T) {
 			}
 			if tt.outputFormat == outputYAML {
 				require.YAMLEq(t, string(b), buf.String())
+			}
+		})
+	}
+}
+
+func TestGetCredsArtifactDeprecationWarning(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		args               []string
+		artifactConfigured bool
+		expectWarning      bool
+	}{
+		{
+			name:               "no args with artifact server configured warns",
+			artifactConfigured: true,
+			expectWarning:      true,
+		},
+		{
+			name:               "no args without artifact server does not warn",
+			artifactConfigured: false,
+			expectWarning:      false,
+		},
+		{
+			name:               "artifact key warns",
+			args:               []string{artifactKey},
+			artifactConfigured: true,
+			expectWarning:      true,
+		},
+		{
+			name:               "registry key does not warn even when artifact configured",
+			args:               []string{registryKey},
+			artifactConfigured: true,
+			expectWarning:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logBuf := new(bytes.Buffer)
+			log, err := logger.New(logger.Config{
+				Level:       logger.Warn,
+				Format:      logger.FormatConsole,
+				Destination: logBuf,
+			})
+			require.NoError(t, err)
+			ctx := logger.WithContext(context.Background(), log)
+
+			c := &cluster.Cluster{
+				Clientset: fake.NewClientset(),
+			}
+			s := &state.State{Distro: "test"}
+			if tt.artifactConfigured {
+				s.ArtifactServer = state.ArtifactServerInfo{Address: "https://git-server.com"}
+			}
+			b, err := json.Marshal(s)
+			require.NoError(t, err)
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      state.ZarfStateSecretName,
+					Namespace: state.ZarfNamespaceName,
+				},
+				Data: map[string][]byte{
+					state.ZarfStateDataKey: b,
+				},
+			}
+			_, err = c.Clientset.CoreV1().Secrets("zarf").Create(ctx, &secret, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			getCredsOpts := getCredsOptions{
+				outputFormat: outputTable,
+				outputWriter: new(bytes.Buffer),
+				cluster:      c,
+			}
+			err = getCredsOpts.run(ctx, tt.args)
+			require.NoError(t, err)
+
+			if tt.expectWarning {
+				require.Contains(t, logBuf.String(), lang.ArtifactServerDeprecated)
+			} else {
+				require.NotContains(t, logBuf.String(), lang.ArtifactServerDeprecated)
 			}
 		})
 	}

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -179,9 +179,10 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInitFlagRegPullPass = "Password for the pull-only user to access the registry"
 	CmdInitFlagRegSecret   = "Internal registry secret value. Only used when --registry-url is not set."
 
-	CmdInitFlagArtifactURL       = "[alpha] External artifact registry url to use for this Zarf cluster"
-	CmdInitFlagArtifactPushUser  = "[alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts."
-	CmdInitFlagArtifactPushToken = "[alpha] API Token for the push-user to access the artifact registry"
+	CmdInitFlagArtifactURL        = "[alpha] External artifact registry url to use for this Zarf cluster"
+	CmdInitFlagArtifactPushUser   = "[alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts."
+	CmdInitFlagArtifactPushToken  = "[alpha] API Token for the push-user to access the artifact registry"
+	CmdInitFlagArtifactDeprecated = "The artifact server is deprecated and will be removed in a future release"
 
 	// zarf internal
 	CmdInternalShort = "Internal tools used by zarf"
@@ -807,9 +808,10 @@ $ zarf tools wait-for network http google.com success                           
 `
 	CmdToolsKubectlDocs = "Kubectl command. See https://kubernetes.io/docs/reference/kubectl/overview/ for more information."
 
-	CmdToolsGetCredsShort   = "Displays a table of credentials for deployed Zarf services. Pass a service key to get a single credential"
-	CmdToolsGetCredsLong    = "Display a table of credentials for deployed Zarf services. Pass a service key to get a single credential. i.e. 'zarf tools get-creds registry'"
-	CmdToolsGetCredsExample = `
+	CmdToolsGetCredsArtifactDeprecated = "The artifact server is deprecated and will be removed in a future release"
+	CmdToolsGetCredsShort              = "Displays a table of credentials for deployed Zarf services. Pass a service key to get a single credential"
+	CmdToolsGetCredsLong               = "Display a table of credentials for deployed Zarf services. Pass a service key to get a single credential. i.e. 'zarf tools get-creds registry'"
+	CmdToolsGetCredsExample            = `
 # Print all Zarf credentials:
 $ zarf tools get-creds
 

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -143,9 +143,6 @@ $ zarf init --registry-push-password={PASSWORD} --registry-push-username={USERNA
 # Initializing w/ an external git server:
 $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-url={URL}
 
-# Initializing w/ an external artifact server:
-$ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNAME} --artifact-url={URL}
-
 # NOTE: Not specifying a pull username/password will use the push user for pulling as well.
 `
 
@@ -179,10 +176,12 @@ $ zarf init --artifact-push-password={PASSWORD} --artifact-push-username={USERNA
 	CmdInitFlagRegPullPass = "Password for the pull-only user to access the registry"
 	CmdInitFlagRegSecret   = "Internal registry secret value. Only used when --registry-url is not set."
 
-	CmdInitFlagArtifactURL        = "[alpha] External artifact registry url to use for this Zarf cluster"
-	CmdInitFlagArtifactPushUser   = "[alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts."
-	CmdInitFlagArtifactPushToken  = "[alpha] API Token for the push-user to access the artifact registry"
-	CmdInitFlagArtifactDeprecated = "The artifact server is deprecated and will be removed in a future release"
+	CmdInitFlagArtifactURL       = "[alpha] External artifact registry url to use for this Zarf cluster"
+	CmdInitFlagArtifactPushUser  = "[alpha] Username to access to the artifact registry Zarf is configured to use. User must be able to upload package artifacts."
+	CmdInitFlagArtifactPushToken = "[alpha] API Token for the push-user to access the artifact registry"
+
+	// The artifact server is deprecated across init and tools creds commands.
+	ArtifactServerDeprecated = "The artifact server is deprecated and will be removed in a future release"
 
 	// zarf internal
 	CmdInternalShort = "Internal tools used by zarf"
@@ -808,10 +807,9 @@ $ zarf tools wait-for network http google.com success                           
 `
 	CmdToolsKubectlDocs = "Kubectl command. See https://kubernetes.io/docs/reference/kubectl/overview/ for more information."
 
-	CmdToolsGetCredsArtifactDeprecated = "The artifact server is deprecated and will be removed in a future release"
-	CmdToolsGetCredsShort              = "Displays a table of credentials for deployed Zarf services. Pass a service key to get a single credential"
-	CmdToolsGetCredsLong               = "Display a table of credentials for deployed Zarf services. Pass a service key to get a single credential. i.e. 'zarf tools get-creds registry'"
-	CmdToolsGetCredsExample            = `
+	CmdToolsGetCredsShort   = "Displays a table of credentials for deployed Zarf services. Pass a service key to get a single credential"
+	CmdToolsGetCredsLong    = "Display a table of credentials for deployed Zarf services. Pass a service key to get a single credential. i.e. 'zarf tools get-creds registry'"
+	CmdToolsGetCredsExample = `
 # Print all Zarf credentials:
 $ zarf tools get-creds
 

--- a/src/internal/agent/start.go
+++ b/src/internal/agent/start.go
@@ -62,6 +62,7 @@ func StartWebhook(ctx context.Context, cluster *cluster.Cluster) error {
 
 // StartHTTPProxy launches the zarf agent proxy in the cluster.
 func StartHTTPProxy(ctx context.Context, cluster *cluster.Cluster) error {
+	logger.From(ctx).Warn("the Zarf internal proxy will is deprecated and will be removed in a future release")
 	mux := http.NewServeMux()
 	mux.Handle("/", agentHttp.ProxyHandler(ctx, cluster))
 	return startServer(ctx, httpPort, mux)


### PR DESCRIPTION
## Description

This deprecates the artifact server. It will not be replaced, it was built for a specific user group whom I believe no longer uses Zarf. I suspect it has little to no users currently. It also deprecates `zarf internal http-proxy`, which was created to push and pull to the artifact server

I considered also writing a deprecation message when users stand up the init package gitea server (since this automatically configures the artifact server) however because there would be a lot of false positives, and because all users taking advantage of the artifact server will run one of: 
- `zarf tools get-creds` 
- `zarf init with --artifact-url --artifact-user --artifact-pass`
- `zarf internal http-proxy`

they should all still see the deprecation message. 

## Related Issue

Relates to #5005

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
