### PR TITLE
chore: update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zarf-dev/zarf
 
-go 1.26.4
+go 1.26.5
 
 // TODO (@AABRO): Pending merge into github.com/gojsonschema/gojsonschema (https://github.com/gojsonschema/gojsonschema/pull/5)
 replace github.com/xeipuuv/gojsonschema => github.com/defenseunicorns/gojsonschema v0.0.0-20231116163348-e00f069122d6

--- a/src/pkg/archive/archive.go
+++ b/src/pkg/archive/archive.go
@@ -398,7 +398,9 @@ func writeEntry(root *os.Root, rel, linkTarget string, f archives.FileInfo, flag
 	}
 	switch {
 	case f.IsDir():
-		return root.MkdirAll(rel, f.Mode().Perm())
+		// Go 1.26.5 (GO-2026-4970 fix) rejects os.Root paths with a
+		// trailing slash; tar directory entries conventionally have one.
+		return root.MkdirAll(strings.TrimSuffix(rel, "/"), f.Mode().Perm())
 	case linkTarget != "":
 		if err := validateEntryName(linkTarget); err != nil {
 			return err

--- a/src/pkg/archive/archive.go
+++ b/src/pkg/archive/archive.go
@@ -396,11 +396,13 @@ func writeEntry(root *os.Root, rel, linkTarget string, f archives.FileInfo, flag
 	if err := validateEntryName(rel); err != nil {
 		return err
 	}
+	// Go 1.26.5 (GO-2026-4970 fix) rejects os.Root paths with a trailing
+	// slash across MkdirAll, OpenFile, Link, and Symlink alike; tar
+	// directory entries conventionally have one.
+	rel = strings.TrimSuffix(rel, "/")
 	switch {
 	case f.IsDir():
-		// Go 1.26.5 (GO-2026-4970 fix) rejects os.Root paths with a
-		// trailing slash; tar directory entries conventionally have one.
-		return root.MkdirAll(strings.TrimSuffix(rel, "/"), f.Mode().Perm())
+		return root.MkdirAll(rel, f.Mode().Perm())
 	case linkTarget != "":
 		if err := validateEntryName(linkTarget); err != nil {
 			return err


### PR DESCRIPTION
## Description

Upgrade go version due to go vulnerabilities that are reachable:
- GO-2026-5856
- GO-2026-4970


## Related Issue

No associated issue

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
