### PR TITLE
fix: proper binary scan location for nightly cve scan

### DIFF
--- a/.github/workflows/nightly-scan-cve.yml
+++ b/.github/workflows/nightly-scan-cve.yml
@@ -49,20 +49,14 @@ jobs:
       ## face. VEX statements in .vex/zarf.cli.openvex.json suppress accepted findings.
       ## Fails the workflow on any un-suppressed High or Critical finding.
 
-      - name: Build Zarf binary
-        run: make build-cli-linux-amd
-
-      ## Equivalent to `make scan-grype` (grype <binary> --config .grype.yaml -o json --fail-on high).
-      ## .grype.yaml is auto-detected when 'config' is not set; VEX documents it references are consumed.
-      - name: Run grype scan (fails on High+)
+      - name: Install pinned Grype
         id: grype
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          path: ./build/zarf
-          fail-build: "true"
-          severity-cutoff: high
-          output-format: json
-          output-file: build/grype.json
+          grype-version: v0.116.0
+
+      - name: Run grype scan (fails on High+)
+        run: make scan-grype GRYPE="${{ steps.grype.outputs.cmd }}"
 
       - name: Check for orphaned VEX statements
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ endif
 
 # Figure out which Zarf binary we should use based on the operating system we are on
 ZARF_BIN := ./build/zarf
+GRYPE ?= grype
 BUILD_CLI_FOR_SYSTEM := build-cli-linux-amd
 ifeq ($(OS),Windows_NT)
 	ZARF_BIN := $(addsuffix .exe,$(ZARF_BIN))
@@ -243,7 +244,7 @@ scan-govulncheck: ## Scan source for vulnerabilities with reachable code paths u
 
 scan-grype: build ## Scan the Zarf binary for CVEs using grype + VEX suppression (must `brew install grype` first); fails on High+
 	@test -d ./build || mkdir ./build
-	grype $(ZARF_BIN) --config .grype.yaml -o json > build/grype.json --fail-on high
+	$(GRYPE) file:$(ZARF_BIN) --config .grype.yaml -o json > build/grype.json --fail-on high
 
 vex-lint: ## Check for orphaned VEX statements in .vex/zarf.cli.openvex.json (requires: run scan-grype first)
 	@test -f build/grype.json || (echo "ERROR: build/grype.json not found — run 'make scan-grype' first" && exit 1)


### PR DESCRIPTION
## Description

Currently nightly scan (the first) is failing due to the scan action interpreting the path as a directory instead of a binary. Switching to use grype directly via make targets.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
