### PR TITLE
feat: deprecate sbom viewer

### DIFF
--- a/src/pkg/packager/layout/viewer/styles.css
+++ b/src/pkg/packager/layout/viewer/styles.css
@@ -69,6 +69,16 @@ body {
     align-items: center;
   }
 
+  .deprecation-banner {
+    background: #ffcc4d;
+    color: #10184c;
+    padding: 12px 16px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+    font-weight: bold;
+    text-align: center;
+  }
+
   .top-bar .element {
     display: flex;
     align-items: center;

--- a/src/pkg/packager/layout/viewer/template.gohtml
+++ b/src/pkg/packager/layout/viewer/template.gohtml
@@ -17,6 +17,9 @@
 </head>
 
 <body>
+    <div class="deprecation-banner" role="alert">
+        The Zarf SBOM Viewer is deprecated and will be removed in a future release.
+    </div>
     <div class="top-bar">
         <div class="element">
             <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Description

Adds a deprecation banner that looks like this

<img width="1214" height="207" alt="image" src="https://github.com/user-attachments/assets/2c7bbe56-2672-4964-8be4-4fc7e9c552da" />


## Related Issue

Relates to #5043

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
