### PR TITLE
feat(init): more secure pod defaults

### DIFF
--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -63,9 +63,6 @@ containerSecurityContext:
       - ALL
   privileged: false
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 serviceAccount:
   create: true

--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -48,6 +48,29 @@ image:
   fullOverride: "###ZARF_CONST_GITEA_IMAGE###"
   rootless: true
 
+podSecurityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
 postgresql-ha:
   enabled: false
 

--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -49,10 +49,10 @@ image:
   rootless: true
 
 podSecurityContext:
-  fsGroup: 1000
-  runAsGroup: 1000
+  fsGroup: ###ZARF_VAR_GIT_SERVER_SECURITY_CONTEXT_FS_GROUP###
+  runAsGroup: ###ZARF_VAR_GIT_SERVER_SECURITY_CONTEXT_RUN_AS_GROUP###
   runAsNonRoot: true
-  runAsUser: 1000
+  runAsUser: ###ZARF_VAR_GIT_SERVER_SECURITY_CONTEXT_RUN_AS_USER###
   seccompProfile:
     type: RuntimeDefault
 

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -54,6 +54,18 @@ variables:
     default: ""
     autoIndent: true
 
+  - name: GIT_SERVER_SECURITY_CONTEXT_RUN_AS_USER
+    description: The user ID to run the git server as
+    default: "1000"
+
+  - name: GIT_SERVER_SECURITY_CONTEXT_FS_GROUP
+    description: The filesystem group ID to run the git server as
+    default: "1000"
+
+  - name: GIT_SERVER_SECURITY_CONTEXT_RUN_AS_GROUP
+    description: The group ID to run the git server as
+    default: "1000"
+
 constants:
   - name: GITEA_IMAGE
     value: "###ZARF_PKG_TMPL_GITEA_IMAGE###"

--- a/packages/zarf-agent/chart/templates/deployment.yaml
+++ b/packages/zarf-agent/chart/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            privileged: false
             runAsNonRoot: true
             capabilities:
               drop: ["ALL"]

--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ include "docker-registry.serviceAccountName" . }}
-      automountServiceAccountToken: false
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/packages/zarf-registry/chart/templates/deployment.yaml
+++ b/packages/zarf-registry/chart/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ include "docker-registry.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -69,6 +70,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            privileged: false
             runAsNonRoot: true
             capabilities:
               drop: ["ALL"]

--- a/packages/zarf-registry/chart/templates/injector-daemonset.yaml
+++ b/packages/zarf-registry/chart/templates/injector-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
         # Don't mutate this pod
         zarf.dev/agent: ignore
     spec:
+      automountServiceAccountToken: false
       priorityClassName: system-node-critical
       containers:
         - name: injector
@@ -61,6 +62,7 @@ spec:
             capabilities:
               drop:
               - ALL
+            privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
     {{- if eq (include "proxy.hostNetwork" .) "true" }}

--- a/packages/zarf-registry/chart/templates/proxy-daemonset.yaml
+++ b/packages/zarf-registry/chart/templates/proxy-daemonset.yaml
@@ -19,6 +19,7 @@ spec:
         checksum/tls-secret: {{ $tlsSecret.data | toJson | sha256sum }}
 {{- end }}
     spec:
+      automountServiceAccountToken: false
       priorityClassName: system-node-critical
       containers:
         - args:
@@ -54,6 +55,7 @@ spec:
             capabilities:
               drop:
               - ALL
+            privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
       volumes:

--- a/src/pkg/cluster/injector.go
+++ b/src/pkg/cluster/injector.go
@@ -578,6 +578,7 @@ func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum s
 			v1ac.PodSpec().
 				// The injector doesn't handle sigterm to avoid extra dependencies, so we set it to 1
 				WithTerminationGracePeriodSeconds(1).
+				WithAutomountServiceAccountToken(false).
 				WithNodeName(nodeName).
 				WithRestartPolicy(corev1.RestartPolicyNever).
 				WithSecurityContext(
@@ -602,6 +603,7 @@ func buildInjectionPod(nodeName, image string, payloadCmNames []string, shasum s
 							v1ac.SecurityContext().
 								WithReadOnlyRootFilesystem(true).
 								WithAllowPrivilegeEscalation(false).
+								WithPrivileged(false).
 								WithRunAsNonRoot(true).
 								WithCapabilities(v1ac.Capabilities().WithDrop(corev1.Capability("ALL"))),
 						).

--- a/src/pkg/cluster/testdata/expected-injection-pod.json
+++ b/src/pkg/cluster/testdata/expected-injection-pod.json
@@ -93,6 +93,7 @@
               "ALL"
             ]
           },
+          "privileged": false,
           "runAsNonRoot": true,
           "readOnlyRootFilesystem": true,
           "allowPrivilegeEscalation": false
@@ -101,6 +102,7 @@
     ],
     "restartPolicy": "Never",
     "terminationGracePeriodSeconds": 1,
+    "automountServiceAccountToken": false,
     "nodeName": "injection-node",
     "securityContext": {
       "runAsUser": 1000,


### PR DESCRIPTION
## Description

Changes pod defaults to be secure, I need to do testing to see where this could break users

The gitea user and group and the current defaults, so nothing should be changed there. We are running gitea in rootless mode so running as non root shouldn't be an issue.

Privileged is already false, just making it explicit. The only pod using service tokens is the agent. 

## Related Issue

Fixes #2757


## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
