### PR TITLE
chore(dependabot): remove vendor keyword from dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: gomod
     directories:
       - "/"
-    vendor: true
     schedule:
       interval: daily
     cooldown:


### PR DESCRIPTION
## Description

For some reason we will inconsistently see flakes on our dependabot config https://github.com/zarf-dev/zarf/pull/5060/checks?check_run_id=86866751785. 

I believe it is unnecessary according to this line in the [github docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#vendor--): 

> For Go modules, any vendored dependencies are automatically identified and maintained as if vendor was enabled.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
