### PR TITLE
fix: ensure `dev generate-schema` includes accurate values for imported components

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -84,7 +84,7 @@ func parseSchemaValues(ctx context.Context, basePath string, defined load.Define
 	return zarfValues, nil
 }
 
-func rootPackageValuesFiles(ctx context.Context, basePath string) ([]string, error) {
+func rootPackageValuesFiles(ctx context.Context, basePath string, setPkgTmpl map[string]string) ([]string, error) {
 	pkgPath, err := layout.ResolvePackagePath(basePath)
 	if err != nil {
 		return nil, err
@@ -96,6 +96,16 @@ func rootPackageValuesFiles(ctx context.Context, basePath string) ([]string, err
 	pkg, err := pkgcfg.Parse(ctx, b)
 	if err != nil {
 		return nil, err
+	}
+	templateMap := map[string]string{
+		v1alpha1.ZarfPackageArch: config.GetArch(pkg.Metadata.Architecture),
+	}
+	for key, value := range setPkgTmpl {
+		templateMap[fmt.Sprintf("%s%s###", v1alpha1.ZarfPackageTemplatePrefix, key)] = value
+		templateMap[fmt.Sprintf("%s%s###", v1alpha1.ZarfPackageVariablePrefix, key)] = value
+	}
+	if err := utils.ReloadYamlTemplate(&pkg, templateMap); err != nil {
+		return nil, fmt.Errorf("unable to render root package templates: %w", err)
 	}
 	return pkg.Values.Files, nil
 }
@@ -213,7 +223,7 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error
 	}
 
 	// Step 1: Merge package defaults, limiting imported defaults to their selected components' chart value mappings.
-	rootValuesFiles, err := rootPackageValuesFiles(ctx, basePath)
+	rootValuesFiles, err := rootPackageValuesFiles(ctx, basePath, o.setPkgTmpl)
 	if err != nil {
 		return fmt.Errorf("unable to read root package values files: %w", err)
 	}

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -27,6 +27,7 @@ import (
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/config/lang"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
+	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -57,6 +58,81 @@ func parseValues(ctx context.Context, valuesFiles []string, setValues map[string
 		}
 	}
 	return values, nil
+}
+
+func parseSchemaValues(ctx context.Context, basePath string, defined load.DefinedPackage, rootValuesFiles []string) (value.Values, error) {
+	rootValuesPaths := map[string]bool{}
+	for _, path := range rootValuesFiles {
+		rootValuesPaths[normalizedValuesPath(path)] = true
+	}
+
+	sourcePaths := chartValueSourcePaths(defined.Pkg.Components)
+
+	zarfValues := value.Values{}
+	for _, path := range defined.Pkg.Values.Files {
+		values, err := value.ParseFiles(ctx, []string{filepath.Join(basePath, path)}, value.ParseFilesOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse package values file %q: %w", path, err)
+		}
+
+		if !rootValuesPaths[normalizedValuesPath(path)] {
+			values = filterValuesForSourcePaths(values, sourcePaths)
+		}
+		zarfValues.DeepMerge(values)
+	}
+
+	return zarfValues, nil
+}
+
+func rootPackageValuesFiles(ctx context.Context, basePath string) ([]string, error) {
+	pkgPath, err := layout.ResolvePackagePath(basePath)
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(pkgPath.ManifestFile)
+	if err != nil {
+		return nil, err
+	}
+	pkg, err := pkgcfg.Parse(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+	return pkg.Values.Files, nil
+}
+
+func chartValueSourcePaths(components []v1alpha1.ZarfComponent) []string {
+	var sourcePaths []string
+	for _, component := range components {
+		for _, chart := range component.Charts {
+			for _, chartValue := range chart.Values {
+				sourcePaths = append(sourcePaths, chartValue.SourcePath)
+			}
+		}
+	}
+	return sourcePaths
+}
+
+func filterValuesForSourcePaths(values value.Values, sourcePaths []string) value.Values {
+	filteredValues := value.Values{}
+	for _, sourcePath := range sourcePaths {
+		mappedValue, err := values.Extract(value.Path(sourcePath))
+		if err != nil {
+			// A mapping may rely entirely on chart defaults, so an absent package default
+			// is not an error during schema generation.
+			continue
+		}
+		if err := filteredValues.Set(value.Path(sourcePath), mappedValue); err != nil {
+			continue
+		}
+	}
+	return filteredValues
+}
+
+func normalizedValuesPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.ToSlash(filepath.Clean(path))
 }
 
 func newDevCommand() *cobra.Command {
@@ -136,12 +212,12 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error
 		return err
 	}
 
-	// Step 1: Merge default values.files to create initial set of default Zarf values
-	valuesPaths := make([]string, len(defined.Pkg.Values.Files))
-	for i, file := range defined.Pkg.Values.Files {
-		valuesPaths[i] = filepath.Join(basePath, file)
+	// Step 1: Merge package defaults, limiting imported defaults to their selected components' chart value mappings.
+	rootValuesFiles, err := rootPackageValuesFiles(ctx, basePath)
+	if err != nil {
+		return fmt.Errorf("unable to read root package values files: %w", err)
 	}
-	zarfValues, err := value.ParseFiles(ctx, valuesPaths, value.ParseFilesOptions{})
+	zarfValues, err := parseSchemaValues(ctx, basePath, defined, rootValuesFiles)
 	if err != nil {
 		return fmt.Errorf("unable to parse package values files: %w", err)
 	}

--- a/src/test/e2e/14_zarf_package_generate_test.go
+++ b/src/test/e2e/14_zarf_package_generate_test.go
@@ -93,6 +93,10 @@ func TestZarfDevGenerate(t *testing.T) {
 		// .backend.replicas should take the description from the child values.schema.json
 		require.Equal(t, "Replica count", bReplicas["description"])
 
+		// .frontend belongs to an unimported component and must not be included from the child values file.
+		_, hasFrontend := props["frontend"]
+		require.False(t, hasFrontend)
+
 		// .backend.service.port should be pulled in from the child's mapped chart
 		bService, ok := backendProps["service"].(map[string]any)
 		require.True(t, ok)

--- a/src/test/packages/14-generate-schema/common/values.yaml
+++ b/src/test/packages/14-generate-schema/common/values.yaml
@@ -1,3 +1,5 @@
 backend:
   name: schema-app
   replicaCount: 2
+frontend:
+  enabled: true

--- a/src/test/packages/14-generate-schema/common/zarf.yaml
+++ b/src/test/packages/14-generate-schema/common/zarf.yaml
@@ -22,3 +22,13 @@ components:
             targetPath: "."
             excludePaths:
               - ".backend.image"
+  - name: frontend-chart
+    charts:
+      - name: frontend-chart
+        version: 0.1.0
+        releaseName: frontend-chart
+        namespace: frontend-test
+        localPath: ../chart
+        values:
+          - sourcePath: ".frontend"
+            targetPath: "."


### PR DESCRIPTION
## Description

More context is in the issue, but currently the `dev generate-schema` command will make a schema that captures ALL "default" values for a package used in an import, even if only one component was used from that package. This change ensures that the default values are filtered based on `sourcePath` mappings so that only the components that are imported are represented in the resulting schema.

## Related Issue

Fixes https://github.com/zarf-dev/zarf/issues/5086

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
