### PR TITLE
fix(helm): create registry client for http chart with OCI re-direct

### DIFF
--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -60,6 +60,26 @@ func negotiateChartPlainHTTP(ctx context.Context, ociURL string, remoteOptions t
 	return plainHTTP, nil
 }
 
+// newChartRegistryClient builds a Helm registry client for an OCI chart reference,
+// negotiating the transport scheme for its host (see negotiateChartPlainHTTP). It
+// returns the client alongside the negotiated plainHTTP so callers can pass the same
+// scheme to the chart getter.
+func newChartRegistryClient(ctx context.Context, ociURL string, remoteOptions types.RemoteOptions) (*registry.Client, bool, error) {
+	plainHTTP, err := negotiateChartPlainHTTP(ctx, ociURL, remoteOptions)
+	if err != nil {
+		return nil, false, err
+	}
+	clientOpts := []registry.ClientOption{registry.ClientOptEnableCache(true)}
+	if plainHTTP {
+		clientOpts = append(clientOpts, registry.ClientOptPlainHTTP())
+	}
+	regClient, err := registry.NewClient(clientOpts...)
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to create the new registry client: %w", err)
+	}
+	return regClient, plainHTTP, nil
+}
+
 // negotiateLoadedChartDependenciesPlainHTTP negotiates a chart's OCI-referenced
 // dependency hosts (see negotiateChartPlainHTTP). Charts with no OCI dependencies
 // return HTTPS without probing. Dependencies spanning hosts that disagree on scheme
@@ -218,9 +238,9 @@ func DownloadPublishedChart(ctx context.Context, chart v1alpha1.ZarfChart, chart
 		regClient *registry.Client
 		chartURL  string
 		err       error
-		// plainHTTP is only ever negotiated (never taken from remoteOptions.PlainHTTP
-		// directly) for the OCI branch below: chart.URL was discovered by reading
-		// package data, not named explicitly on this command line, so the global
+		// plainHTTP is always negotiated for an OCI chart host (never taken from
+		// remoteOptions.PlainHTTP directly): the host was discovered by reading package
+		// data or a repo index, not named explicitly on this command line, so the global
 		// --plain-http flag is not necessarily meant for it.
 		plainHTTP bool
 	)
