### PR TITLE
fix(injection): support retry for toomanyrequests

### DIFF
--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -40,11 +40,6 @@ import (
 
 var zarfImageRegex = regexp.MustCompile(`(?m)^(127\.0\.0\.1|\[::1\]):`)
 
-const (
-	payloadConfigMapBaseDelay = 250 * time.Millisecond
-	payloadConfigMapMaxDelay  = 2 * time.Second
-)
-
 // ZarfInjectorOptions represents the options used by injector pod
 type ZarfInjectorOptions struct {
 	// RegistryNodePort, using uint16 allows for only valid ports; 0 lets Kubernetes choose
@@ -137,10 +132,7 @@ func (c *Cluster) CreateInjectorConfigMaps(ctx context.Context, tmpDir, imagesDi
 		WithLabels(map[string]string{
 			PackageLabel: pkgName,
 		})
-	_, err = retryInjectorRequest(ctx, "apply injector binary ConfigMap", func() error {
-		_, err := c.Clientset.CoreV1().ConfigMaps(*cm.Namespace).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
-		return err
-	})
+	_, err = c.Clientset.CoreV1().ConfigMaps(*cm.Namespace).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 	if err != nil {
 		return nil, "", err
 	}
@@ -182,29 +174,6 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	// This is needed because labels were not present in payload config maps previously.
-	// Without this injector will fail if the config maps exist from a previous Zarf version.
-	var cmList *corev1.ConfigMapList
-	_, err = retryInjectorRequest(ctx, "list legacy injector payload ConfigMaps", func() error {
-		var listErr error
-		cmList, listErr = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).List(ctx, metav1.ListOptions{})
-		return listErr
-	})
-	if err != nil {
-		return err
-	}
-	for _, cm := range cmList.Items {
-		if !strings.HasPrefix(cm.Name, "zarf-payload-") {
-			continue
-		}
-		_, err = retryInjectorRequest(ctx, "delete legacy injector payload ConfigMap", func() error {
-			return c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-		})
-		if err != nil {
-			return err
-		}
 	}
 
 	// TODO: Replace with wait package in the future.
@@ -269,7 +238,6 @@ func (c *Cluster) createPayloadConfigMaps(ctx context.Context, tmpDir, imagesDir
 		return nil, "", err
 	}
 	cmNames := []string{}
-	payloadConfigMapDelay := payloadConfigMapBaseDelay
 	l.Info("adding archived binary configmaps of registry image to the cluster")
 	for i, data := range chunks {
 		fileName := fmt.Sprintf("zarf-payload-%03d", i)
@@ -282,25 +250,14 @@ func (c *Cluster) createPayloadConfigMaps(ctx context.Context, tmpDir, imagesDir
 			WithBinaryData(map[string][]byte{
 				fileName: data,
 			})
-		retried, err := retryInjectorRequest(ctx, "apply injector payload ConfigMap", func() error {
-			_, applyErr := c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
-			return applyErr
-		})
+		_, err = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 		if err != nil {
 			return nil, "", err
 		}
 		cmNames = append(cmNames, fileName)
 
-		if retried {
-			payloadConfigMapDelay = min(payloadConfigMapDelay*2, payloadConfigMapMaxDelay)
-		} else if payloadConfigMapDelay > payloadConfigMapBaseDelay {
-			payloadConfigMapDelay = max(payloadConfigMapDelay/2, payloadConfigMapBaseDelay)
-		}
-		if i < len(chunks)-1 {
-			if err := waitForPayloadConfigMapPacing(ctx, payloadConfigMapDelay); err != nil {
-				return nil, "", err
-			}
-		}
+		// Give the control plane a 250ms buffer between each configmap.
+		time.Sleep(250 * time.Millisecond)
 	}
 	return cmNames, shasum, nil
 }
@@ -712,7 +669,7 @@ func (c *Cluster) createInjectorNodeportService(ctx context.Context, pkgName str
 	return svc, nil
 }
 
-// retryInjectorRequest retries headerless transient Kubernetes API throttles for idempotent injector ConfigMap operations.
+// retryInjectorRequest retries headerless transient Kubernetes API throttles for injector payload cleanup.
 func retryInjectorRequest(ctx context.Context, operation string, request func() error) (retried bool, err error) {
 	l := logger.From(ctx)
 	err = retry.Do(func() error {
@@ -749,15 +706,4 @@ func retryInjectorRequest(ctx context.Context, operation string, request func() 
 func hasServerRetryDelay(err error) bool {
 	_, ok := kerrors.SuggestsClientDelay(err)
 	return ok
-}
-
-func waitForPayloadConfigMapPacing(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
 }

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -268,7 +268,6 @@ func (c *Cluster) createPayloadConfigMaps(ctx context.Context, tmpDir, imagesDir
 	if err != nil {
 		return nil, "", err
 	}
-
 	cmNames := []string{}
 	payloadConfigMapDelay := payloadConfigMapBaseDelay
 	l.Info("adding archived binary configmaps of registry image to the cluster")
@@ -729,13 +728,20 @@ func retryInjectorRequest(ctx context.Context, operation string, request func() 
 		retry.Attempts(uint(config.ZarfDefaultRetries)),
 		retry.Delay(config.ZarfDefaultRetryDelay),
 		retry.MaxDelay(config.ZarfDefaultRetryMaxDelay),
-		retry.DelayType(retry.CombineDelay(retry.BackOffDelay, retry.RandomDelay)),
+		retry.DelayType(func(n uint, requestErr error, retryConfig *retry.Config) time.Duration {
+			delay := retry.CombineDelay(retry.BackOffDelay, retry.RandomDelay)(n, requestErr, retryConfig)
+			retried = true
+			l.Warn("retrying transient Kubernetes API request",
+				"operation", operation,
+				"attempt", n+1,
+				"maxAttempts", config.ZarfDefaultRetries,
+				"nextDelay", delay,
+				"error", requestErr,
+			)
+			return delay
+		}),
 		retry.LastErrorOnly(true),
 		retry.Context(ctx),
-		retry.OnRetry(func(n uint, requestErr error) {
-			retried = true
-			l.Warn("retrying transient Kubernetes API request", "operation", operation, "attempt", n+1, "maxAttempts", config.ZarfDefaultRetries, "error", requestErr)
-		}),
 	)
 	return retried, err
 }

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/defenseunicorns/pkg/helpers/v2"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/healthchecks"
 	"github.com/zarf-dev/zarf/src/pkg/archive"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -38,6 +39,13 @@ import (
 )
 
 var zarfImageRegex = regexp.MustCompile(`(?m)^(127\.0\.0\.1|\[::1\]):`)
+
+var errInjectorNodePortConflict = errors.New("injector service NodePort conflicts with registry NodePort")
+
+const (
+	payloadConfigMapBaseDelay = 250 * time.Millisecond
+	payloadConfigMapMaxDelay  = 2 * time.Second
+)
 
 // ZarfInjectorOptions represents the options used by injector pod
 type ZarfInjectorOptions struct {
@@ -91,7 +99,10 @@ func (c *Cluster) StartInjection(ctx context.Context, tmpDir, imagesDir string, 
 	}
 
 	pod := buildInjectionPod(injectorNodeName, injectorImage, payloadCmNames, shasum, resReq, pkgName, opts.IPFamily)
-	_, err = c.Clientset.CoreV1().Pods(*pod.Namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+	_, err = retryInjectorRequest(ctx, "apply injector pod", func() error {
+		_, err := c.Clientset.CoreV1().Pods(*pod.Namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+		return err
+	})
 	if err != nil {
 		return "", 0, fmt.Errorf("error creating pod in cluster: %w", err)
 	}
@@ -131,7 +142,10 @@ func (c *Cluster) CreateInjectorConfigMaps(ctx context.Context, tmpDir, imagesDi
 		WithLabels(map[string]string{
 			PackageLabel: pkgName,
 		})
-	_, err = c.Clientset.CoreV1().ConfigMaps(*cm.Namespace).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+	_, err = retryInjectorRequest(ctx, "apply injector binary ConfigMap", func() error {
+		_, err := c.Clientset.CoreV1().ConfigMaps(*cm.Namespace).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+		return err
+	})
 	if err != nil {
 		return nil, "", err
 	}
@@ -143,15 +157,21 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 	start := time.Now()
 	l := logger.From(ctx)
 	l.Debug("deleting injector resources")
-	err := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Delete(ctx, "injector", metav1.DeleteOptions{})
+	_, err := retryInjectorRequest(ctx, "delete injector pod", func() error {
+		return c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Delete(ctx, "injector", metav1.DeleteOptions{})
+	})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
-	err = c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
+	_, err = retryInjectorRequest(ctx, "delete injector service", func() error {
+		return c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
+	})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
-	err = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Delete(ctx, "rust-binary", metav1.DeleteOptions{})
+	_, err = retryInjectorRequest(ctx, "delete injector binary ConfigMap", func() error {
+		return c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Delete(ctx, "rust-binary", metav1.DeleteOptions{})
+	})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
@@ -166,14 +186,21 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 	listOpts := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	err = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts)
+	_, err = retryInjectorRequest(ctx, "delete injector payload ConfigMaps", func() error {
+		return c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts)
+	})
 	if err != nil {
 		return err
 	}
 
 	// This is needed because labels were not present in payload config maps previously.
 	// Without this injector will fail if the config maps exist from a previous Zarf version.
-	cmList, err := c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).List(ctx, metav1.ListOptions{})
+	var cmList *corev1.ConfigMapList
+	_, err = retryInjectorRequest(ctx, "list legacy injector payload ConfigMaps", func() error {
+		var listErr error
+		cmList, listErr = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).List(ctx, metav1.ListOptions{})
+		return listErr
+	})
 	if err != nil {
 		return err
 	}
@@ -181,7 +208,9 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 		if !strings.HasPrefix(cm.Name, "zarf-payload-") {
 			continue
 		}
-		err = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+		_, err = retryInjectorRequest(ctx, "delete legacy injector payload ConfigMap", func() error {
+			return c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+		})
 		if err != nil {
 			return err
 		}
@@ -189,7 +218,10 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 
 	// TODO: Replace with wait package in the future.
 	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Get(ctx, "injector", metav1.GetOptions{})
+		_, err := retryInjectorRequest(ctx, "get injector pod during cleanup", func() error {
+			_, getErr := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Get(ctx, "injector", metav1.GetOptions{})
+			return getErr
+		})
 		if kerrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -250,6 +282,7 @@ func (c *Cluster) createPayloadConfigMaps(ctx context.Context, tmpDir, imagesDir
 	}
 
 	cmNames := []string{}
+	payloadConfigMapDelay := payloadConfigMapBaseDelay
 	l.Info("adding archived binary configmaps of registry image to the cluster")
 	for i, data := range chunks {
 		fileName := fmt.Sprintf("zarf-payload-%03d", i)
@@ -262,14 +295,25 @@ func (c *Cluster) createPayloadConfigMaps(ctx context.Context, tmpDir, imagesDir
 			WithBinaryData(map[string][]byte{
 				fileName: data,
 			})
-		_, err = c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+		retried, err := retryInjectorRequest(ctx, "apply injector payload ConfigMap", func() error {
+			_, applyErr := c.Clientset.CoreV1().ConfigMaps(state.ZarfNamespaceName).Apply(ctx, cm, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
+			return applyErr
+		})
 		if err != nil {
 			return nil, "", err
 		}
 		cmNames = append(cmNames, fileName)
 
-		// Give the control plane a 250ms buffer between each configmap
-		time.Sleep(250 * time.Millisecond)
+		if retried {
+			payloadConfigMapDelay = min(payloadConfigMapDelay*2, payloadConfigMapMaxDelay)
+		} else if payloadConfigMapDelay > payloadConfigMapBaseDelay {
+			payloadConfigMapDelay = max(payloadConfigMapDelay/2, payloadConfigMapBaseDelay)
+		}
+		if i < len(chunks)-1 {
+			if err := waitForPayloadConfigMapPacing(ctx, payloadConfigMapDelay); err != nil {
+				return nil, "", err
+			}
+		}
 	}
 	return cmNames, shasum, nil
 }
@@ -659,24 +703,74 @@ func (c *Cluster) createInjectorNodeportService(ctx context.Context, pkgName str
 		})
 
 		var err error
-		svc, err = c.Clientset.CoreV1().Services(*svcAc.Namespace).Apply(ctx, svcAc, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
-		if err != nil {
+		_, err = retryInjectorRequest(ctx, "apply injector service", func() error {
+			svc, err = c.Clientset.CoreV1().Services(*svcAc.Namespace).Apply(ctx, svcAc, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 			return err
+		})
+		if err != nil {
+			return retry.Unrecoverable(err)
 		}
 
 		assignedNodePort := int(svc.Spec.Ports[0].NodePort)
 		if assignedNodePort == int(opts.RegistryNodePort) {
 			l.Info("injector service NodePort conflicts with registry NodePort, recreating service", "conflictingPort", assignedNodePort)
-			deleteErr := c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
+			_, deleteErr := retryInjectorRequest(ctx, "delete conflicting injector service", func() error {
+				return c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
+			})
 			if deleteErr != nil {
-				return deleteErr
+				return retry.Unrecoverable(deleteErr)
 			}
-			return fmt.Errorf("nodePort conflict with registry port %d", opts.RegistryNodePort)
+			return fmt.Errorf("%w: %d", errInjectorNodePortConflict, opts.RegistryNodePort)
 		}
 		return nil
-	}, retry.Attempts(10), retry.Delay(500*time.Millisecond), retry.Context(timeoutCtx))
+	}, retry.Attempts(10), retry.Delay(500*time.Millisecond), retry.Context(timeoutCtx), retry.RetryIf(func(err error) bool {
+		return errors.Is(err, errInjectorNodePortConflict)
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the injector nodeport service: %w", err)
 	}
 	return svc, nil
+}
+
+// retryInjectorRequest retries headerless transient Kubernetes API throttles for idempotent injector operations.
+func retryInjectorRequest(ctx context.Context, operation string, request func() error) (retried bool, err error) {
+	l := logger.From(ctx)
+	err = retry.Do(func() error {
+		requestErr := request()
+		if requestErr == nil {
+			return nil
+		}
+		if !kerrors.IsTooManyRequests(requestErr) || hasServerRetryDelay(requestErr) {
+			return retry.Unrecoverable(requestErr)
+		}
+		return requestErr
+	},
+		retry.Attempts(uint(config.ZarfDefaultRetries)),
+		retry.Delay(config.ZarfDefaultRetryDelay),
+		retry.MaxDelay(config.ZarfDefaultRetryMaxDelay),
+		retry.DelayType(retry.CombineDelay(retry.BackOffDelay, retry.RandomDelay)),
+		retry.LastErrorOnly(true),
+		retry.Context(ctx),
+		retry.OnRetry(func(n uint, requestErr error) {
+			retried = true
+			l.Warn("retrying transient Kubernetes API request", "operation", operation, "attempt", n+1, "maxAttempts", config.ZarfDefaultRetries, "error", requestErr)
+		}),
+	)
+	return retried, err
+}
+
+func hasServerRetryDelay(err error) bool {
+	_, ok := kerrors.SuggestsClientDelay(err)
+	return ok
+}
+
+func waitForPayloadConfigMapPacing(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -40,8 +40,6 @@ import (
 
 var zarfImageRegex = regexp.MustCompile(`(?m)^(127\.0\.0\.1|\[::1\]):`)
 
-var errInjectorNodePortConflict = errors.New("injector service NodePort conflicts with registry NodePort")
-
 const (
 	payloadConfigMapBaseDelay = 250 * time.Millisecond
 	payloadConfigMapMaxDelay  = 2 * time.Second
@@ -99,10 +97,7 @@ func (c *Cluster) StartInjection(ctx context.Context, tmpDir, imagesDir string, 
 	}
 
 	pod := buildInjectionPod(injectorNodeName, injectorImage, payloadCmNames, shasum, resReq, pkgName, opts.IPFamily)
-	_, err = retryInjectorRequest(ctx, "apply injector pod", func() error {
-		_, err := c.Clientset.CoreV1().Pods(*pod.Namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
-		return err
-	})
+	_, err = c.Clientset.CoreV1().Pods(*pod.Namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 	if err != nil {
 		return "", 0, fmt.Errorf("error creating pod in cluster: %w", err)
 	}
@@ -157,15 +152,11 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 	start := time.Now()
 	l := logger.From(ctx)
 	l.Debug("deleting injector resources")
-	_, err := retryInjectorRequest(ctx, "delete injector pod", func() error {
-		return c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Delete(ctx, "injector", metav1.DeleteOptions{})
-	})
+	err := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Delete(ctx, "injector", metav1.DeleteOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
-	_, err = retryInjectorRequest(ctx, "delete injector service", func() error {
-		return c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
-	})
+	err = c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
@@ -218,10 +209,7 @@ func (c *Cluster) StopInjection(ctx context.Context) error {
 
 	// TODO: Replace with wait package in the future.
 	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := retryInjectorRequest(ctx, "get injector pod during cleanup", func() error {
-			_, getErr := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Get(ctx, "injector", metav1.GetOptions{})
-			return getErr
-		})
+		_, err := c.Clientset.CoreV1().Pods(state.ZarfNamespaceName).Get(ctx, "injector", metav1.GetOptions{})
 		if kerrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -703,36 +691,29 @@ func (c *Cluster) createInjectorNodeportService(ctx context.Context, pkgName str
 		})
 
 		var err error
-		_, err = retryInjectorRequest(ctx, "apply injector service", func() error {
-			svc, err = c.Clientset.CoreV1().Services(*svcAc.Namespace).Apply(ctx, svcAc, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
-			return err
-		})
+		svc, err = c.Clientset.CoreV1().Services(*svcAc.Namespace).Apply(ctx, svcAc, metav1.ApplyOptions{Force: true, FieldManager: FieldManagerName})
 		if err != nil {
-			return retry.Unrecoverable(err)
+			return err
 		}
 
 		assignedNodePort := int(svc.Spec.Ports[0].NodePort)
 		if assignedNodePort == int(opts.RegistryNodePort) {
 			l.Info("injector service NodePort conflicts with registry NodePort, recreating service", "conflictingPort", assignedNodePort)
-			_, deleteErr := retryInjectorRequest(ctx, "delete conflicting injector service", func() error {
-				return c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
-			})
+			deleteErr := c.Clientset.CoreV1().Services(state.ZarfNamespaceName).Delete(ctx, "zarf-injector", metav1.DeleteOptions{})
 			if deleteErr != nil {
-				return retry.Unrecoverable(deleteErr)
+				return deleteErr
 			}
-			return fmt.Errorf("%w: %d", errInjectorNodePortConflict, opts.RegistryNodePort)
+			return fmt.Errorf("nodePort conflict with registry port %d", opts.RegistryNodePort)
 		}
 		return nil
-	}, retry.Attempts(10), retry.Delay(500*time.Millisecond), retry.Context(timeoutCtx), retry.RetryIf(func(err error) bool {
-		return errors.Is(err, errInjectorNodePortConflict)
-	}))
+	}, retry.Attempts(10), retry.Delay(500*time.Millisecond), retry.Context(timeoutCtx))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the injector nodeport service: %w", err)
 	}
 	return svc, nil
 }
 
-// retryInjectorRequest retries headerless transient Kubernetes API throttles for idempotent injector operations.
+// retryInjectorRequest retries headerless transient Kubernetes API throttles for idempotent injector ConfigMap operations.
 func retryInjectorRequest(ctx context.Context, operation string, request func() error) (retried bool, err error) {
 	l := logger.From(ctx)
 	err = retry.Do(func() error {

--- a/src/pkg/cluster/injector_retry_test.go
+++ b/src/pkg/cluster/injector_retry_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package cluster
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/config"
+	"github.com/zarf-dev/zarf/src/pkg/state"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestClientGoRetriesConfigMapApplyWithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			writeTooManyRequests(w, "0")
+			return
+		}
+		writeConfigMap(w)
+	})
+
+	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
+		FieldManager: FieldManagerName,
+		Force:        true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestClientGoRetriesConfigMapDeleteWithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			writeTooManyRequests(w, "0")
+			return
+		}
+		writeSuccessStatus(w)
+	})
+
+	err := client.ConfigMaps(state.ZarfNamespaceName).Delete(t.Context(), "zarf-payload-000", metav1.DeleteOptions{})
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestClientGoDoesNotRetryHeaderlessTooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		writeTooManyRequests(w, "")
+	})
+
+	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
+		FieldManager: FieldManagerName,
+		Force:        true,
+	})
+
+	require.Error(t, err)
+	require.True(t, kerrors.IsTooManyRequests(err))
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestClientGoBoundsRetriesWithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		writeTooManyRequests(w, "0")
+	})
+
+	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
+		FieldManager: FieldManagerName,
+		Force:        true,
+	})
+
+	require.Error(t, err)
+	require.True(t, kerrors.IsTooManyRequests(err))
+	require.Equal(t, int32(11), attempts.Load())
+}
+
+func TestClientGoStopsRetryingWhenContextExpires(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		writeTooManyRequests(w, "1")
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+
+	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(ctx, v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
+		FieldManager: FieldManagerName,
+		Force:        true,
+	})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestStopInjectionRetriesTooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset()
+	var attempts atomic.Int32
+	cs.PrependReactor("delete", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		if attempts.Add(1) == 1 {
+			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
+		}
+		return false, nil, nil
+	})
+	c := &Cluster{Clientset: cs}
+
+	err := c.StopInjection(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestStopInjectionRetriesPayloadConfigMapCleanup(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset()
+	var attempts atomic.Int32
+	cs.PrependReactor("delete-collection", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		if attempts.Add(1) == 1 {
+			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
+		}
+		return false, nil, nil
+	})
+	c := &Cluster{Clientset: cs}
+
+	err := c.StopInjection(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestCreateInjectorConfigMapsRetriesTooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset()
+	var attempts atomic.Int32
+	cs.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok || patchAction.GetName() != "rust-binary" {
+			return false, nil, nil
+		}
+		if attempts.Add(1) == 1 {
+			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
+		}
+		return false, nil, nil
+	})
+	c := &Cluster{Clientset: cs}
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "zarf-injector"), []byte("injector"), 0o644))
+	idx, err := random.Index(1, 1, 1)
+	require.NoError(t, err)
+	_, err = layout.Write(filepath.Join(tmpDir, "seed-images"), idx)
+	require.NoError(t, err)
+
+	_, _, err = c.CreateInjectorConfigMaps(t.Context(), tmpDir, t.TempDir(), nil, "test")
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestCreatePayloadConfigMapsResumesAfterTooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset()
+	attempts := map[string]int{}
+	cs.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok {
+			return false, nil, nil
+		}
+		name := patchAction.GetName()
+		attempts[name]++
+		if name == "zarf-payload-000" && attempts[name] == 1 {
+			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
+		}
+		return false, nil, nil
+	})
+	c := &Cluster{Clientset: cs}
+	tmpDir := t.TempDir()
+	seedImagesDir := filepath.Join(tmpDir, "seed-images")
+	idx, err := random.Index(1, 1, 1)
+	require.NoError(t, err)
+	_, err = layout.Write(seedImagesDir, idx)
+	require.NoError(t, err)
+	payload := make([]byte, 1024*768+1)
+	_, err = cryptorand.Read(payload)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(seedImagesDir, "payload"), payload, 0o644))
+
+	cmNames, _, err := c.createPayloadConfigMaps(t.Context(), tmpDir, t.TempDir(), nil, "test")
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(cmNames), 2)
+	require.Equal(t, 2, attempts[cmNames[0]])
+	for _, cmName := range cmNames[1:] {
+		require.Equal(t, 1, attempts[cmName])
+	}
+}
+
+func TestRetryInjectorRequestBoundsHeaderlessTooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	retried, err := retryInjectorRequest(t.Context(), "test request", func() error {
+		attempts.Add(1)
+		return kerrors.NewTooManyRequests("control plane throttled", 0)
+	})
+
+	require.Error(t, err)
+	require.True(t, kerrors.IsTooManyRequests(err))
+	require.True(t, retried)
+	require.Equal(t, int32(config.ZarfDefaultRetries), attempts.Load())
+}
+
+func TestRetryInjectorRequestDoesNotRetryServerDirectedThrottle(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	retried, err := retryInjectorRequest(t.Context(), "test request", func() error {
+		attempts.Add(1)
+		return kerrors.NewTooManyRequests("control plane throttled", 1)
+	})
+
+	require.Error(t, err)
+	require.True(t, kerrors.IsTooManyRequests(err))
+	require.False(t, retried)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestRetryInjectorRequestDoesNotRetryPermanentError(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	retried, err := retryInjectorRequest(t.Context(), "test request", func() error {
+		attempts.Add(1)
+		return kerrors.NewBadRequest("invalid request")
+	})
+
+	require.Error(t, err)
+	require.True(t, kerrors.IsBadRequest(err))
+	require.False(t, retried)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestRetryInjectorRequestHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var attempts atomic.Int32
+	retried, err := retryInjectorRequest(ctx, "test request", func() error {
+		attempts.Add(1)
+		return nil
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, retried)
+	require.Zero(t, attempts.Load())
+}
+
+func newCoreV1Client(t *testing.T, handler http.HandlerFunc) corev1client.CoreV1Interface {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := corev1client.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	return client
+}
+
+func writeTooManyRequests(w http.ResponseWriter, retryAfter string) {
+	if retryAfter != "" {
+		w.Header().Set("Retry-After", retryAfter)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	writeJSON(w, kerrors.NewTooManyRequests("control plane throttled", 0).ErrStatus)
+}
+
+func writeConfigMap(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "zarf-payload-000",
+			Namespace: state.ZarfNamespaceName,
+		},
+	})
+}
+
+func writeSuccessStatus(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, &metav1.Status{Status: metav1.StatusSuccess})
+}
+
+func writeJSON(w http.ResponseWriter, object any) {
+	if err := json.NewEncoder(w).Encode(object); err != nil {
+		panic(err)
+	}
+}

