### PR TITLE
feat: stop requiring version for localpath charts

### DIFF
--- a/examples/helm-charts/zarf.yaml
+++ b/examples/helm-charts/zarf.yaml
@@ -10,7 +10,6 @@ components:
     charts:
       # Charts are organized in a list with unique chart names per component - note that a Zarf chart name does not need to match the chart name in a Chart.yaml
       - name: podinfo-local
-        version: 6.4.0
         namespace: podinfo-from-local-chart
         # In this case `localPath` will load the podinfo chart that is located in the `chart` directory
         localPath: chart

--- a/src/internal/api/v1alpha1/validate.go
+++ b/src/internal/api/v1alpha1/validate.go
@@ -292,7 +292,7 @@ func validateChart(chart v1alpha1.ZarfChart) error {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartURLOrPath, chart.Name))
 	}
 
-	// Local charts don't need to be found ihn an upstream repo and their Chart.yaml already has a version
+	// Local charts don't need to be found in an upstream repo and their Chart.yaml already has a version
 	if chart.LocalPath == "" && chart.Version == "" {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartVersion, chart.Name))
 	}

--- a/src/internal/api/v1alpha1/validate.go
+++ b/src/internal/api/v1alpha1/validate.go
@@ -292,7 +292,7 @@ func validateChart(chart v1alpha1.ZarfChart) error {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartURLOrPath, chart.Name))
 	}
 
-	// Local charts take their version from the chart's own Chart.yaml, so a version is only required for remote charts.
+	// Local charts don't need to be found ihn an upstream repo and their Chart.yaml already has a version
 	if chart.LocalPath == "" && chart.Version == "" {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartVersion, chart.Name))
 	}

--- a/src/internal/api/v1alpha1/validate.go
+++ b/src/internal/api/v1alpha1/validate.go
@@ -292,7 +292,8 @@ func validateChart(chart v1alpha1.ZarfChart) error {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartURLOrPath, chart.Name))
 	}
 
