### PR TITLE
fix: version aware topic assignments for hidden pages

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -26,6 +26,11 @@ const sections = readdirSync(docsDir, { withFileTypes: true })
   .map((e) => e.name.replace(/\.mdx?$/, ""))
   .filter((name) => name !== "index");
 
+function hasPage(slug: string, page: string): boolean {
+  const rel = slug ? `${slug}/${page}` : page;
+  return existsSync(path.join(docsDir, `${rel}.mdx`)) || existsSync(path.join(docsDir, `${rel}.md`));
+}
+
 // Build a Starlight sidebar for one docs version. `slug` is "" for the current
 // checkout (Latest) or a version slug (e.g. "0-76") for an archived subtree.
 // Sections missing from an older version are skipped so autogenerate never
@@ -34,8 +39,6 @@ function buildSidebar(slug: string): any[] {
   const base = slug ? `/${slug}` : "";
   const rel = (p: string) => (slug ? `${slug}/${p}` : p);
   const hasDir = (d: string) => existsSync(path.join(docsDir, rel(d)));
-  const hasPage = (p: string) =>
-    existsSync(path.join(docsDir, rel(`${p}.mdx`))) || existsSync(path.join(docsDir, rel(`${p}.md`)));
 
   const items: any[] = [{ label: "Overview", link: `${base}/` }];
 
@@ -46,7 +49,7 @@ function buildSidebar(slug: string): any[] {
     items.push({ label, items: [{ autogenerate }], ...(opts.collapsed ? { collapsed: true } : {}) });
   };
   const pageLink = (label: string, p: string) => {
-    if (hasPage(p)) items.push({ label, link: `${base}/${p}` });
+    if (hasPage(slug, p)) items.push({ label, link: `${base}/${p}` });
   };
 
   dirGroup("Start Here", "getting-started");
@@ -71,7 +74,21 @@ const topics = [
 ];
 
 // Associate pages that aren't in any sidebar (404, sidebar-hidden pages) with a topic.
-const topicsOption: Record<string, string[]> = { latest: ["/404", "/schema/v1beta1-package"] };
+function unlistedPages(slug: string): string[] {
+  const base = slug ? `/${slug}` : "";
+  const pages = slug ? [] : ["/404"];
+
+  if (hasPage(slug, "schema/v1beta1-package")) {
+    pages.push(`${base}/schema/v1beta1-package`);
+  }
+
+  return pages;
+}
+
+const topicsOption: Record<string, string[]> = {
+  latest: unlistedPages(""),
+  ...Object.fromEntries(versions.map((version) => [version.slug, unlistedPages(version.slug)])),
+};
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Description

v0.82 introduced a hidden schema/v1beta1-package page. Versioned-doc staging copied it to /v0-82/..., but the sidebar-topics config assigned only the root page to latest. The plugin couldn't assign the archived hidden page to a topic, so the site build failed.

This makes hidden-page topic assignments version aware. The config now adds the schema page to each version’s topic only when that staged version contains it. 

## Related Issue

No associated issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