--- a/src/pkg/cluster/injector_retry_test.go
+++ b/src/pkg/cluster/injector_retry_test.go
@@ -5,52 +5,24 @@ package cluster
 
 import (
 	"context"
-	cryptorand "crypto/rand"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/v1/layout"
-	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/state"
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 )
-
-func TestClientGoRetriesConfigMapApplyWithRetryAfter(t *testing.T) {
-	t.Parallel()
-
-	var attempts atomic.Int32
-	client := newCoreV1Client(t, func(w http.ResponseWriter, _ *http.Request) {
-		if attempts.Add(1) == 1 {
-			writeTooManyRequests(w, "0")
-			return
-		}
-		writeConfigMap(w)
-	})
-
-	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
-		FieldManager: FieldManagerName,
-		Force:        true,
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int32(2), attempts.Load())
-}
 
 func TestClientGoRetriesConfigMapDeleteWithRetryAfter(t *testing.T) {
 	t.Parallel()
@@ -79,10 +51,7 @@ func TestClientGoDoesNotRetryHeaderlessTooManyRequests(t *testing.T) {
 		writeTooManyRequests(w, "")
 	})
 
-	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
-		FieldManager: FieldManagerName,
-		Force:        true,
-	})
+	err := client.ConfigMaps(state.ZarfNamespaceName).DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
 	require.Error(t, err)
 	require.True(t, kerrors.IsTooManyRequests(err))
