### PR TITLE
fix(proxy): support for system CA with mTLS certs

### DIFF
--- a/src/pkg/pki/pki.go
+++ b/src/pkg/pki/pki.go
@@ -389,13 +389,31 @@ func GenerateMTLSCerts(caSubject string, serverDNSNames []string, serverCommonNa
 }
 
 // TransportWithKey creates an HTTP transport configured with mTLS certificates.
+//
+// The registry CA is added to, rather than replaces, the system trust store. Registry
+// storage drivers can redirect blob requests to external endpoints such as S3
 func TransportWithKey(certs GeneratedPKI) (http.RoundTripper, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil || rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	return transportWithKey(certs, rootCAs)
+}
+
+// transportWithKey creates an mTLS transport using baseRootCAs as the existing
+// trusted roots. It is split out to make the combined trust behavior testable
+// without depending on the host's system trust store.
+func transportWithKey(certs GeneratedPKI, baseRootCAs *x509.CertPool) (http.RoundTripper, error) {
 	cert, err := tls.X509KeyPair(certs.Cert, certs.Key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load client certificate: %w", err)
 	}
 
-	caCertPool := x509.NewCertPool()
+	if baseRootCAs == nil {
+		baseRootCAs = x509.NewCertPool()
+	}
+	caCertPool := baseRootCAs.Clone()
 	if !caCertPool.AppendCertsFromPEM(certs.CA) {
 		return nil, fmt.Errorf("failed to parse CA certificate")
 	}

--- a/src/pkg/pki/pki_test.go
+++ b/src/pkg/pki/pki_test.go
@@ -6,6 +6,11 @@ package pki
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -96,6 +101,64 @@ func TestGeneratePKIWithOptions(t *testing.T) {
 	require.NoError(t, err)
 	expectedExpiry := creationTime.Add(duration)
 	require.Equal(t, expectedExpiry, cert.NotAfter)
+}
+
+func TestTransportWithKeyFollowsRedirectToSeparatelyTrustedEndpoint(t *testing.T) {
+	originalNow := now
+	now = time.Now
+	t.Cleanup(func() { now = originalNow })
+
+	registryServerPKI, registryClientPKI, err := GenerateMTLSCerts("registry CA", nil, "registry", "registry-client")
+	require.NoError(t, err)
+
+	externalPKI, err := GeneratePKI("external")
+	require.NoError(t, err)
+
+	externalCert, err := tls.X509KeyPair(externalPKI.Cert, externalPKI.Key)
+	require.NoError(t, err)
+	externalServer := newTLSServer(t, &tls.Config{Certificates: []tls.Certificate{externalCert}}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer externalServer.Close()
+
+	registryCert, err := tls.X509KeyPair(registryServerPKI.Cert, registryServerPKI.Key)
+	require.NoError(t, err)
+	registryClientCAs := x509.NewCertPool()
+	require.True(t, registryClientCAs.AppendCertsFromPEM(registryClientPKI.CA))
+	registryServer := newTLSServer(t, &tls.Config{
+		Certificates: []tls.Certificate{registryCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    registryClientCAs,
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, externalServer.URL, http.StatusTemporaryRedirect)
+	}))
+	defer registryServer.Close()
+
+	externalRootCAs := x509.NewCertPool()
+	require.True(t, externalRootCAs.AppendCertsFromPEM(externalPKI.CA))
+	transport, err := transportWithKey(registryClientPKI, externalRootCAs)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: transport}
+	response, err := client.Get(registryServer.URL)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, response.Body.Close())
+	}()
+	require.Equal(t, http.StatusNoContent, response.StatusCode)
+}
+
+func newTLSServer(t *testing.T, tlsConfig *tls.Config, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.TLS = tlsConfig
+	server.StartTLS()
+	return server
 }
 
 func TestGetRemainingCertLifePercentage(t *testing.T) {


### PR DESCRIPTION
## Description

The use of the proxy registry mode (which notably added mTLS certs to the registry/proxy) enabled encryption of the image push logic - but when the registry is backed by an s3 storage backend and not configured to disable redirects uses the self-signed CA to perform the redirect to the S3 bucket and fails due to TLS handshake. 

This adds the self signed CA to the system CA instead of solely creating a new cert pool.

Worth noting that this can be overcome by setting configuration on the registry to disable redirects and have the registry route all traffic.

## Related Issue

Fixes #5075


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