@@ -239,17 +259,9 @@ func DownloadPublishedChart(ctx context.Context, chart v1alpha1.ZarfChart, chart
 
 	// Handle OCI registries
 	if registry.IsOCI(chart.URL) {
-		plainHTTP, err = negotiateChartPlainHTTP(ctx, chart.URL, remoteOptions)
+		regClient, plainHTTP, err = newChartRegistryClient(ctx, chart.URL, remoteOptions)
 		if err != nil {
 			return err
-		}
-		clientOpts := []registry.ClientOption{registry.ClientOptEnableCache(true)}
-		if plainHTTP {
-			clientOpts = append(clientOpts, registry.ClientOptPlainHTTP())
-		}
-		regClient, err = registry.NewClient(clientOpts...)
-		if err != nil {
-			return fmt.Errorf("unable to create the new registry client: %w", err)
 		}
 		chartURL = chart.URL
 		// Explicitly set the pull version for OCI
@@ -282,6 +294,16 @@ func DownloadPublishedChart(ctx context.Context, chart v1alpha1.ZarfChart, chart
 		)
 		if err != nil {
 			return fmt.Errorf("unable to pull the helm chart: %w", err)
+		}
+
+		// A classic Helm repo index may redirect a chart to an OCI reference
+		// Helm's downloader requires a registry client to resolve
+		// an OCI ref, so build one for the resolved URL.
+		if registry.IsOCI(chartURL) {
+			regClient, plainHTTP, err = newChartRegistryClient(ctx, chartURL, remoteOptions)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/src/internal/packager/helm/repo.go
+++ b/src/internal/packager/helm/repo.go
@@ -60,26 +60,6 @@ func negotiateChartPlainHTTP(ctx context.Context, ociURL string, remoteOptions t
 	return plainHTTP, nil
 }
 
-// newChartRegistryClient builds a Helm registry client for an OCI chart reference,
-// negotiating the transport scheme for its host (see negotiateChartPlainHTTP). It
-// returns the client alongside the negotiated plainHTTP so callers can pass the same
-// scheme to the chart getter.
-func newChartRegistryClient(ctx context.Context, ociURL string, remoteOptions types.RemoteOptions) (*registry.Client, bool, error) {
-	plainHTTP, err := negotiateChartPlainHTTP(ctx, ociURL, remoteOptions)
-	if err != nil {
-		return nil, false, err
-	}
-	clientOpts := []registry.ClientOption{registry.ClientOptEnableCache(true)}
-	if plainHTTP {
-		clientOpts = append(clientOpts, registry.ClientOptPlainHTTP())
-	}
-	regClient, err := registry.NewClient(clientOpts...)
-	if err != nil {
-		return nil, false, fmt.Errorf("unable to create the new registry client: %w", err)
-	}
-	return regClient, plainHTTP, nil
-}
-
 // negotiateLoadedChartDependenciesPlainHTTP negotiates a chart's OCI-referenced
 // dependency hosts (see negotiateChartPlainHTTP). Charts with no OCI dependencies
 // return HTTPS without probing. Dependencies spanning hosts that disagree on scheme
@@ -259,10 +239,6 @@ func DownloadPublishedChart(ctx context.Context, chart v1alpha1.ZarfChart, chart
 
 	// Handle OCI registries
 	if registry.IsOCI(chart.URL) {
-		regClient, plainHTTP, err = newChartRegistryClient(ctx, chart.URL, remoteOptions)
-		if err != nil {
-			return err
-		}
 		chartURL = chart.URL
 		// Explicitly set the pull version for OCI
 		pull.Version = chart.Version
@@ -295,15 +271,22 @@ func DownloadPublishedChart(ctx context.Context, chart v1alpha1.ZarfChart, chart
 		if err != nil {
 			return fmt.Errorf("unable to pull the helm chart: %w", err)
 		}
+	}
 
-		// A classic Helm repo index may redirect a chart to an OCI reference
-		// Helm's downloader requires a registry client to resolve
-		// an OCI ref, so build one for the resolved URL.
-		if registry.IsOCI(chartURL) {
-			regClient, plainHTTP, err = newChartRegistryClient(ctx, chartURL, remoteOptions)
-			if err != nil {
-				return err
-			}
+	// chartURL is OCI either when given directly or when a classic Helm repo
+	// index redirects to an OCI reference
+	if registry.IsOCI(chartURL) {
+		plainHTTP, err = negotiateChartPlainHTTP(ctx, chartURL, remoteOptions)
+		if err != nil {
+			return err
+		}
+		clientOpts := []registry.ClientOption{registry.ClientOptEnableCache(true)}
+		if plainHTTP {
+			clientOpts = append(clientOpts, registry.ClientOptPlainHTTP())
+		}
+		regClient, err = registry.NewClient(clientOpts...)
+		if err != nil {
+			return fmt.Errorf("unable to create the new registry client: %w", err)
 		}
 	}
 

--- a/src/internal/packager/helm/repo_test.go
+++ b/src/internal/packager/helm/repo_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+// Package helm contains operations for working with helm charts.
+package helm
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	chartv2 "helm.sh/helm/v4/pkg/chart/v2"
+	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
+	"helm.sh/helm/v4/pkg/registry"
+
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/test/testutil"
+	"github.com/zarf-dev/zarf/src/types"
+)
+
+// TestDownloadPublishedChartResolvesToOCI covers a classic Helm repository whose
+// index redirects a chart to an OCI reference (as Bitnami's does). Helm's
+// downloader requires a registry client to resolve an OCI ref, so Zarf must
+// provision one even though the chart URL is a plain HTTP repository.
+func TestDownloadPublishedChartResolvesToOCI(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.TestContext(t)
+
+	// Package a minimal chart into a tarball to push to the registry.
+	ch := &chartv2.Chart{Metadata: &chartv2.Metadata{
+		APIVersion: chartv2.APIVersionV1,
+		Name:       "simple-chart",
+		Version:    "1.0.0",
+	}}
+	tgzPath, err := chartutil.Save(ch, t.TempDir())
+	require.NoError(t, err)
+	chartData, err := os.ReadFile(tgzPath)
+	require.NoError(t, err)
+
+	// Push the chart to an in-memory OCI registry over plain HTTP.
+	regAddr := testutil.SetupInMemoryRegistryDynamic(ctx, t)
+	regClient, err := registry.NewClient(registry.ClientOptPlainHTTP())
+	require.NoError(t, err)
+	ociRef := fmt.Sprintf("%s/charts/simple-chart:1.0.0", regAddr)
+	_, err = regClient.Push(chartData, ociRef)
+	require.NoError(t, err)
+
+	// Serve a classic Helm repo index that points the chart at the OCI ref.
+	index := fmt.Sprintf(`apiVersion: v1
+entries:
+  simple-chart:
+  - apiVersion: v2
+    name: simple-chart
+    version: 1.0.0
+    urls:
+    - oci://%s
+`, ociRef)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(index)) //nolint:errcheck
+	})
+	repoSrv := httptest.NewServer(mux)
+	defer repoSrv.Close()
+
+	chart := v1alpha1.ZarfChart{
+		Name:    "simple-chart",
+		Version: "1.0.0",
+		URL:     repoSrv.URL,
+	}
+	chartPath := t.TempDir()
+	err = PackageChart(ctx, chart, chartPath, t.TempDir(), t.TempDir(), types.RemoteOptions{
+		PlainHTTP:             true,
+		InsecureSkipTLSVerify: true,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, StandardName(chartPath, chart)+".tgz")
+}

--- a/src/internal/packager/helm/repo_test.go
+++ b/src/internal/packager/helm/repo_test.go
@@ -78,3 +78,42 @@ entries:
 	require.NoError(t, err)
 	require.FileExists(t, StandardName(chartPath, chart)+".tgz")
 }
+
+// TestDownloadPublishedChartFromOCI covers a chart whose URL is itself an OCI
+// reference, so Zarf provisions a registry client directly rather than resolving
+// through a classic Helm repository index.
+func TestDownloadPublishedChartFromOCI(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.TestContext(t)
+
+	// Package a minimal chart into a tarball to push to the registry.
+	ch := &chartv2.Chart{Metadata: &chartv2.Metadata{
+		APIVersion: chartv2.APIVersionV1,
+		Name:       "simple-chart",
+		Version:    "1.0.0",
+	}}
+	tgzPath, err := chartutil.Save(ch, t.TempDir())
+	require.NoError(t, err)
+	chartData, err := os.ReadFile(tgzPath)
+	require.NoError(t, err)
+
+	// Push the chart to an in-memory OCI registry over plain HTTP.
+	regAddr := testutil.SetupInMemoryRegistryDynamic(ctx, t)
+	regClient, err := registry.NewClient(registry.ClientOptPlainHTTP())
+	require.NoError(t, err)
+	_, err = regClient.Push(chartData, fmt.Sprintf("%s/charts/simple-chart:1.0.0", regAddr))
+	require.NoError(t, err)
+
+	chart := v1alpha1.ZarfChart{
+		Name:    "simple-chart",
+		Version: "1.0.0",
+		URL:     fmt.Sprintf("oci://%s/charts/simple-chart", regAddr),
+	}
+	chartPath := t.TempDir()
+	err = PackageChart(ctx, chart, chartPath, t.TempDir(), t.TempDir(), types.RemoteOptions{
+		PlainHTTP:             true,
+		InsecureSkipTLSVerify: true,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, StandardName(chartPath, chart)+".tgz")
+}

--- a/src/internal/packager/helm/repo_test.go
+++ b/src/internal/packager/helm/repo_test.go
@@ -79,9 +79,6 @@ entries:
 	require.FileExists(t, StandardName(chartPath, chart)+".tgz")
 }
 
-// TestDownloadPublishedChartFromOCI covers a chart whose URL is itself an OCI
-// reference, so Zarf provisions a registry client directly rather than resolving
-// through a classic Helm repository index.
 func TestDownloadPublishedChartFromOCI(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.TestContext(t)


### PR DESCRIPTION
## Description

This broke with Helm 3 to Helm 4. Starting in Helm 4 all OCI pulls require an explicit registry client, and we were not creating this client in the direct path

## Related Issue

Fixes #5064


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