@@ -98,10 +67,7 @@ func TestClientGoBoundsRetriesWithRetryAfter(t *testing.T) {
 		writeTooManyRequests(w, "0")
 	})
 
-	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(t.Context(), v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
-		FieldManager: FieldManagerName,
-		Force:        true,
-	})
+	err := client.ConfigMaps(state.ZarfNamespaceName).DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
 	require.Error(t, err)
 	require.True(t, kerrors.IsTooManyRequests(err))
@@ -119,10 +85,7 @@ func TestClientGoStopsRetryingWhenContextExpires(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
 	defer cancel()
 
-	_, err := client.ConfigMaps(state.ZarfNamespaceName).Apply(ctx, v1ac.ConfigMap("zarf-payload-000", state.ZarfNamespaceName), metav1.ApplyOptions{
-		FieldManager: FieldManagerName,
-		Force:        true,
-	})
+	err := client.ConfigMaps(state.ZarfNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Equal(t, int32(1), attempts.Load())
@@ -147,71 +110,17 @@ func TestStopInjectionRetriesPayloadConfigMapCleanup(t *testing.T) {
 	require.Equal(t, int32(2), attempts.Load())
 }
 
-func TestCreateInjectorConfigMapsRetriesTooManyRequests(t *testing.T) {
+func TestStopInjectionDoesNotListLegacyPayloadConfigMaps(t *testing.T) {
 	t.Parallel()
 
 	cs := fake.NewClientset()
-	var attempts atomic.Int32
-	cs.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		patchAction, ok := action.(k8stesting.PatchAction)
-		if !ok || patchAction.GetName() != "rust-binary" {
-			return false, nil, nil
-		}
-		if attempts.Add(1) == 1 {
-			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
-		}
-		return false, nil, nil
-	})
 	c := &Cluster{Clientset: cs}
-	tmpDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "zarf-injector"), []byte("injector"), 0o644))
-	idx, err := random.Index(1, 1, 1)
-	require.NoError(t, err)
-	_, err = layout.Write(filepath.Join(tmpDir, "seed-images"), idx)
-	require.NoError(t, err)
 
