### PR TITLE
docs: update command from 'prepare' to 'dev' in tutorial command html

### DIFF
--- a/site/public/tutorials/prepare_find_images.html
+++ b/site/public/tutorials/prepare_find_images.html
@@ -47,7 +47,7 @@ b.BWHI {background-color: #aaaaaa}
 </head>
 <body>
 <pre>
-<b class="WHI">$ zarf prepare find-images</b><br/>
+<b class="WHI">$ zarf dev find-images</b><br/>
 <b class=YEL>Saving log file to /tmp/zarf-2023-05-06-16-17-52-1241631429.log</b>
 •  <b style="color:#55ffff;">Processing helm chart wordpress:26.0.0 from repo oci://registry-1.docker.io/bitnamicharts/wordpress</b>
 •  <b style="color:#55ffff;">Templating helm chart wordpress</b><br/>


### PR DESCRIPTION
## Description

The documentation instructs users to run the `dev` command rather than `prepare`, so I updated the command to match the tutorial. The `prepare` command produces the same result, but it is not the command referenced in the documentation.

...

## Related Issue

None

## Checklist before merging

- [ x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
