### PR TITLE
ci: mitigate 403 errors when building docs site

### DIFF
--- a/.github/workflows/test-site.yml
+++ b/.github/workflows/test-site.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: run site build
         run: npm run build:versions
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: check links
         run: npm run link-check

--- a/.github/workflows/test-site.yml
+++ b/.github/workflows/test-site.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: run site build
         run: npm run build:versions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: check links
         run: npm run link-check

--- a/site/README.md
+++ b/site/README.md
@@ -50,7 +50,7 @@ regenerating its examples and schema (`src/assets/schema/<slug>.json`) from the
 tag's `examples/` and `zarf.schema.json`. Archived content therefore renders with
 the **current** toolchain and components, never its own.
 
-Versions are discovered from GitHub Releases and reduced to the newest patch per
+Versions are discovered from git tags and reduced to the newest patch per
 minor. Only the current major and the one before it are kept — the current major shows
 its last 10 minors and the previous major its latest 3 minors.
 The set is written to versions.json, which the version switcher reads.

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -21,6 +21,7 @@ const KEEP_CURRENT_MAJOR = 10;
 const KEEP_PREVIOUS_MAJOR = 3;
 
 const VERSION_SLUG = /^v\d+-\d+$/;
+const SEMVER_TAG = /^v?\d+\.\d+\.\d+$/;
 
 function git(args, opts = {}) {
   return execFileSync("git", args, { cwd: repoDir, stdio: "inherit", ...opts });
@@ -67,21 +68,11 @@ function toVersion(tag) {
   return { ref: tag, slug: slugOf(minorKey(tag)) };
 }
 
-// Released minors, newest first, capped per major.
-async function discoverVersions() {
-  const headers = { Accept: "application/vnd.github+json" };
-  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers });
-  if (!res.ok) {
-    throw new Error(`GitHub API returned ${res.status} ${res.statusText} for ${REPO} releases`);
-  }
-  const releases = await res.json();
-  const tags = releases.filter((r) => !r.prerelease && !r.draft).map((r) => r.tag_name);
-
+function versionsFromTags(tags) {
   // Keep only the newest patch per minor.
   const newestByMinor = new Map();
   for (const tag of tags) {
-    if (!/^v?\d+\.\d+\.\d+$/.test(tag)) continue;
+    if (!SEMVER_TAG.test(tag)) continue;
     const minor = minorKey(tag);
     const current = newestByMinor.get(minor);
     if (!current || parseSemver(tag)[2] > parseSemver(current)[2]) {
@@ -92,6 +83,46 @@ async function discoverVersions() {
   const minorsDesc = [...newestByMinor.keys()].sort(cmpMinorDesc);
   const archived = limitByMajor(minorsDesc).map((m) => toVersion(newestByMinor.get(m)));
   return { latest: minorsDesc[0], archived };
+}
+
+async function discoverReleaseTags() {
+  const headers = { Accept: "application/vnd.github+json" };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API returned ${res.status} ${res.statusText} for ${REPO} releases`);
+  }
+  const releases = await res.json();
+  return releases.filter((r) => !r.prerelease && !r.draft).map((r) => r.tag_name);
+}
+
+function discoverGitTags() {
+  const output = git(["ls-remote", "--tags", "origin", "v*.*.*"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  return [
+    ...new Set(
+      output
+        .split("\n")
+        .map((line) => line.trim().split(/\s+/)[1])
+        .filter(Boolean)
+        .map((ref) => ref.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, ""))
+        .filter((tag) => SEMVER_TAG.test(tag)),
+    ),
+  ];
+}
+
+// Released minors, newest first, capped per major.
+async function discoverVersions() {
+  try {
+    return versionsFromTags(await discoverReleaseTags());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`${message}; falling back to git tag discovery`);
+    return versionsFromTags(discoverGitTags());
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -14,7 +14,6 @@ const docsDir = path.join(siteDir, "src/content/docs");
 const schemaDir = path.join(siteDir, "src/assets/schema");
 const worktreeRoot = path.join(repoDir, ".docs-version-builds");
 
-const REPO = "zarf-dev/zarf";
 // Minors kept in the switcher, from the current major and the one before it.
 // Majors older than the previous one are dropped entirely.
 const KEEP_CURRENT_MAJOR = 10;
@@ -85,17 +84,6 @@ function versionsFromTags(tags) {
   return { latest: minorsDesc[0], archived };
 }
 
-async function discoverReleaseTags() {
-  const headers = { Accept: "application/vnd.github+json" };
-  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers });
-  if (!res.ok) {
-    throw new Error(`GitHub API returned ${res.status} ${res.statusText} for ${REPO} releases`);
-  }
-  const releases = await res.json();
-  return releases.filter((r) => !r.prerelease && !r.draft).map((r) => r.tag_name);
-}
-
 function discoverGitTags() {
   const output = git(["ls-remote", "--tags", "origin", "v*.*.*"], {
     encoding: "utf8",
@@ -114,15 +102,9 @@ function discoverGitTags() {
   ];
 }
 
-// Released minors, newest first, capped per major.
+// Released version tags, newest minor first, capped per major.
 async function discoverVersions() {
-  try {
-    return versionsFromTags(await discoverReleaseTags());
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`${message}; falling back to git tag discovery`);
-    return versionsFromTags(discoverGitTags());
-  }
+  return versionsFromTags(discoverGitTags());
 }
 
 // ---------------------------------------------------------------------------

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -13,6 +13,7 @@ const repoDir = path.resolve(siteDir, "..");
 const docsDir = path.join(siteDir, "src/content/docs");
 const schemaDir = path.join(siteDir, "src/assets/schema");
 const worktreeRoot = path.join(repoDir, ".docs-version-builds");
+const zarfGitRepo = "https://github.com/zarf-dev/zarf.git";
 
 // Minors kept in the switcher, from the current major and the one before it.
 // Majors older than the previous one are dropped entirely.
@@ -85,7 +86,7 @@ function versionsFromTags(tags) {
 }
 
 function discoverGitTags() {
-  const output = git(["ls-remote", "--tags", "origin", "v*.*.*"], {
+  const output = git(["ls-remote", "--tags", zarfGitRepo, "v*.*.*"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "inherit"],
   });
@@ -143,7 +144,7 @@ async function stageVersion({ ref, slug }) {
   console.log(`\n=== Staging ${slug} from ${ref} ===`);
   // CI often uses a shallow clone without tag commits; fetch the tag's commit.
   try {
-    git(["fetch", "--depth=1", "origin", "tag", ref, "--no-tags"]);
+    git(["fetch", "--depth=1", zarfGitRepo, "tag", ref, "--no-tags"]);
   } catch {
     console.warn(`git fetch of tag ${ref} failed; assuming it is already present`);
   }


### PR DESCRIPTION
## Description

mitigate 403 errors when building docs site by getting the tags through the Git CLI rather than GitHub API. 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