-	_, _, err = c.CreateInjectorConfigMaps(t.Context(), tmpDir, t.TempDir(), nil, "test")
+	err := c.StopInjection(t.Context())
 
 	require.NoError(t, err)
-	require.Equal(t, int32(2), attempts.Load())
-}
-
-func TestCreatePayloadConfigMapsResumesAfterTooManyRequests(t *testing.T) {
-	t.Parallel()
-
-	cs := fake.NewClientset()
-	attempts := map[string]int{}
-	cs.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		patchAction, ok := action.(k8stesting.PatchAction)
-		if !ok {
-			return false, nil, nil
-		}
-		name := patchAction.GetName()
-		attempts[name]++
-		if name == "zarf-payload-000" && attempts[name] == 1 {
-			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
-		}
-		return false, nil, nil
-	})
-	c := &Cluster{Clientset: cs}
-	tmpDir := t.TempDir()
-	seedImagesDir := filepath.Join(tmpDir, "seed-images")
-	idx, err := random.Index(1, 1, 1)
-	require.NoError(t, err)
-	_, err = layout.Write(seedImagesDir, idx)
-	require.NoError(t, err)
-	payload := make([]byte, 1024*768+1)
-	_, err = cryptorand.Read(payload)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(seedImagesDir, "payload"), payload, 0o644))
-
-	cmNames, _, err := c.createPayloadConfigMaps(t.Context(), tmpDir, t.TempDir(), nil, "test")
-
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(cmNames), 2)
-	require.Equal(t, 2, attempts[cmNames[0]])
-	for _, cmName := range cmNames[1:] {
-		require.Equal(t, 1, attempts[cmName])
+	for _, action := range cs.Actions() {
+		require.False(t, action.GetVerb() == "list" && action.GetResource().Resource == "configmaps")
 	}
 }
 