-	if chart.Version == "" {
+	// Local charts take their version from the chart's own Chart.yaml, so a version is only required for remote charts.
+	if chart.LocalPath == "" && chart.Version == "" {
 		err = errors.Join(err, fmt.Errorf(PkgValidateErrChartVersion, chart.Name))
 	}
 

--- a/src/internal/api/v1alpha1/validate_test.go
+++ b/src/internal/api/v1alpha1/validate_test.go
@@ -293,6 +293,18 @@ func TestValidateChart(t *testing.T) {
 			},
 		},
 		{
+			name:         "local path without version",
+			chart:        v1alpha1.ZarfChart{Name: "chart1", Namespace: "whatever", LocalPath: "wherever"},
+			expectedErrs: nil,
+		},
+		{
+			name:  "url without version",
+			chart: v1alpha1.ZarfChart{Name: "chart1", Namespace: "whatever", URL: "http://whatever"},
+			expectedErrs: []string{
+				fmt.Sprintf(PkgValidateErrChartVersion, "chart1"),
+			},
+		},
+		{
 			name:         "invalid releaseName",
 			chart:        v1alpha1.ZarfChart{ReleaseName: "namedwithperiods-0.47.0", Name: "releaseName", Namespace: "whatever", URL: "http://whatever", Version: "v1.0.0"},
 			expectedErrs: []string{"invalid release name 'namedwithperiods-0.47.0'"},

--- a/src/pkg/packager/layout/assemble.go
+++ b/src/pkg/packager/layout/assemble.go
@@ -882,22 +882,28 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 
 func collectVersionRequirements(pkg v1alpha1.ZarfPackage, hasIndex bool) []v1alpha1.VersionRequirement {
 	var reqs []v1alpha1.VersionRequirement
-	var hasImageArchives, hasTemplatedValuesFiles bool
+	var hasImageArchives, hasTemplatedValuesFiles, hasVersionlessChart bool
 	for _, comp := range pkg.Components {
 		if !hasImageArchives && len(comp.ImageArchives) > 0 {
 			hasImageArchives = true
 		}
-		if !hasTemplatedValuesFiles {
-			for _, chart := range comp.Charts {
-				if len(chart.TemplatedValuesFiles) > 0 {
-					hasTemplatedValuesFiles = true
-					break
-				}
+		for _, chart := range comp.Charts {
+			if len(chart.TemplatedValuesFiles) > 0 {
+				hasTemplatedValuesFiles = true
+			}
+			if chart.Version == "" {
+				hasVersionlessChart = true
 			}
 		}
-		if hasImageArchives && hasTemplatedValuesFiles {
+		if hasImageArchives && hasTemplatedValuesFiles && hasVersionlessChart {
 			break
 		}
+	}
+	if hasVersionlessChart {
+		reqs = append(reqs, v1alpha1.VersionRequirement{
+			Version: "v0.65.0",
+			Reason:  "This package contains a chart without a version, which is only supported on v0.65.0+",
+		})
 	}
 	if hasImageArchives {
 		reqs = append(reqs, v1alpha1.VersionRequirement{

--- a/src/pkg/packager/layout/assemble_test.go
+++ b/src/pkg/packager/layout/assemble_test.go
@@ -232,6 +232,10 @@ func TestCollectVersionRequirements(t *testing.T) {
 		Version: "v0.77.0",
 		Reason:  "This package contains multi-platform images preserved by index digest, which require v0.77.0+",
 	}
+	versionlessChartReq := v1alpha1.VersionRequirement{
+		Version: "v0.65.0",
+		Reason:  "This package contains a chart without a version, which is only supported on v0.65.0+",
+	}
 
 	tests := []struct {
 		name     string
@@ -286,6 +290,40 @@ func TestCollectVersionRequirements(t *testing.T) {
 				},
 			},
 			expected: []v1alpha1.VersionRequirement{imageArchivesReq},
+		},
+		{
+			name: "chart without a version triggers v0.65.0",
+			pkg: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name:   "c1",
+						Charts: []v1alpha1.ZarfChart{{Name: "local", LocalPath: "./chart"}},
+					},
+				},
+			},
+			expected: []v1alpha1.VersionRequirement{versionlessChartReq},
+		},
+		{
+			name: "versionless chart requirement is only emitted once across charts",
+			pkg: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{Name: "c1", Charts: []v1alpha1.ZarfChart{{Name: "a", LocalPath: "./a"}}},
+					{Name: "c2", Charts: []v1alpha1.ZarfChart{{Name: "b", LocalPath: "./b"}}},
+				},
+			},
+			expected: []v1alpha1.VersionRequirement{versionlessChartReq},
+		},
+		{
+			name: "chart with a version has no requirement",
+			pkg: v1alpha1.ZarfPackage{
+				Components: []v1alpha1.ZarfComponent{
+					{
+						Name:   "c1",
+						Charts: []v1alpha1.ZarfChart{{Name: "local", LocalPath: "./chart", Version: "1.0.0"}},
+					},
+				},
+			},
+			expected: nil,
 		},
 	}
 

--- a/src/test/e2e/15_oci_compose_test.go
+++ b/src/test/e2e/15_oci_compose_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/transform"
@@ -290,8 +291,8 @@ func (suite *PublishCopySkeletonSuite) verifyComponentPaths(unpackedPath string,
 				suite.DirExists(filepath.Join(chartDir, dir))
 				continue
 			}
-			tgz := fmt.Sprintf("%s-%s.tgz", chart.Name, chart.Version)
-			suite.FileExists(filepath.Join(chartDir, tgz))
+			tgz := helm.StandardName(chartDir, chart) + ".tgz"
+			suite.FileExists(tgz)
 		}
 
 		var containsFiles bool

--- a/src/test/packages/49-adopt-no-ns-template/zarf.yaml
+++ b/src/test/packages/49-adopt-no-ns-template/zarf.yaml
@@ -8,6 +8,5 @@ components:
     required: true
     charts:
       - name: adopt-no-ns-template
-        version: 0.1.0
         namespace: adopt-no-ns-template
         localPath: chart

--- a/src/test/packages/49-adopt-ns-with-agent-ignore/zarf.yaml
+++ b/src/test/packages/49-adopt-ns-with-agent-ignore/zarf.yaml
@@ -8,6 +8,5 @@ components:
     required: true
     charts:
       - name: adopt-ns-with-agent-ignore
-        version: 0.1.0
         namespace: adopt-ns-with-agent-ignore
         localPath: chart


### PR DESCRIPTION
## Description

stop requiring version for charts when localpath is used

## Related Issue

Fixes #3813

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
