### PR TITLE
feat(cmd): add viper option for cache

### DIFF
--- a/site/src/content/docs/commands/zarf_tools_helm.md
+++ b/site/src/content/docs/commands/zarf_tools_helm.md
@@ -99,7 +99,6 @@ zarf tools helm [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_kubectl.md
+++ b/site/src/content/docs/commands/zarf_tools_kubectl.md
@@ -55,7 +55,6 @@ zarf tools kubectl [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string              Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString   Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --plain-http                Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_monitor.md
+++ b/site/src/content/docs/commands/zarf_tools_monitor.md
@@ -49,7 +49,6 @@ zarf tools monitor [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string              Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString   Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --plain-http                Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.
 ```

--- a/site/src/content/docs/commands/zarf_tools_registry.md
+++ b/site/src/content/docs/commands/zarf_tools_registry.md
@@ -23,7 +23,6 @@ Tools for working with container registries using go-containertools
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_catalog.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_catalog.md
@@ -37,7 +37,6 @@ $ zarf tools registry catalog reg.example.com
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_copy.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_copy.md
@@ -27,7 +27,6 @@ zarf tools registry copy SRC DST [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_delete.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_delete.md
@@ -36,7 +36,6 @@ $ zarf tools registry delete reg.example.com/stefanprodan/podinfo@sha256:57a654a
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_digest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_digest.md
@@ -38,7 +38,6 @@ $ zarf tools registry digest reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_login.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_login.md
@@ -45,7 +45,6 @@ zarf tools registry login [OPTIONS] [SERVER] [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_logout.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_logout.md
@@ -33,7 +33,6 @@ zarf tools registry logout [SERVER] [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_ls.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_ls.md
@@ -38,7 +38,6 @@ $ zarf tools registry ls reg.example.com/stefanprodan/podinfo
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_manifest.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_manifest.md
@@ -36,7 +36,6 @@ $ zarf tools registry manifest ghcr.io/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_prune.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_prune.md
@@ -27,7 +27,6 @@ zarf tools registry prune [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                         Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_pull.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_pull.md
@@ -39,7 +39,6 @@ $ zarf tools registry pull reg.example.com/stefanprodan/podinfo:6.4.0 image.tar
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_push.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_push.md
@@ -42,7 +42,6 @@ $ zarf tools registry push image.tar reg.example.com/stefanprodan/podinfo:6.4.0
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_registry_version.md
+++ b/site/src/content/docs/commands/zarf_tools_registry_version.md
@@ -31,7 +31,6 @@ zarf tools registry version [flags]
 
 ```
       --allow-nondistributable-artifacts   Allow pushing non-distributable (foreign) layers
-      --cache string                       Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString            Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure                           Allow image references to be fetched without TLS
       --insecure-skip-tls-verify           Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom.md
@@ -78,7 +78,6 @@ zarf tools sbom [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_attest.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_attest.md
@@ -57,7 +57,6 @@ zarf tools sbom attest --output [FORMAT] <IMAGE> [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger.md
@@ -19,7 +19,6 @@ Show available catalogers and configuration
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_cataloger_list.md
@@ -27,7 +27,6 @@ zarf tools sbom cataloger list [OPTIONS] [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_config.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config.md
@@ -24,7 +24,6 @@ zarf tools sbom config [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_config_locations.md
@@ -24,7 +24,6 @@ zarf tools sbom config locations [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_convert.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_convert.md
@@ -39,7 +39,6 @@ zarf tools sbom convert [SOURCE-SBOM] -o [FORMAT] [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_login.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_login.md
@@ -33,7 +33,6 @@ zarf tools sbom login [OPTIONS] [SERVER] [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_scan.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_scan.md
@@ -74,7 +74,6 @@ zarf tools sbom scan [SOURCE] [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_sbom_version.md
+++ b/site/src/content/docs/commands/zarf_tools_sbom_version.md
@@ -24,7 +24,6 @@ zarf tools sbom version [flags]
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -c, --config stringArray         syft configuration file(s) to use
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_yq.md
+++ b/site/src/content/docs/commands/zarf_tools_yq.md
@@ -90,7 +90,6 @@ zarf tools yq -P sample.json
 ### Options inherited from parent commands
 
 ```
-      --cache string               Specify the location of the Zarf cache directory (default "~/.zarf-cache")
       --features stringToString    Provide a comma-separated list of feature names to bools to enable or disable. Ex. --features "foo=true,bar=false,baz=true" (default [])
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
       --plain-http                 Force the connections over HTTP instead of HTTPS. This flag should only be used if you have a specific reason and accept the reduced security posture.

--- a/site/src/content/docs/commands/zarf_tools_yq_completion.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_completion.md
@@ -57,7 +57,6 @@ zarf tools yq completion [bash|zsh|fish|powershell]
 ### Options inherited from parent commands
 
 ```
-      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval-all.md
@@ -53,7 +53,6 @@ cat file2.yml | zarf tools yq ea '.a.b' file1.yml - file3.yml
 ### Options inherited from parent commands
 
 ```
-      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/site/src/content/docs/commands/zarf_tools_yq_eval.md
+++ b/site/src/content/docs/commands/zarf_tools_yq_eval.md
@@ -55,7 +55,6 @@ zarf tools yq e '.a.b = "cool"' -i file.yaml
 ### Options inherited from parent commands
 
 ```
-      --cache string                    Specify the location of the Zarf cache directory (default "~/.zarf-cache")
   -C, --colors                          force print with colors
       --csv-auto-parse                  parse CSV YAML/JSON values (default true)
       --csv-separator char              CSV Separator character (default ,)

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -133,6 +133,7 @@ func (o *internalGenCliDocsOptions) run(_ *cobra.Command, _ []string) error {
 					addHiddenDummyFlag(toolCmd, "no-log-file")
 					addHiddenDummyFlag(toolCmd, "no-progress")
 					addHiddenDummyFlag(toolCmd, "zarf-cache")
+					addHiddenDummyFlag(toolCmd, "cache")
 					addHiddenDummyFlag(toolCmd, "tmpdir")
 					addHiddenDummyFlag(toolCmd, "no-color")
 				}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -236,9 +236,16 @@ func setupRootFlags(rootCmd *cobra.Command) {
 
 	// Core functionality
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", vpr.GetString(VArchitecture), lang.RootCmdFlagArch)
-	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", vpr.GetString(VZarfCache), lang.RootCmdFlagCachePath)
-	rootCmd.PersistentFlags().MarkDeprecated("zarf-cache", "use --cache instead")
-	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "cache", vpr.GetString(VZarfCache), lang.RootCmdFlagCachePath)
+	cachePath := vpr.GetString(VCache)
+	if cachePath == "" {
+		cachePath = vpr.GetString(VZarfCache)
+	}
+	if cachePath == "" {
+		cachePath = config.ZarfDefaultCachePath
+	}
+	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", cachePath, lang.RootCmdFlagCachePath)
+	_ = rootCmd.PersistentFlags().MarkDeprecated("zarf-cache", "use --cache instead")
+	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "cache", cachePath, lang.RootCmdFlagCachePath)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", vpr.GetString(VTmpDir), lang.RootCmdFlagTempDir)
 
 	// Security

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -26,6 +26,7 @@ const (
 	// Root config keys
 
 	VArchitecture          = "architecture"
+	VCache                 = "cache"
 	VZarfCache             = "zarf_cache"
 	VTmpDir                = "tmp_dir"
 	VPlainHTTP             = "plain_http"
@@ -260,7 +261,6 @@ func PrintViperConfigUsed(ctx context.Context) error {
 func setDefaults(v *viper.Viper) {
 	// Root defaults that are non-zero values
 	v.SetDefault(VLogLevel, "info")
-	v.SetDefault(VZarfCache, config.ZarfDefaultCachePath)
 	v.SetDefault(VLogFormat, string(logger.FormatConsole))
 
 	// Package defaults that are non-zero values


### PR DESCRIPTION
## Description

We deprecated `--zarf-cache` and re-named it to `--cache`, but never added an equivalent viper config

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