@@ -293,16 +202,6 @@ func writeTooManyRequests(w http.ResponseWriter, retryAfter string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusTooManyRequests)
 	writeJSON(w, kerrors.NewTooManyRequests("control plane throttled", 0).ErrStatus)
-}
-
-func writeConfigMap(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "zarf-payload-000",
-			Namespace: state.ZarfNamespaceName,
-		},
-	})
 }
 
 func writeSuccessStatus(w http.ResponseWriter) {

--- a/src/pkg/cluster/injector_retry_test.go
+++ b/src/pkg/cluster/injector_retry_test.go
@@ -128,25 +128,6 @@ func TestClientGoStopsRetryingWhenContextExpires(t *testing.T) {
 	require.Equal(t, int32(1), attempts.Load())
 }
 
-func TestStopInjectionRetriesTooManyRequests(t *testing.T) {
-	t.Parallel()
-
-	cs := fake.NewClientset()
-	var attempts atomic.Int32
-	cs.PrependReactor("delete", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		if attempts.Add(1) == 1 {
-			return true, nil, kerrors.NewTooManyRequests("control plane throttled", 0)
-		}
-		return false, nil, nil
-	})
-	c := &Cluster{Clientset: cs}
-
-	err := c.StopInjection(t.Context())
-
-	require.NoError(t, err)
-	require.Equal(t, int32(2), attempts.Load())
-}
-
 func TestStopInjectionRetriesPayloadConfigMapCleanup(t *testing.T) {
 	t.Parallel()
 

--- a/src/pkg/cluster/injector_retry_test.go
+++ b/src/pkg/cluster/injector_retry_test.go
@@ -24,7 +24,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-func TestClientGoRetriesConfigMapDeleteWithRetryAfter(t *testing.T) {
+func TestClientGoRetriesConfigMapDeleteCollectionWithRetryAfter(t *testing.T) {
 	t.Parallel()
 
 	var attempts atomic.Int32
@@ -36,7 +36,7 @@ func TestClientGoRetriesConfigMapDeleteWithRetryAfter(t *testing.T) {
 		writeSuccessStatus(w)
 	})
 
-	err := client.ConfigMaps(state.ZarfNamespaceName).Delete(t.Context(), "zarf-payload-000", metav1.DeleteOptions{})
+	err := client.ConfigMaps(state.ZarfNamespaceName).DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
 	require.NoError(t, err)
 	require.Equal(t, int32(2), attempts.Load())
@@ -108,20 +108,6 @@ func TestStopInjectionRetriesPayloadConfigMapCleanup(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, int32(2), attempts.Load())
-}
-
-func TestStopInjectionDoesNotListLegacyPayloadConfigMaps(t *testing.T) {
-	t.Parallel()
-
-	cs := fake.NewClientset()
-	c := &Cluster{Clientset: cs}
-
-	err := c.StopInjection(t.Context())
-
-	require.NoError(t, err)
-	for _, action := range cs.Actions() {
-		require.False(t, action.GetVerb() == "list" && action.GetResource().Resource == "configmaps")
-	}
 }
 
 func TestRetryInjectorRequestBoundsHeaderlessTooManyRequests(t *testing.T) {


### PR DESCRIPTION
## Description

Attempts to address `toomanyrequests` in the handling of 429 responses that are not natively handled by `client-go`. These might be headerless 429 or have exhausted the retry budget. 

`client-go` remains responsible for 429 responses with `Retry-after`. A warning log was added to make the retry case a bit more observable. 

## Related Issue

Fixes #5093
Fixes #5072

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
