### PR TITLE
feat(find-images): exclude images from Helm tests

### DIFF
--- a/site/src/content/docs/commands/zarf_dev_find-images.md
+++ b/site/src/content/docs/commands/zarf_dev_find-images.md
@@ -14,7 +14,10 @@ Evaluates components in a Zarf file to identify images specified in their helm c
 
 Evaluates components in a Zarf file to identify images specified in their helm charts and manifests.
 
-Components that have repos that host helm charts can be processed by providing the --repo-chart-path.
+Images defined as part of Helm test hooks are excluded. Images explicitly defined in the helm.sh/images
+annotation in a component Helm chart's Chart.yaml are included regardless of their presence in the rendered
+chart. Components that have git repositories that host helm charts can be processed by providing the
+--repo-chart-path.
 
 ```
 zarf dev find-images [ DIRECTORY ] [flags]

--- a/site/src/content/docs/ref/dev.mdx
+++ b/site/src/content/docs/ref/dev.mdx
@@ -81,7 +81,8 @@ $ zarf dev deploy examples/dos-games --no-yolo
 ## `zarf dev find-images`
 
 Evaluates components in a `zarf.yaml` to identify images specified in their helm charts and manifests.
-
+Images defined as part of Helm test hooks are excluded.
+Images explicitly defined in the `helm.sh/images` annotation in a component Helm chart's `Chart.yaml` are included regardless of their presence in the rendered chart.
 Components that have `git` repositories that host helm charts can be processed by providing the `--repo-chart-path`.
 
 ```bash

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -523,7 +523,10 @@ $ zarf package pull oci://ghcr.io/zarf-dev/packages/dos-games:1.3.0 -a skeleton`
 
 	CmdDevFindImagesShort = "Evaluates components in a Zarf file to identify images specified in their helm charts and manifests."
 	CmdDevFindImagesLong  = "Evaluates components in a Zarf file to identify images specified in their helm charts and manifests.\n\n" +
-		"Components that have repos that host helm charts can be processed by providing the --repo-chart-path."
+		"Images defined as part of Helm test hooks are excluded. Images explicitly defined in the helm.sh/images\n" +
+		"annotation in a component Helm chart's Chart.yaml are included regardless of their presence in the rendered\n" +
+		"chart. Components that have git repositories that host helm charts can be processed by providing the\n" +
+		"--repo-chart-path."
 
 	CmdDevGenerateConfigShort = "Generates a config file for Zarf"
 	CmdDevGenerateConfigLong  = "Generates a Zarf config file for controlling how the Zarf CLI operates. Optionally accepts a filename to write the config to.\n\n" +

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -296,6 +296,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 			if err != nil {
 				return nil, err
 			}
+			yamls = slices.DeleteFunc(yamls, isHelmTestResource)
 			resources = append(resources, yamls...)
 			chartPath := filepath.Join(compBuildPath, string(layout.ChartsComponentDir))
 			chartTarball := filepath.Join(chartPath, layout.ChartArchiveName(zarfChart.Name, zarfChart.Version))
@@ -339,6 +340,7 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 				if err != nil {
 					return nil, err
 				}
+				yamls = slices.DeleteFunc(yamls, isHelmTestResource)
 				resources = append(resources, yamls...)
 
 				// Check if the --why flag is set and if it is process the manifests
@@ -466,6 +468,10 @@ func findImages(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath strin
 	}
 
 	return componentImageScans, nil
+}
+
+func isHelmTestResource(resource *unstructured.Unstructured) bool {
+	return resource.GetAnnotations()["helm.sh/hook"] == "test"
 }
 
 // processUnstructuredImages processes a Kubernetes resource and extracts container images

--- a/src/pkg/packager/find_images_test.go
+++ b/src/pkg/packager/find_images_test.go
@@ -45,7 +45,7 @@ func TestFindImages(t *testing.T) {
 			},
 		},
 		{
-			name:        "helm chart",
+			name:        "helm chart excludes test resources by default",
 			packagePath: "./testdata/find-images/helm-chart",
 			opts: FindImagesOptions{
 				SkipCosign: true,
@@ -55,7 +55,7 @@ func TestFindImages(t *testing.T) {
 					ComponentName: "baseline",
 					Matches: []string{
 						"docker.io/library/nginx:1.16.0",
-						"docker.io/library/busybox:latest",
+						"docker.io/library/alpine:latest",
 					},
 				},
 			},
@@ -297,7 +297,7 @@ func TestFindDefinitionImages(t *testing.T) {
 					ComponentImageScan: ComponentImageScan{
 						ComponentName: "baseline",
 						Matches: []string{
-							"docker.io/library/busybox:latest",
+							"docker.io/library/alpine:latest",
 							"docker.io/library/nginx:1.16.0",
 						},
 					},
@@ -398,6 +398,16 @@ func TestFindDefinitionImages(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindImagesWhyExcludesHelmTestResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+	packagePath := "./testdata/find-images/helm-chart"
+
+	_, err := FindImages(ctx, packagePath, FindImagesOptions{Why: "busybox", SkipCosign: true})
+	require.EqualError(t, err, "image busybox not found in any charts or manifests")
 }
 
 func TestBuildImageMap(t *testing.T) {

--- a/src/pkg/packager/testdata/find-images/helm-chart/chart/templates/post-install-hook.yaml
+++ b/src/pkg/packager/testdata/find-images/helm-chart/chart/templates/post-install-hook.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "chart.fullname" . }}-post-install-or-test"
+  annotations:
+    "helm.sh/hook": post-install,test
+spec:
+  template:
+    spec:
+      containers:
+        - name: post-install-or-test
+          image: alpine
+      restartPolicy: Never


### PR DESCRIPTION
## Description

This PR refactors `zarf dev find-images` and `zarf dev generate` to exclude test resource images.

**This is a breaking behavioral change for the `zarf` CLI.**

## Related Issue

Fixes #4079 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
