### PR TITLE
feat: expose GetComponent function for package templating

### DIFF
--- a/examples/values-templating/nginx-configmap.yaml
+++ b/examples/values-templating/nginx-configmap.yaml
@@ -84,7 +84,7 @@ data:
         <h3>Package values (via .Pkg)</h3>
         <pre>Name: {{ .Pkg.Metadata.Name }}</pre>
         <pre>CLI version during build: {{ .Pkg.Build.Version }}</pre>
-        <pre>Nginx Image: {{ range .Pkg.Components }}{{ if eq .Name "values-with-manifest" }}{{ index .Images 0 }}{{ end }}{{ end }}</pre>
+        <pre>Nginx Image: {{ index (.Pkg.GetComponent "values-with-manifest").Images 0 }}</pre>
 
         {{ .Values.site.footer }}
       </body>

--- a/examples/values-templating/readme.md
+++ b/examples/values-templating/readme.md
@@ -6,6 +6,7 @@ This example demonstrates the pre-release alpha version of Zarf's values templat
 
 - **Basic templating** with `{{ .Values.* }}`, `{{ .Build.* }}`, `{{ .Metadata.* }}`, `{{ .Constants.* }}`, and `{{ .Variables.* }}`
 - **Cluster state** with `{{ .State.Registry.Address }}`, `{{ .State.StorageClass }}`, `{{ .State.IPFamily }}`, and other non-sensitive runtime fields via `.State`
+- **Package object** access via `.Pkg`, including `{{ (.Pkg.GetComponent "name").Images }}` to look up a component by name
 - **Sprig functions** for string manipulation, lists, math, encoding, and more
 - **File templating** with both simple substitution and complex transformations
 - **Dynamic configuration** using template functions for practical Kubernetes deployments

--- a/src/api/v1alpha1/package.go
+++ b/src/api/v1alpha1/package.go
@@ -81,6 +81,16 @@ func (pkg ZarfPackage) IsInitConfig() bool {
 	return pkg.Kind == ZarfInitConfig
 }
 
+// GetComponent returns the component with the given name, or an error if no such component exists.
+func (pkg ZarfPackage) GetComponent(name string) (ZarfComponent, error) {
+	for _, component := range pkg.Components {
+		if component.Name == name {
+			return component, nil
+		}
+	}
+	return ZarfComponent{}, fmt.Errorf("no component named %q in package %q", name, pkg.Metadata.Name)
+}
+
 // HasImages returns true if one of the components contains an image.
 func (pkg ZarfPackage) HasImages() bool {
 	for _, component := range pkg.Components {

--- a/src/api/v1alpha1/package_test.go
+++ b/src/api/v1alpha1/package_test.go
@@ -157,6 +157,31 @@ func TestUniqueNamespaces(t *testing.T) {
 	}
 }
 
+func TestGetComponent(t *testing.T) {
+	t.Parallel()
+
+	pkg := ZarfPackage{
+		Components: []ZarfComponent{
+			{Name: "first", Images: []string{"docker.io/library/nginx:latest"}},
+			{Name: "second"},
+		},
+	}
+
+	t.Run("returns matching component", func(t *testing.T) {
+		t.Parallel()
+		got, err := pkg.GetComponent("first")
+		require.NoError(t, err)
+		require.Equal(t, "first", got.Name)
+		require.Equal(t, []string{"docker.io/library/nginx:latest"}, got.Images)
+	})
+
+	t.Run("errors when component is absent", func(t *testing.T) {
+		t.Parallel()
+		_, err := pkg.GetComponent("missing")
+		require.Error(t, err)
+	})
+}
+
 func TestZarfPackageIsSBOMable(t *testing.T) {
 	t.Parallel()
 

--- a/src/api/v1beta1/package.go
+++ b/src/api/v1beta1/package.go
@@ -4,6 +4,8 @@
 // Package v1beta1 holds the definition of the v1beta1 Zarf Package. This API is work in progress and not yet used within Zarf.
 package v1beta1
 
+import "fmt"
+
 // PackageKind is an enum of the different kinds of Zarf packages.
 type PackageKind string
 
@@ -51,6 +53,16 @@ func (pkg Package) GetDeprecatedVariables() []InteractiveVariable {
 // Deprecated: only used to convert v1alpha1 packages; will be removed once v1alpha1 support is dropped.
 func (pkg Package) GetDeprecatedConstants() []Constant {
 	return pkg.constants
+}
+
+// GetComponent returns the component with the given name, or an error if no such component exists.
+func (pkg Package) GetComponent(name string) (Component, error) {
+	for _, component := range pkg.Components {
+		if component.Name == name {
+			return component, nil
+		}
+	}
+	return Component{}, fmt.Errorf("no component named %q in package %q", name, pkg.Metadata.Name)
 }
 
 // HasImages returns true if one of the components contains an image.

--- a/src/api/v1beta1/package_test.go
+++ b/src/api/v1beta1/package_test.go
@@ -31,6 +31,34 @@ func TestPackageHasImages(t *testing.T) {
 	require.True(t, pkg.HasImages())
 }
 
+func TestGetComponent(t *testing.T) {
+	t.Parallel()
+
+	pkg := Package{
+		Components: []Component{
+			{
+				Name:          "first",
+				ComponentSpec: ComponentSpec{Images: []Image{{Name: "docker.io/library/nginx:latest"}}},
+			},
+			{Name: "second"},
+		},
+	}
+
+	t.Run("returns matching component", func(t *testing.T) {
+		t.Parallel()
+		got, err := pkg.GetComponent("first")
+		require.NoError(t, err)
+		require.Equal(t, "first", got.Name)
+		require.Equal(t, []Image{{Name: "docker.io/library/nginx:latest"}}, got.Images)
+	})
+
+	t.Run("errors when component is absent", func(t *testing.T) {
+		t.Parallel()
+		_, err := pkg.GetComponent("missing")
+		require.Error(t, err)
+	})
+}
+
 func TestPackageIsSBOMable(t *testing.T) {
 	t.Parallel()
 

--- a/src/internal/template/template_test.go
+++ b/src/internal/template/template_test.go
@@ -316,6 +316,30 @@ func TestApply(t *testing.T) {
 			expected: "echo HELLO WORLD",
 		},
 		{
+			name: "package GetComponent lookup",
+			s:    `image {{ index (.Pkg.GetComponent "web").Images 0 }}`,
+			objects: Objects{
+				objectKeyPackage: v1alpha1.ZarfPackage{
+					Components: []v1alpha1.ZarfComponent{
+						{Name: "web", Images: []string{"nginx:latest"}},
+					},
+				},
+			},
+			expected: "image nginx:latest",
+		},
+		{
+			name: "package GetComponent missing component errors",
+			s:    `image {{ (.Pkg.GetComponent "absent").Name }}`,
+			objects: Objects{
+				objectKeyPackage: v1alpha1.ZarfPackage{
+					Components: []v1alpha1.ZarfComponent{
+						{Name: "web"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name:    "invalid template syntax",
 			s:       "echo {{ .Values.missing",
 			objects: Objects{},


### PR DESCRIPTION
## Description

Exposes a Pkg.GetComponent function, this will be helpful when use the `.Pkg` object when templating files

## Related Issue

Fixes #4878

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
