### PR TITLE
feat: support package values in skeleton packages

### DIFF
--- a/site/src/content/docs/ref/package-values.mdx
+++ b/site/src/content/docs/ref/package-values.mdx
@@ -69,6 +69,17 @@ values:
 
 Generate a schema that includes each package value using `zarf dev generate-schema`.
 
+### Skeleton Packages
+
+Skeleton packages can include package values and schemas. When a package imports a
+values-bearing skeleton from OCI, Zarf materializes its values and schema and applies
+the same precedence as local imports: imported values are merged before the parent
+package's values, and a parent schema takes precedence over imported schemas.
+
+Values-bearing skeletons require a Zarf CLI that supports this format. Package authors
+should verify the required minimum CLI version before publishing packages for older
+consumers.
+
 ## Using Values
 
 Values are accessed in templates through the `.Values` template object. See the [Templating](#templating) section for details on the other available template objects (`.State`, `.Pkg`) and functions.

--- a/site/src/content/docs/ref/package-values.mdx
+++ b/site/src/content/docs/ref/package-values.mdx
@@ -69,12 +69,6 @@ values:
 
 Generate a schema that includes each package value using `zarf dev generate-schema`.
 
-### Skeleton Packages
-
-Skeleton packages can include package values and schemas. When a package imports a
-values-bearing skeleton from OCI, Zarf materializes its values and schema. Parent
-values and schema definitions override imported skeletons.
-
 ## Using Values
 
 Values are accessed in templates through the `.Values` template object. See the [Templating](#templating) section for details on the other available template objects (`.State`, `.Pkg`) and functions.

--- a/site/src/content/docs/ref/package-values.mdx
+++ b/site/src/content/docs/ref/package-values.mdx
@@ -72,9 +72,8 @@ Generate a schema that includes each package value using `zarf dev generate-sche
 ### Skeleton Packages
 
 Skeleton packages can include package values and schemas. When a package imports a
-values-bearing skeleton from OCI, Zarf materializes its values and schema and applies
-the same precedence as local imports: imported values are merged before the parent
-package's values, and a parent schema takes precedence over imported schemas.
+values-bearing skeleton from OCI, Zarf materializes its values and schema. Parent
+values and schema definitions override imported skeletons.
 
 ## Using Values
 

--- a/site/src/content/docs/ref/package-values.mdx
+++ b/site/src/content/docs/ref/package-values.mdx
@@ -76,10 +76,6 @@ values-bearing skeleton from OCI, Zarf materializes its values and schema and ap
 the same precedence as local imports: imported values are merged before the parent
 package's values, and a parent schema takes precedence over imported schemas.
 
-Values-bearing skeletons require a Zarf CLI that supports this format. Package authors
-should verify the required minimum CLI version before publishing packages for older
-consumers.
-
 ## Using Values
 
 Values are accessed in templates through the `.Values` template object. See the [Templating](#templating) section for details on the other available template objects (`.State`, `.Pkg`) and functions.

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -111,7 +111,7 @@ func newDevGenerateSchemaCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error {
+func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) (err error) {
 	l := logger.From(ctx)
 
 	basePath, err := setBaseDirectory(args)
@@ -123,6 +123,13 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error
 	if err != nil {
 		return err
 	}
+	definitionTmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(definitionTmpDir))
+	}()
 
 	loadOpts := load.DefinitionOptions{
 		Flavor:                     o.flavor,
@@ -131,6 +138,7 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error
 		SkipVersionCheck:           true,
 		SkipValuesSchemaValidation: true,
 		CachePath:                  cachePath,
+		TempDir:                    definitionTmpDir,
 		RemoteOptions:              defaultRemoteOptions(),
 	}
 
@@ -138,7 +146,6 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) error
 	if err != nil {
 		return err
 	}
-
 	// Step 1: Merge default values.files to create initial set of default Zarf values
 	valuesPaths := make([]string, len(defined.Pkg.Values.Files))
 	for i, file := range defined.Pkg.Values.Files {
@@ -280,7 +287,7 @@ func newDevInspectDefinitionCommand(v *viper.Viper) *cobra.Command {
 	return cmd
 }
 
-func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) error {
+func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) (err error) {
 	ctx := cmd.Context()
 	v := getViper()
 	o.setPkgTmpl = helpers.TransformAndMergeMap(
@@ -289,10 +296,18 @@ func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) err
 	if err != nil {
 		return err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           o.flavor,
 		SetVariables:     o.setPkgTmpl,
 		CachePath:        cachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    true,
 		SkipVersionCheck: true,
 		RemoteOptions:    defaultRemoteOptions(),

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -123,14 +123,6 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) (err 
 	if err != nil {
 		return err
 	}
-	definitionTmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(definitionTmpDir))
-	}()
-
 	loadOpts := load.DefinitionOptions{
 		Flavor:                     o.flavor,
 		SetVariables:               o.setPkgTmpl,
@@ -138,7 +130,6 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) (err 
 		SkipVersionCheck:           true,
 		SkipValuesSchemaValidation: true,
 		CachePath:                  cachePath,
-		TempDir:                    definitionTmpDir,
 		RemoteOptions:              defaultRemoteOptions(),
 	}
 
@@ -146,6 +137,9 @@ func (o *devGenerateSchemaOptions) run(ctx context.Context, args []string) (err 
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	// Step 1: Merge default values.files to create initial set of default Zarf values
 	valuesPaths := make([]string, len(defined.Pkg.Values.Files))
 	for i, file := range defined.Pkg.Values.Files {
@@ -296,18 +290,10 @@ func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) (er
 	if err != nil {
 		return err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           o.flavor,
 		SetVariables:     o.setPkgTmpl,
 		CachePath:        cachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    true,
 		SkipVersionCheck: true,
 		RemoteOptions:    defaultRemoteOptions(),
@@ -320,6 +306,9 @@ func (o *devInspectDefinitionOptions) run(cmd *cobra.Command, args []string) (er
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	defined.Pkg.Build = v1alpha1.ZarfBuildData{}
 	err = utils.ColorPrintYAML(defined.Pkg, nil, false)
 	if err != nil {

--- a/src/pkg/packager/assemble/assemble.go
+++ b/src/pkg/packager/assemble/assemble.go
@@ -897,6 +897,7 @@ func recordPackageMetadata(pkg v1alpha1.ZarfPackage, flavor string, registryOver
 func collectVersionRequirements(pkg v1alpha1.ZarfPackage, hasIndex bool) []v1alpha1.VersionRequirement {
 	var reqs []v1alpha1.VersionRequirement
 	var hasImageArchives, hasTemplatedValuesFiles, hasVersionlessChart bool
+	hasSkeletonValues := pkg.Metadata.Architecture == v1alpha1.SkeletonArch && (len(pkg.Values.Files) > 0 || pkg.Values.Schema != "")
 	for _, comp := range pkg.Components {
 		if !hasImageArchives && len(comp.ImageArchives) > 0 {
 			hasImageArchives = true
@@ -935,6 +936,12 @@ func collectVersionRequirements(pkg v1alpha1.ZarfPackage, hasIndex bool) []v1alp
 		reqs = append(reqs, v1alpha1.VersionRequirement{
 			Version: "v0.77.0",
 			Reason:  "This package contains multi-platform images preserved by index digest, which require v0.77.0+",
+		})
+	}
+	if hasSkeletonValues {
+		reqs = append(reqs, v1alpha1.VersionRequirement{
+			Version: "v0.83.0",
+			Reason:  "This skeleton package contains package values or a values schema, which require v0.83.0+",
 		})
 	}
 	return reqs

--- a/src/pkg/packager/assemble/assemble.go
+++ b/src/pkg/packager/assemble/assemble.go
@@ -249,14 +249,22 @@ type AssembleSkeletonOptions struct {
 func AssembleSkeleton(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string, importedSchemas []string, opts AssembleSkeletonOptions) (*layout.PackageLayout, error) {
 	pkg.Metadata.Architecture = v1alpha1.SkeletonArch
 
-	// Creating skeleton packages with the values feature is not yet supported
-	if len(pkg.Values.Files) > 0 || pkg.Values.Schema != "" || len(importedSchemas) > 0 {
-		return nil, errors.New("creating skeleton packages with the values feature is not yet supported")
-	}
-
 	buildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(pkg.Values.Files) > 0 {
+		if err = mergeAndWriteValuesFile(ctx, pkg.Values.Files, packagePath, buildPath); err != nil {
+			return nil, err
+		}
+		pkg.Values.Files = []string{layout.ValuesYAML}
+	}
+	if pkg.Values.Schema != "" || len(importedSchemas) > 0 {
+		if err = mergeAndWriteValuesSchema(ctx, pkg.Values.Schema, importedSchemas, packagePath, buildPath); err != nil {
+			return nil, err
+		}
+		pkg.Values.Schema = layout.ValuesSchema
 	}
 
 	if err = createDocumentationTar(pkg, packagePath, buildPath); err != nil {

--- a/src/pkg/packager/assemble/assemble_test.go
+++ b/src/pkg/packager/assemble/assemble_test.go
@@ -671,6 +671,7 @@ func TestAssembleSkeleton(t *testing.T) {
 
 	defined, err := load.PackageDefinition(ctx, "./testdata/zarf-skeleton-package", load.DefinitionOptions{})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, defined.Cleanup()) })
 
 	opt := AssembleSkeletonOptions{}
 	pkgLayout, err := AssembleSkeleton(ctx, defined.Pkg, "./testdata/zarf-skeleton-package", defined.ImportedSchemas, opt)
@@ -762,6 +763,7 @@ func TestGetSBOM(t *testing.T) {
 	writePackageToDisk(t, pkg, tmpdir)
 	defined, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, defined.Cleanup()) })
 
 	pkgLayout, err := AssemblePackage(ctx, defined.Pkg, tmpdir, nil, AssembleOptions{})
 	require.NoError(t, err)
@@ -853,6 +855,7 @@ func TestCreateAbsoluteSources(t *testing.T) {
 
 			defined, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
 			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, defined.Cleanup()) })
 
 			var pkgLayout *layout.PackageLayout
 			if tt.isSkeleton {
@@ -939,6 +942,7 @@ func TestCreateAbsolutePathImports(t *testing.T) {
 	writePackageToDisk(t, childPkg, childDir)
 	defined, err := load.PackageDefinition(ctx, tmpdir, load.DefinitionOptions{})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, defined.Cleanup()) })
 	// create the package
 	pkgLayout, err := AssemblePackage(context.Background(), defined.Pkg, tmpdir, nil, AssembleOptions{})
 	require.NoError(t, err)

--- a/src/pkg/packager/assemble/assemble_test.go
+++ b/src/pkg/packager/assemble/assemble_test.go
@@ -671,6 +671,44 @@ fb7ebee94a4479bacddd71195030a483b0b0b96d4f73f7fcd2c2c8e0fce0c5c6 components/helm
 	require.Equal(t, "20c2cf8bde902c8daad1ad9fb3cd9f06741550ac34401474500a24835cb36114", testutil.ChecksumZarfYAMLContent(t, pkgLayout.Pkg), "skeleton zarf.yaml checksum drift — package would differ across build hosts")
 }
 
+func TestAssembleSkeletonWithValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+	packagePath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packagePath, "values.yaml"), []byte("setting: skeleton\n"), helpers.ReadWriteUser))
+	require.NoError(t, os.WriteFile(filepath.Join(packagePath, "values.schema.json"), []byte(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"setting":{"type":"string"}}}`), helpers.ReadWriteUser))
+
+	pkg := v1alpha1.ZarfPackage{
+		Kind: v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{
+			Name:    "skeleton-with-values",
+			Version: "0.0.1",
+		},
+		Values: v1alpha1.ZarfValues{
+			Files:  []string{"values.yaml"},
+			Schema: "values.schema.json",
+		},
+	}
+
+	pkgLayout, err := AssembleSkeleton(ctx, pkg, packagePath, nil, AssembleSkeletonOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{layout.ValuesYAML}, pkgLayout.Pkg.Values.Files)
+	require.Equal(t, layout.ValuesSchema, pkgLayout.Pkg.Values.Schema)
+
+	values, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ValuesYAML))
+	require.NoError(t, err)
+	require.YAMLEq(t, "setting: skeleton\n", string(values))
+	schema, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"setting":{"type":"string"}}}`, string(schema))
+
+	checksums, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.Checksums))
+	require.NoError(t, err)
+	require.Contains(t, string(checksums), " "+layout.ValuesYAML)
+	require.Contains(t, string(checksums), " "+layout.ValuesSchema)
+}
+
 func writePackageToDisk(t *testing.T, pkg v1alpha1.ZarfPackage, dir string) {
 	t.Helper()
 	b, err := goyaml.Marshal(pkg)

--- a/src/pkg/packager/assemble/assemble_test.go
+++ b/src/pkg/packager/assemble/assemble_test.go
@@ -241,6 +241,10 @@ func TestCollectVersionRequirements(t *testing.T) {
 		Version: "v0.65.0",
 		Reason:  "This package contains a chart without a version, which is only supported on v0.65.0+",
 	}
+	skeletonValuesReq := v1alpha1.VersionRequirement{
+		Version: "v0.83.0",
+		Reason:  "This skeleton package contains package values or a values schema, which require v0.83.0+",
+	}
 
 	tests := []struct {
 		name     string
@@ -252,6 +256,22 @@ func TestCollectVersionRequirements(t *testing.T) {
 			name:     "no requirements for a plain package",
 			pkg:      v1alpha1.ZarfPackage{},
 			expected: nil,
+		},
+		{
+			name: "skeleton values require v0.83.0",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Architecture: v1alpha1.SkeletonArch},
+				Values:   v1alpha1.ZarfValues{Files: []string{layout.ValuesYAML}},
+			},
+			expected: []v1alpha1.VersionRequirement{skeletonValuesReq},
+		},
+		{
+			name: "skeleton values schema requires v0.83.0",
+			pkg: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Architecture: v1alpha1.SkeletonArch},
+				Values:   v1alpha1.ZarfValues{Schema: layout.ValuesSchema},
+			},
+			expected: []v1alpha1.VersionRequirement{skeletonValuesReq},
 		},
 		{
 			name: "image archives trigger v0.68.0",
@@ -695,6 +715,10 @@ func TestAssembleSkeletonWithValues(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{layout.ValuesYAML}, pkgLayout.Pkg.Values.Files)
 	require.Equal(t, layout.ValuesSchema, pkgLayout.Pkg.Values.Schema)
+	require.Equal(t, []v1alpha1.VersionRequirement{{
+		Version: "v0.83.0",
+		Reason:  "This skeleton package contains package values or a values schema, which require v0.83.0+",
+	}}, pkgLayout.Pkg.Build.VersionRequirements)
 
 	values, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ValuesYAML))
 	require.NoError(t, err)

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/assemble"
@@ -54,11 +56,19 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 	if err != nil {
 		return "", err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 
 	loadOpts := load.DefinitionOptions{
 		Flavor:             opts.Flavor,
 		SetVariables:       opts.SetVariables,
 		CachePath:          opts.CachePath,
+		TempDir:            tmpDir,
 		IsInteractive:      opts.IsInteractive,
 		SkipRequiredValues: true,
 		SkipVersionCheck:   opts.SkipVersionCheck,
@@ -68,7 +78,6 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 	if err != nil {
 		return "", err
 	}
-
 	pkgPath, err := layout.ResolvePackagePath(packagePath)
 	if err != nil {
 		return "", fmt.Errorf("unable to access package path %q: %w", packagePath, err)

--- a/src/pkg/packager/create.go
+++ b/src/pkg/packager/create.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/images"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 	"github.com/zarf-dev/zarf/src/pkg/packager/assemble"
@@ -56,19 +54,10 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 	if err != nil {
 		return "", err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
 	loadOpts := load.DefinitionOptions{
 		Flavor:             opts.Flavor,
 		SetVariables:       opts.SetVariables,
 		CachePath:          opts.CachePath,
-		TempDir:            tmpDir,
 		IsInteractive:      opts.IsInteractive,
 		SkipRequiredValues: true,
 		SkipVersionCheck:   opts.SkipVersionCheck,
@@ -78,6 +67,9 @@ func Create(ctx context.Context, packagePath string, output string, opts CreateO
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	pkgPath, err := layout.ResolvePackagePath(packagePath)
 	if err != nil {
 		return "", fmt.Errorf("unable to access package path %q: %w", packagePath, err)

--- a/src/pkg/packager/create_test.go
+++ b/src/pkg/packager/create_test.go
@@ -5,10 +5,12 @@ package packager
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -70,4 +72,72 @@ func TestPackageCreateDifferentialOCIPackage(t *testing.T) {
 			require.Equal(t, filepath.Join(tmpdir, "zarf-package-differential-test-amd64-0.0.1-differential-0.0.2.tar.zst"), newPackageSource)
 		})
 	}
+}
+
+func TestPackageCreateWithImportedSkeletonValues(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	cachePath := filepath.Join(t.TempDir(), "cache")
+	registryRef := createRegistry(ctx, t)
+
+	// Publish a skeleton whose values and schema will be imported by the parent package.
+	skeletonPath := filepath.Join(t.TempDir(), "skeleton")
+	require.NoError(t, os.MkdirAll(skeletonPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, "values.yaml"), []byte("shared: 1\nchild: value\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, "values.schema.json"), []byte(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"shared":{"type":"integer"},"child":{"type":"string"}}}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, layout.ZarfYAML), []byte(`kind: ZarfPackageConfig
+metadata:
+  name: values-skeleton
+  version: 0.0.1
+values:
+  files:
+    - values.yaml
+  schema: values.schema.json
+components:
+  - name: imported
+`), 0o600))
+
+	skeletonRef, err := PublishSkeleton(ctx, skeletonPath, registryRef, PublishSkeletonOptions{
+		CachePath:     cachePath,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.NoError(t, err)
+
+	// Create a parent that imports the skeleton component and overrides its values and schema.
+	parentPath := filepath.Join(t.TempDir(), "parent")
+	require.NoError(t, os.MkdirAll(parentPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, "values.yaml"), []byte("shared: parent\nparent: value\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, "values.schema.json"), []byte(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"shared":{"type":"string"},"parent":{"type":"string"}}}`), 0o600))
+	parentManifest := fmt.Sprintf(`kind: ZarfPackageConfig
+metadata:
+  name: values-parent
+  version: 0.0.1
+values:
+  files:
+    - values.yaml
+  schema: values.schema.json
+components:
+  - name: imported
+    import:
+      url: oci://%s
+      name: imported
+`, skeletonRef.String())
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, layout.ZarfYAML), []byte(parentManifest), 0o600))
+
+	packageRef, err := Create(ctx, parentPath, fmt.Sprintf("oci://%s", registryRef.String()), CreateOptions{
+		CachePath:     cachePath,
+		SkipSBOM:      true,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.NoError(t, err)
+
+	// Pull the created package to verify the assembled values and schema layers.
+	created := pullFromRemote(ctx, t, packageRef, "amd64", "", t.TempDir())
+	defer func() { require.NoError(t, created.Cleanup()) }()
+	values, err := os.ReadFile(filepath.Join(created.DirPath(), layout.ValuesYAML))
+	require.NoError(t, err)
+	require.YAMLEq(t, "shared: parent\nchild: value\nparent: value\n", string(values))
+
+	schema, err := os.ReadFile(filepath.Join(created.DirPath(), layout.ValuesSchema))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"shared":{"type":"string"},"child":{"type":"string"},"parent":{"type":"string"}}}`, string(schema))
 }

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -6,6 +6,7 @@ package packager
 import (
 	"context"
 	"errors"
+	"os"
 	"runtime"
 	"slices"
 	"time"
@@ -71,11 +72,19 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    false,
 		SkipVersionCheck: opts.SkipVersionCheck,
 		RemoteOptions:    opts.RemoteOptions,
@@ -84,7 +93,6 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
-
 	filter := filters.Combine(
 		filters.ByLocalOS(runtime.GOOS),
 		filters.ForDeploy(opts.OptionalComponents, false),

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -6,7 +6,6 @@ package packager
 import (
 	"context"
 	"errors"
-	"os"
 	"runtime"
 	"slices"
 	"time"
@@ -72,19 +71,10 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    false,
 		SkipVersionCheck: opts.SkipVersionCheck,
 		RemoteOptions:    opts.RemoteOptions,
@@ -93,6 +83,9 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	filter := filters.Combine(
 		filters.ByLocalOS(runtime.GOOS),
 		filters.ForDeploy(opts.OptionalComponents, false),

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -101,18 +101,10 @@ func FindDefinitionImages(ctx context.Context, packagePath string, opts FindImag
 	if err != nil {
 		return nil, err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        cachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -121,6 +113,9 @@ func FindDefinitionImages(ctx context.Context, packagePath string, opts FindImag
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	imageScans, err := findImages(ctx, defined.Pkg, packagePath, opts)
 	if err != nil {
 		return nil, err
@@ -136,19 +131,10 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 	if err != nil {
 		return nil, err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -157,6 +143,9 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	return findImages(ctx, defined.Pkg, packagePath, opts)
 }
 

--- a/src/pkg/packager/find_images.go
+++ b/src/pkg/packager/find_images.go
@@ -96,15 +96,23 @@ type DefinitionImageResult struct {
 // FindDefinitionImages finds all images contained in a component and filters them according to images discovered in
 // imageArchives.
 // It returns []DefinitionImageResult
-func FindDefinitionImages(ctx context.Context, packagePath string, opts FindImagesOptions) ([]DefinitionImageResult, error) {
+func FindDefinitionImages(ctx context.Context, packagePath string, opts FindImagesOptions) (_ []DefinitionImageResult, err error) {
 	cachePath, err := utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return nil, err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        cachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -128,11 +136,19 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 	if err != nil {
 		return nil, err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -141,7 +157,6 @@ func FindImages(ctx context.Context, packagePath string, opts FindImagesOptions)
 	if err != nil {
 		return nil, err
 	}
-
 	return findImages(ctx, defined.Pkg, packagePath, opts)
 }
 

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -284,18 +284,10 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 	if err != nil {
 		return nil, err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -304,6 +296,9 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	pkg := defined.Pkg
 	variableConfig, err := getPopulatedVariableConfig(ctx, pkg, opts.DeploySetVariables, opts.IsInteractive)
 	if err != nil {

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -284,10 +284,18 @@ func InspectDefinitionResources(ctx context.Context, packagePath string, opts In
 	if err != nil {
 		return nil, err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.CreateSetVariables,
 		CachePath:        opts.CachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    opts.IsInteractive,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,

--- a/src/pkg/packager/lint.go
+++ b/src/pkg/packager/lint.go
@@ -6,9 +6,7 @@ package packager
 import (
 	"context"
 	"errors"
-	"os"
 
-	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -33,19 +31,10 @@ func Lint(ctx context.Context, packagePath string, opts LintOptions) (err error)
 	if err != nil {
 		return err
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.SetVariables,
 		CachePath:        opts.CachePath,
-		TempDir:          tmpDir,
 		IsInteractive:    false,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,
@@ -54,6 +43,9 @@ func Lint(ctx context.Context, packagePath string, opts LintOptions) (err error)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	findings := []lint.PackageFinding{}
 	for i, component := range defined.Pkg.Components {
 		findings = append(findings, lint.CheckComponentValues(component, i)...)

--- a/src/pkg/packager/lint.go
+++ b/src/pkg/packager/lint.go
@@ -6,7 +6,9 @@ package packager
 import (
 	"context"
 	"errors"
+	"os"
 
+	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/lint"
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
@@ -22,21 +24,28 @@ type LintOptions struct {
 }
 
 // Lint lints the given Zarf package
-func Lint(ctx context.Context, packagePath string, opts LintOptions) error {
+func Lint(ctx context.Context, packagePath string, opts LintOptions) (err error) {
 	if packagePath == "" {
 		return errors.New("package path is required")
 	}
 
-	var err error
 	opts.CachePath, err = utils.ResolveCachePath(opts.CachePath)
 	if err != nil {
 		return err
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 
 	loadOpts := load.DefinitionOptions{
 		Flavor:           opts.Flavor,
 		SetVariables:     opts.SetVariables,
 		CachePath:        opts.CachePath,
+		TempDir:          tmpDir,
 		IsInteractive:    false,
 		SkipVersionCheck: true,
 		RemoteOptions:    opts.RemoteOptions,

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -178,9 +178,6 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 			}
 
 			if len(importedPkg.Values.Files) > 0 || importedPkg.Values.Schema != "" {
-				if tempDir == "" {
-					return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("a temporary directory is required to stage values from imported skeleton %s", component.Import.URL)
-				}
 				packageValuesPath, err = fetchOCISkeletonValues(ctx, remote, root, rootDesc, component.Import.URL, pkgPath.BaseDir, cachePath, tempDir, importedPkg)
 				if err != nil {
 					return v1alpha1.ZarfPackage{}, nil, err
@@ -229,7 +226,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		variables = append(variables, importedPkg.Variables...)
 		constants = append(constants, importedPkg.Constants...)
 		if packageValuesPath != "" {
-			// OCI package values are projected to canonical staging paths, so remote
+			// OCI package values are projected to canonical temporary paths, so remote
 			// metadata must never select an arbitrary path on the local filesystem.
 			if len(importedPkg.Values.Files) > 0 {
 				valuesFiles = append(valuesFiles, makePathRelativeTo(layout.ValuesYAML, packageValuesPath))
@@ -302,15 +299,15 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 }
 
 // fetchOCISkeletonValues projects package-scoped values layers from an imported
-// skeleton into an operation-scoped staging directory. OCI blobs remain in the cache.
-func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.Manifest, rootDesc ocispec.Descriptor, importURL, packagePath, cachePath, stagingPath string, pkg v1alpha1.ZarfPackage) (string, error) {
+// skeleton into an operation-scoped temporary directory. OCI blobs remain in the cache.
+func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.Manifest, rootDesc ocispec.Descriptor, importURL, packagePath, cachePath, tempDir string, pkg v1alpha1.ZarfPackage) (string, error) {
 	cache := filepath.Join(cachePath, "oci")
 	store, err := ocistore.New(cache)
 	if err != nil {
 		return "", err
 	}
 
-	valuesDir := filepath.Join(stagingPath, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
+	valuesDir := filepath.Join(tempDir, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
 	if err := helpers.CreateDirectory(valuesDir, helpers.ReadWriteExecuteUser); err != nil {
 		return "", err
 	}

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -102,6 +102,9 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 
 		var importedPkg v1alpha1.ZarfPackage
 		var innerSchemas []string
+		var packageValuesPath string
+		var importedRemote *zoci.Remote
+		var importedRoot *oci.Manifest
 		if component.Import.Path != "" {
 			importPath := filepath.Join(pkgPath.BaseDir, component.Import.Path)
 			for _, sp := range importStack {
@@ -148,20 +151,29 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, nil, err
 			}
-			_, err = remote.ResolveRoot(ctx)
+			rootDesc, err := remote.ResolveRoot(ctx)
 			if err != nil {
 				if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
 					return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
 				}
 				return v1alpha1.ZarfPackage{}, nil, err
 			}
-			importedPkg, err = remote.FetchZarfYAML(ctx)
+			root, err := remote.FetchManifest(ctx, rootDesc)
+			if err != nil {
+				return v1alpha1.ZarfPackage{}, nil, err
+			}
+			importedRemote = remote
+			importedRoot = root
+			importedPkg, err = zoci.FetchZarfYAML(ctx, root, remote)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, nil, err
 			}
 
 			if len(importedPkg.Values.Files) > 0 || importedPkg.Values.Schema != "" {
-				return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("imported skeleton %s declares values which are not yet supported", component.Import.URL)
+				packageValuesPath, err = fetchOCISkeletonValues(ctx, remote, root, rootDesc, component.Import.URL, pkgPath.BaseDir, cachePath, importedPkg)
+				if err != nil {
+					return v1alpha1.ZarfPackage{}, nil, err
+				}
 			}
 
 			if !skipVersionCheck {
@@ -186,7 +198,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		}
 		importedComponent := found[0]
 
-		importPath, err := fetchOCISkeleton(ctx, component, pkgPath.BaseDir, cachePath, remoteOptions)
+		importPath, err := fetchOCISkeleton(ctx, component, pkgPath.BaseDir, cachePath, importedRemote, importedRoot)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, nil, err
 		}
@@ -212,11 +224,15 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		components = append(components, composed)
 		variables = append(variables, importedPkg.Variables...)
 		constants = append(constants, importedPkg.Constants...)
+		valuesAnchorPath := importPath
+		if packageValuesPath != "" {
+			valuesAnchorPath = packageValuesPath
+		}
 		for _, v := range importedPkg.Values.Files {
-			valuesFiles = append(valuesFiles, makePathRelativeTo(v, importPath))
+			valuesFiles = append(valuesFiles, makePathRelativeTo(v, valuesAnchorPath))
 		}
 		if importedPkg.Values.Schema != "" {
-			importedSchemas = append(importedSchemas, makePathRelativeTo(importedPkg.Values.Schema, importPath))
+			importedSchemas = append(importedSchemas, makePathRelativeTo(importedPkg.Values.Schema, valuesAnchorPath))
 		}
 		for _, s := range innerSchemas {
 			importedSchemas = append(importedSchemas, makePathRelativeTo(s, importPath))
@@ -274,6 +290,69 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 	return pkg, deduplicatedSchemas, nil
 }
 
+// fetchOCISkeletonValues materializes package-scoped values layers from an imported
+// skeleton. The directory is keyed by the resolved root descriptor so repeat imports
+// share both the cached blobs and the stable paths used during values merging.
+func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.Manifest, rootDesc ocispec.Descriptor, importURL, packagePath, cachePath string, pkg v1alpha1.ZarfPackage) (string, error) {
+	cache := filepath.Join(cachePath, "oci")
+	store, err := ocistore.New(cache)
+	if err != nil {
+		return "", err
+	}
+
+	valuesDir := filepath.Join(cache, "packages", rootDesc.Digest.Encoded())
+	if err := helpers.CreateDirectory(valuesDir, helpers.ReadWriteExecuteUser); err != nil {
+		return "", err
+	}
+
+	type layer struct {
+		declared bool
+		path     string
+		name     string
+	}
+	layers := []layer{
+		{declared: len(pkg.Values.Files) > 0, path: layout.ValuesYAML, name: "values"},
+		{declared: pkg.Values.Schema != "", path: layout.ValuesSchema, name: "values schema"},
+	}
+	for _, layer := range layers {
+		if !layer.declared {
+			continue
+		}
+		desc := root.Locate(layer.path)
+		if oci.IsEmptyDescriptor(desc) {
+			return "", fmt.Errorf("imported skeleton %s declares %s but does not contain %q", importURL, layer.name, layer.path)
+		}
+		exists, err := store.Exists(ctx, desc)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			if err := remote.CopyToTarget(ctx, []ocispec.Descriptor{desc}, store, remote.GetDefaultCopyOpts()); err != nil {
+				return "", err
+			}
+		}
+		src := filepath.Join(cache, "blobs", "sha256", desc.Digest.Encoded())
+		dst := filepath.Join(valuesDir, layer.path)
+		contents, err := os.ReadFile(src)
+		if err != nil {
+			return "", fmt.Errorf("unable to read %s for imported skeleton %s: %w", layer.path, importURL, err)
+		}
+		if err := os.WriteFile(dst, contents, helpers.ReadWriteUser); err != nil {
+			return "", fmt.Errorf("unable to materialize %s for imported skeleton %s: %w", layer.path, importURL, err)
+		}
+	}
+
+	absPackagePath, err := filepath.Abs(packagePath)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absPackagePath, valuesDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 func validateComponentCompose(c v1alpha1.ZarfComponent) error {
 	errs := []error{}
 	if strings.Contains(c.Import.Path, v1alpha1.ZarfPackageTemplatePrefix) || strings.Contains(c.Import.URL, v1alpha1.ZarfPackageTemplatePrefix) {
@@ -305,10 +384,14 @@ func compatibleComponent(c v1alpha1.ZarfComponent, arch, flavor string) bool {
 	return satisfiesArch && satisfiesFlavor
 }
 
-// TODO (phillebaba): Refactor package structure so that pullOCI can be used instead.
-func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string, remoteOptions types.RemoteOptions) (string, error) {
+// TODO: Extract descriptor-pinned selected-layer materialization into zoci so this
+// component-import path and pullOCI can share it without introducing a package cycle.
+func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, packagePath string, cachePath string, remote *zoci.Remote, manifest *oci.Manifest) (string, error) {
 	if component.Import.URL == "" {
 		return component.Import.Path, nil
+	}
+	if remote == nil || manifest == nil {
+		return "", fmt.Errorf("missing resolved remote manifest for skeleton %s", component.Import.URL)
 	}
 
 	name := component.Name
@@ -321,29 +404,9 @@ func fetchOCISkeleton(ctx context.Context, component v1alpha1.ZarfComponent, pac
 		return "", err
 	}
 
-	// Get the descriptor for the component.
-	plainHTTP, err := negotiateImportPlainHTTP(ctx, component.Import.URL, remoteOptions)
-	if err != nil {
-		return "", err
-	}
-	remote, err := zoci.NewRemote(ctx, component.Import.URL, zoci.PlatformForSkeleton(),
-		oci.WithPlainHTTP(plainHTTP), oci.WithInsecureSkipVerify(remoteOptions.InsecureSkipTLSVerify))
-	if err != nil {
-		return "", err
-	}
-	_, err = remote.ResolveRoot(ctx)
-	if err != nil {
-		// This error likely won't occur as the root has been resolved before this function is invoked.
-		// This serves as a secondary mechanism to highlight the potential for the package existing without a published skeleton.
-		if strings.Contains(err.Error(), "no matching manifest was found in the manifest list") {
-			return "", fmt.Errorf("package at %s exists but has not been published as a skeleton: %w", component.Import.URL, err)
-		}
-		return "", fmt.Errorf("published skeleton package for %s does not exist: %w", component.Import.URL, err)
-	}
-	manifest, err := remote.FetchRoot(ctx)
-	if err != nil {
-		return "", err
-	}
+	// The caller resolves the OCI reference once and passes its manifest through so
+	// component layers remain pinned to the same immutable descriptor as zarf.yaml
+	// and package-level values.
 	componentDesc := manifest.Locate(filepath.Join(layout.ComponentsDir, fmt.Sprintf("%s.tar", name)))
 	var tarball, dir string
 	// If the descriptor for the component tarball was not found then all resources in the component are remote

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -224,15 +224,22 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		components = append(components, composed)
 		variables = append(variables, importedPkg.Variables...)
 		constants = append(constants, importedPkg.Constants...)
-		valuesAnchorPath := importPath
 		if packageValuesPath != "" {
-			valuesAnchorPath = packageValuesPath
-		}
-		for _, v := range importedPkg.Values.Files {
-			valuesFiles = append(valuesFiles, makePathRelativeTo(v, valuesAnchorPath))
-		}
-		if importedPkg.Values.Schema != "" {
-			importedSchemas = append(importedSchemas, makePathRelativeTo(importedPkg.Values.Schema, valuesAnchorPath))
+			// OCI package values are materialized to canonical cache paths, so remote
+			// metadata must never select an arbitrary path on the local filesystem.
+			if len(importedPkg.Values.Files) > 0 {
+				valuesFiles = append(valuesFiles, makePathRelativeTo(layout.ValuesYAML, packageValuesPath))
+			}
+			if importedPkg.Values.Schema != "" {
+				importedSchemas = append(importedSchemas, makePathRelativeTo(layout.ValuesSchema, packageValuesPath))
+			}
+		} else {
+			for _, valueFile := range importedPkg.Values.Files {
+				valuesFiles = append(valuesFiles, makePathRelativeTo(valueFile, importPath))
+			}
+			if importedPkg.Values.Schema != "" {
+				importedSchemas = append(importedSchemas, makePathRelativeTo(importedPkg.Values.Schema, importPath))
+			}
 		}
 		for _, s := range innerSchemas {
 			importedSchemas = append(importedSchemas, makePathRelativeTo(s, importPath))

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -169,17 +169,17 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 				return v1alpha1.ZarfPackage{}, nil, err
 			}
 
+			if !skipVersionCheck {
+				// Validate skeleton package compatibility before pulling its component or values layers.
+				if err := pkgvalidate.ValidateVersionRequirements(importedPkg); err != nil {
+					return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("package %s has unmet requirements: %w If you cannot upgrade Zarf you may skip this check with --skip-version-check. Unexpected behavior or errors may occur", component.Import.URL, err)
+				}
+			}
+
 			if len(importedPkg.Values.Files) > 0 || importedPkg.Values.Schema != "" {
 				packageValuesPath, err = fetchOCISkeletonValues(ctx, remote, root, rootDesc, component.Import.URL, pkgPath.BaseDir, cachePath, importedPkg)
 				if err != nil {
 					return v1alpha1.ZarfPackage{}, nil, err
-				}
-			}
-
-			if !skipVersionCheck {
-				// Validate skeleton package is compatible with new package
-				if err := pkgvalidate.ValidateVersionRequirements(importedPkg); err != nil {
-					return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("package %s has unmet requirements: %w If you cannot upgrade Zarf you may skip this check with --skip-version-check. Unexpected behavior or errors may occur", component.Import.URL, err)
 				}
 			}
 		}

--- a/src/pkg/packager/load/import.go
+++ b/src/pkg/packager/load/import.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +56,7 @@ func getComponentToImportName(component v1alpha1.ZarfComponent) string {
 	return component.Name
 }
 
-func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool, remoteOptions types.RemoteOptions) (v1alpha1.ZarfPackage, []string, error) {
+func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, arch, flavor string, importStack []string, cachePath string, skipVersionCheck bool, remoteOptions types.RemoteOptions, tempDir string) (v1alpha1.ZarfPackage, []string, error) {
 	l := logger.From(ctx)
 	start := time.Now()
 
@@ -133,7 +134,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 				}
 			}
 			importedPkg.Components = relevantComponents
-			importedPkg, innerSchemas, err = resolveImports(ctx, importedPkg, importPkgPath.ManifestFile, arch, flavor, importStack, cachePath, skipVersionCheck, remoteOptions)
+			importedPkg, innerSchemas, err = resolveImports(ctx, importedPkg, importPkgPath.ManifestFile, arch, flavor, importStack, cachePath, skipVersionCheck, remoteOptions, tempDir)
 			if err != nil {
 				return v1alpha1.ZarfPackage{}, nil, err
 			}
@@ -177,7 +178,10 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 			}
 
 			if len(importedPkg.Values.Files) > 0 || importedPkg.Values.Schema != "" {
-				packageValuesPath, err = fetchOCISkeletonValues(ctx, remote, root, rootDesc, component.Import.URL, pkgPath.BaseDir, cachePath, importedPkg)
+				if tempDir == "" {
+					return v1alpha1.ZarfPackage{}, nil, fmt.Errorf("a temporary directory is required to stage values from imported skeleton %s", component.Import.URL)
+				}
+				packageValuesPath, err = fetchOCISkeletonValues(ctx, remote, root, rootDesc, component.Import.URL, pkgPath.BaseDir, cachePath, tempDir, importedPkg)
 				if err != nil {
 					return v1alpha1.ZarfPackage{}, nil, err
 				}
@@ -225,7 +229,7 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 		variables = append(variables, importedPkg.Variables...)
 		constants = append(constants, importedPkg.Constants...)
 		if packageValuesPath != "" {
-			// OCI package values are materialized to canonical cache paths, so remote
+			// OCI package values are projected to canonical staging paths, so remote
 			// metadata must never select an arbitrary path on the local filesystem.
 			if len(importedPkg.Values.Files) > 0 {
 				valuesFiles = append(valuesFiles, makePathRelativeTo(layout.ValuesYAML, packageValuesPath))
@@ -297,17 +301,16 @@ func resolveImports(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath, 
 	return pkg, deduplicatedSchemas, nil
 }
 
-// fetchOCISkeletonValues materializes package-scoped values layers from an imported
-// skeleton. The directory is keyed by the resolved root descriptor so repeat imports
-// share both the cached blobs and the stable paths used during values merging.
-func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.Manifest, rootDesc ocispec.Descriptor, importURL, packagePath, cachePath string, pkg v1alpha1.ZarfPackage) (string, error) {
+// fetchOCISkeletonValues projects package-scoped values layers from an imported
+// skeleton into an operation-scoped staging directory. OCI blobs remain in the cache.
+func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.Manifest, rootDesc ocispec.Descriptor, importURL, packagePath, cachePath, stagingPath string, pkg v1alpha1.ZarfPackage) (string, error) {
 	cache := filepath.Join(cachePath, "oci")
 	store, err := ocistore.New(cache)
 	if err != nil {
 		return "", err
 	}
 
-	valuesDir := filepath.Join(cache, "packages", rootDesc.Digest.Encoded())
+	valuesDir := filepath.Join(stagingPath, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
 	if err := helpers.CreateDirectory(valuesDir, helpers.ReadWriteExecuteUser); err != nil {
 		return "", err
 	}
@@ -338,13 +341,19 @@ func fetchOCISkeletonValues(ctx context.Context, remote *zoci.Remote, root *oci.
 				return "", err
 			}
 		}
-		src := filepath.Join(cache, "blobs", "sha256", desc.Digest.Encoded())
-		dst := filepath.Join(valuesDir, layer.path)
-		contents, err := os.ReadFile(src)
+		src, err := store.Fetch(ctx, desc)
 		if err != nil {
-			return "", fmt.Errorf("unable to read %s for imported skeleton %s: %w", layer.path, importURL, err)
+			return "", fmt.Errorf("unable to fetch %s for imported skeleton %s: %w", layer.path, importURL, err)
 		}
-		if err := os.WriteFile(dst, contents, helpers.ReadWriteUser); err != nil {
+		dst := filepath.Join(valuesDir, layer.path)
+		if err := func() error {
+			out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, helpers.ReadWriteUser)
+			if err != nil {
+				return errors.Join(err, src.Close())
+			}
+			_, copyErr := io.Copy(out, src)
+			return errors.Join(copyErr, out.Close(), src.Close())
+		}(); err != nil {
 			return "", fmt.Errorf("unable to materialize %s for imported skeleton %s: %w", layer.path, importURL, err)
 		}
 	}

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -4,6 +4,7 @@
 package load
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
+	ocistore "oras.land/oras-go/v2/content/oci"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/pkgcfg"
@@ -32,7 +34,7 @@ func TestResolveImportsCircular(t *testing.T) {
 	pkg, err := pkgcfg.Parse(ctx, b)
 	require.NoError(t, err)
 
-	_, _, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false, types.RemoteOptions{})
+	_, _, err = resolveImports(ctx, pkg, "./testdata/import/circular/first", "", "", []string{}, "", false, types.RemoteOptions{}, "")
 	require.EqualError(t, err, "package testdata/import/circular/second imported in cycle by testdata/import/circular/third in component component")
 }
 
@@ -118,7 +120,7 @@ func TestResolveImports(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolvedPkg, _, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false, types.RemoteOptions{})
+			resolvedPkg, _, err := resolveImports(ctx, pkg, tc.path, "", tc.flavor, []string{}, "", false, types.RemoteOptions{}, "")
 			require.NoError(t, err)
 
 			b, err = os.ReadFile(filepath.Join(tc.path, "expected.yaml"))
@@ -153,7 +155,7 @@ func TestResolveImportsDedupNormalization(t *testing.T) {
 	// Reuse an existing fixture's directory only as the on-disk anchor — resolveImports
 	// stats the path but does not re-parse zarf.yaml when pkg is passed in.
 	resolved, _, err := resolveImports(ctx, pkg, "./testdata/import/values/duplicate-consecutive",
-		"", "", []string{}, "", false, types.RemoteOptions{})
+		"", "", []string{}, "", false, types.RemoteOptions{}, "")
 	require.NoError(t, err)
 	require.Equal(t, []string{"parent-values.yaml"}, resolved.Values.Files)
 }
@@ -187,10 +189,50 @@ func TestFetchOCISkeletonValuesMissingDeclaredLayer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rootDesc := ocispec.Descriptor{Digest: digest.FromString(tt.name)}
-			_, err := fetchOCISkeletonValues(ctx, nil, &pkgoci.Manifest{}, rootDesc, "oci://example.com/skeleton", t.TempDir(), t.TempDir(), tt.pkg)
+			_, err := fetchOCISkeletonValues(ctx, nil, &pkgoci.Manifest{}, rootDesc, "oci://example.com/skeleton", t.TempDir(), t.TempDir(), t.TempDir(), tt.pkg)
 			require.ErrorContains(t, err, tt.expectedErr)
 		})
 	}
+}
+
+func TestFetchOCISkeletonValuesUsesOperationStaging(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+	cachePath := t.TempDir()
+	cache := filepath.Join(cachePath, "oci")
+	store, err := ocistore.New(cache)
+	require.NoError(t, err)
+
+	contents := []byte("from: skeleton\n")
+	desc := ocispec.Descriptor{
+		Digest:      digest.FromBytes(contents),
+		Size:        int64(len(contents)),
+		Annotations: map[string]string{ocispec.AnnotationTitle: layout.ValuesYAML},
+	}
+	require.NoError(t, store.Push(ctx, desc, bytes.NewReader(contents)))
+
+	rootDesc := ocispec.Descriptor{Digest: digest.FromString("skeleton-root")}
+	pkg := v1alpha1.ZarfPackage{Values: v1alpha1.ZarfValues{Files: []string{layout.ValuesYAML}}}
+	manifest := &pkgoci.Manifest{Manifest: ocispec.Manifest{Layers: []ocispec.Descriptor{desc}}}
+	packagePath := t.TempDir()
+	stagingPath := t.TempDir()
+	got, err := fetchOCISkeletonValues(ctx, nil, manifest, rootDesc, "oci://example.com/skeleton", packagePath, cachePath, stagingPath, pkg)
+	require.NoError(t, err)
+
+	valuesDir := filepath.Join(stagingPath, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
+	require.FileExists(t, filepath.Join(valuesDir, layout.ValuesYAML))
+	info, err := os.Lstat(filepath.Join(valuesDir, layout.ValuesYAML))
+	require.NoError(t, err)
+	require.True(t, info.Mode().IsRegular())
+	materialized, err := os.ReadFile(filepath.Join(valuesDir, layout.ValuesYAML))
+	require.NoError(t, err)
+	require.Equal(t, contents, materialized)
+
+	expected, err := filepath.Rel(packagePath, valuesDir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.ToSlash(expected), got)
+	require.NoDirExists(t, filepath.Join(cache, "packages"))
 }
 
 func TestMakePathRelativeTo(t *testing.T) {
@@ -283,7 +325,7 @@ func TestResolveImportsValueMerge(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolved, _, err := resolveImports(ctx, pkg, tc.path, "", "", []string{}, "", false, types.RemoteOptions{})
+			resolved, _, err := resolveImports(ctx, pkg, tc.path, "", "", []string{}, "", false, types.RemoteOptions{}, "")
 			require.NoError(t, err)
 
 			absPaths := make([]string, len(resolved.Values.Files))
@@ -341,7 +383,7 @@ func TestResolveImportsSchemaCollection(t *testing.T) {
 			pkg, err := pkgcfg.Parse(ctx, b)
 			require.NoError(t, err)
 
-			resolved, importedSchemas, err := resolveImports(ctx, pkg, tc.path, "", "", []string{}, "", false, types.RemoteOptions{})
+			resolved, importedSchemas, err := resolveImports(ctx, pkg, tc.path, "", "", []string{}, "", false, types.RemoteOptions{}, "")
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectedSchemas, importedSchemas)

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -195,7 +195,7 @@ func TestFetchOCISkeletonValuesMissingDeclaredLayer(t *testing.T) {
 	}
 }
 
-func TestFetchOCISkeletonValuesUsesOperationStaging(t *testing.T) {
+func TestFetchOCISkeletonValuesUsesOperationTempDir(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.TestContext(t)
@@ -216,11 +216,11 @@ func TestFetchOCISkeletonValuesUsesOperationStaging(t *testing.T) {
 	pkg := v1alpha1.ZarfPackage{Values: v1alpha1.ZarfValues{Files: []string{layout.ValuesYAML}}}
 	manifest := &pkgoci.Manifest{Manifest: ocispec.Manifest{Layers: []ocispec.Descriptor{desc}}}
 	packagePath := t.TempDir()
-	stagingPath := t.TempDir()
-	got, err := fetchOCISkeletonValues(ctx, nil, manifest, rootDesc, "oci://example.com/skeleton", packagePath, cachePath, stagingPath, pkg)
+	tempDir := t.TempDir()
+	got, err := fetchOCISkeletonValues(ctx, nil, manifest, rootDesc, "oci://example.com/skeleton", packagePath, cachePath, tempDir, pkg)
 	require.NoError(t, err)
 
-	valuesDir := filepath.Join(stagingPath, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
+	valuesDir := filepath.Join(tempDir, rootDesc.Digest.Algorithm().String(), rootDesc.Digest.Encoded())
 	require.FileExists(t, filepath.Join(valuesDir, layout.ValuesYAML))
 	info, err := os.Lstat(filepath.Join(valuesDir, layout.ValuesYAML))
 	require.NoError(t, err)

--- a/src/pkg/packager/load/import_test.go
+++ b/src/pkg/packager/load/import_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	pkgoci "github.com/defenseunicorns/pkg/oci"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
@@ -153,6 +156,41 @@ func TestResolveImportsDedupNormalization(t *testing.T) {
 		"", "", []string{}, "", false, types.RemoteOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"parent-values.yaml"}, resolved.Values.Files)
+}
+
+func TestFetchOCISkeletonValuesMissingDeclaredLayer(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+	tests := []struct {
+		name        string
+		pkg         v1alpha1.ZarfPackage
+		expectedErr string
+	}{
+		{
+			name: "values",
+			pkg: v1alpha1.ZarfPackage{Values: v1alpha1.ZarfValues{
+				Files: []string{layout.ValuesYAML},
+			}},
+			expectedErr: "declares values but does not contain \"values.yaml\"",
+		},
+		{
+			name: "schema",
+			pkg: v1alpha1.ZarfPackage{Values: v1alpha1.ZarfValues{
+				Schema: layout.ValuesSchema,
+			}},
+			expectedErr: "declares values schema but does not contain \"values.schema.json\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rootDesc := ocispec.Descriptor{Digest: digest.FromString(tt.name)}
+			_, err := fetchOCISkeletonValues(ctx, nil, &pkgoci.Manifest{}, rootDesc, "oci://example.com/skeleton", t.TempDir(), t.TempDir(), tt.pkg)
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestMakePathRelativeTo(t *testing.T) {

--- a/src/pkg/packager/load/load.go
+++ b/src/pkg/packager/load/load.go
@@ -6,6 +6,7 @@ package load
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,8 +38,8 @@ type DefinitionOptions struct {
 	SkipValuesSchemaValidation bool
 	// CachePath is used to cache layers from skeleton package pulls
 	CachePath string
-	// TempDir is a caller-created workspace used to stage OCI skeleton values.
-	// The caller is responsible for removing it after consuming the definition.
+	// TempDir is the parent directory for operation-scoped import temporary files. When
+	// empty, config.CommonOptions.TempDirectory is used.
 	TempDir string
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
@@ -49,14 +50,37 @@ type DefinitionOptions struct {
 
 // DefinedPackage is the result of loading and resolving a package definition.
 // ImportedSchemas is transient assembly state — child schema paths collected during
-// import resolution that must be passed to AssemblePackage for merging.
+// import resolution that must be passed to AssemblePackage for merging. Call Cleanup
+// after consuming the definition.
 type DefinedPackage struct {
 	Pkg             v1alpha1.ZarfPackage
 	ImportedSchemas []string
+	tempDir         string
+}
+
+// Cleanup removes operation-scoped files created while resolving imports.
+func (p DefinedPackage) Cleanup() error {
+	if p.tempDir == "" {
+		return nil
+	}
+	return os.RemoveAll(p.tempDir)
 }
 
 // PackageDefinition returns a validated package definition after flavors, imports, variables, and values are applied.
-func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionOptions) (DefinedPackage, error) {
+func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionOptions) (_ DefinedPackage, retErr error) {
+	if opts.TempDir == "" {
+		opts.TempDir = config.CommonOptions.TempDirectory
+	}
+	tempDir, err := utils.MakeTempDir(opts.TempDir)
+	if err != nil {
+		return DefinedPackage{}, err
+	}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, os.RemoveAll(tempDir))
+		}
+	}()
+
 	l := logger.From(ctx)
 	start := time.Now()
 	l.Debug("start layout.LoadPackage",
@@ -84,7 +108,7 @@ func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionO
 		return DefinedPackage{}, err
 	}
 	var importedSchemas []string
-	pkg, importedSchemas, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck, opts.RemoteOptions, opts.TempDir)
+	pkg, importedSchemas, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck, opts.RemoteOptions, tempDir)
 	if err != nil {
 		return DefinedPackage{}, err
 	}
@@ -105,7 +129,7 @@ func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionO
 		return DefinedPackage{}, err
 	}
 	l.Debug("done layout.LoadPackage", "duration", time.Since(start))
-	return DefinedPackage{Pkg: pkg, ImportedSchemas: importedSchemas}, nil
+	return DefinedPackage{Pkg: pkg, ImportedSchemas: importedSchemas, tempDir: tempDir}, nil
 }
 
 func validate(ctx context.Context, pkg v1alpha1.ZarfPackage, packagePath string, setVariables map[string]string, flavor string, skipRequiredValues bool, skipSchemaValidation bool) error {

--- a/src/pkg/packager/load/load.go
+++ b/src/pkg/packager/load/load.go
@@ -37,6 +37,9 @@ type DefinitionOptions struct {
 	SkipValuesSchemaValidation bool
 	// CachePath is used to cache layers from skeleton package pulls
 	CachePath string
+	// TempDir is a caller-created workspace used to stage OCI skeleton values.
+	// The caller is responsible for removing it after consuming the definition.
+	TempDir string
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
 	// SkipVersionCheck skips version requirement validation
@@ -81,7 +84,7 @@ func PackageDefinition(ctx context.Context, packagePath string, opts DefinitionO
 		return DefinedPackage{}, err
 	}
 	var importedSchemas []string
-	pkg, importedSchemas, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck, opts.RemoteOptions)
+	pkg, importedSchemas, err = resolveImports(ctx, pkg, pkgPath.ManifestFile, pkg.Metadata.Architecture, opts.Flavor, []string{}, opts.CachePath, opts.SkipVersionCheck, opts.RemoteOptions, opts.TempDir)
 	if err != nil {
 		return DefinedPackage{}, err
 	}

--- a/src/pkg/packager/load/load_test.go
+++ b/src/pkg/packager/load/load_test.go
@@ -41,12 +41,13 @@ func TestLoadPackageWithFlavors(t *testing.T) {
 			opts := DefinitionOptions{
 				Flavor: tt.flavor,
 			}
-			_, err := PackageDefinition(context.Background(), filepath.Join("testdata", "package-with-flavors"), opts)
+			defined, err := PackageDefinition(context.Background(), filepath.Join("testdata", "package-with-flavors"), opts)
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, err, tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)
+			require.NoError(t, defined.Cleanup())
 		})
 	}
 }
@@ -146,12 +147,13 @@ func TestPackageDefinitionWithValuesSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := testutil.TestContext(t)
 			opts := DefinitionOptions{}
-			_, err := PackageDefinition(ctx, tt.packagePath, opts)
+			defined, err := PackageDefinition(ctx, tt.packagePath, opts)
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, err, tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)
+			require.NoError(t, defined.Cleanup())
 		})
 	}
 }

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -5,7 +5,9 @@ package packager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -198,7 +200,7 @@ type PublishSkeletonOptions struct {
 
 // PublishSkeleton takes a Path to the package definition and uploads a skeleton package to the given a registry.
 // dst is the path to the registry namespace, e.g. my-registry.com/my-namespace. The full package ref is created using the package name and returned
-func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, opts PublishSkeletonOptions) (registry.Reference, error) {
+func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, opts PublishSkeletonOptions) (_ registry.Reference, err error) {
 	l := logger.From(ctx)
 
 	// disallow infinite or negative
@@ -224,11 +226,19 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 	if path == "" {
 		return registry.Reference{}, fmt.Errorf("path must be specified")
 	}
+	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
+	if err != nil {
+		return registry.Reference{}, err
+	}
+	defer func() {
+		err = errors.Join(err, os.RemoveAll(tmpDir))
+	}()
 
 	// Load package layout
 	l.Info("loading skeleton package", "path", path)
 	defined, err := load.PackageDefinition(ctx, path, load.DefinitionOptions{
 		CachePath:          opts.CachePath,
+		TempDir:            tmpDir,
 		Flavor:             opts.Flavor,
 		SkipVersionCheck:   opts.SkipVersionCheck,
 		SkipRequiredValues: true,

--- a/src/pkg/packager/publish.go
+++ b/src/pkg/packager/publish.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -226,19 +225,10 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 	if path == "" {
 		return registry.Reference{}, fmt.Errorf("path must be specified")
 	}
-	tmpDir, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
-	if err != nil {
-		return registry.Reference{}, err
-	}
-	defer func() {
-		err = errors.Join(err, os.RemoveAll(tmpDir))
-	}()
-
 	// Load package layout
 	l.Info("loading skeleton package", "path", path)
 	defined, err := load.PackageDefinition(ctx, path, load.DefinitionOptions{
 		CachePath:          opts.CachePath,
-		TempDir:            tmpDir,
 		Flavor:             opts.Flavor,
 		SkipVersionCheck:   opts.SkipVersionCheck,
 		SkipRequiredValues: true,
@@ -247,6 +237,9 @@ func PublishSkeleton(ctx context.Context, path string, ref registry.Reference, o
 	if err != nil {
 		return registry.Reference{}, err
 	}
+	defer func() {
+		err = errors.Join(err, defined.Cleanup())
+	}()
 	for _, comp := range defined.Pkg.Components {
 		if comp.ImageArchives != nil {
 			return registry.Reference{}, fmt.Errorf("cannot publish skeleton package with image archives")

--- a/src/pkg/packager/skeleton_values_test.go
+++ b/src/pkg/packager/skeleton_values_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -75,8 +76,16 @@ components:
 `, skeletonRef.String(), skeletonRef.String())
 	require.NoError(t, os.WriteFile(filepath.Join(parentPath, layout.ZarfYAML), []byte(parentManifest), 0o600))
 
+	_, err = load.PackageDefinition(ctx, parentPath, load.DefinitionOptions{
+		CachePath:     cachePath,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.ErrorContains(t, err, "a temporary directory is required to stage values from imported skeleton")
+
+	tmpDir := t.TempDir()
 	defined, err := load.PackageDefinition(ctx, parentPath, load.DefinitionOptions{
 		CachePath:     cachePath,
+		TempDir:       tmpDir,
 		RemoteOptions: defaultTestRemoteOptions(),
 	})
 	require.NoError(t, err)
@@ -84,6 +93,10 @@ components:
 	require.Len(t, defined.ImportedSchemas, 1, "repeated imports must contribute schemas once")
 	require.FileExists(t, filepath.Join(parentPath, defined.Pkg.Values.Files[0]))
 	require.FileExists(t, filepath.Join(parentPath, defined.ImportedSchemas[0]))
+	stagedValuesPath := filepath.Join(parentPath, defined.Pkg.Values.Files[0])
+	relativeStagedPath, err := filepath.Rel(tmpDir, stagedValuesPath)
+	require.NoError(t, err)
+	require.False(t, strings.HasPrefix(relativeStagedPath, ".."), "values must be staged in the caller-provided workspace")
 
 	pkgLayout, err := assemble.AssemblePackage(ctx, defined.Pkg, parentPath, defined.ImportedSchemas, assemble.AssembleOptions{
 		CachePath:     cachePath,

--- a/src/pkg/packager/skeleton_values_test.go
+++ b/src/pkg/packager/skeleton_values_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -76,16 +75,8 @@ components:
 `, skeletonRef.String(), skeletonRef.String())
 	require.NoError(t, os.WriteFile(filepath.Join(parentPath, layout.ZarfYAML), []byte(parentManifest), 0o600))
 
-	_, err = load.PackageDefinition(ctx, parentPath, load.DefinitionOptions{
-		CachePath:     cachePath,
-		RemoteOptions: defaultTestRemoteOptions(),
-	})
-	require.ErrorContains(t, err, "a temporary directory is required to stage values from imported skeleton")
-
-	tmpDir := t.TempDir()
 	defined, err := load.PackageDefinition(ctx, parentPath, load.DefinitionOptions{
 		CachePath:     cachePath,
-		TempDir:       tmpDir,
 		RemoteOptions: defaultTestRemoteOptions(),
 	})
 	require.NoError(t, err)
@@ -94,9 +85,11 @@ components:
 	require.FileExists(t, filepath.Join(parentPath, defined.Pkg.Values.Files[0]))
 	require.FileExists(t, filepath.Join(parentPath, defined.ImportedSchemas[0]))
 	stagedValuesPath := filepath.Join(parentPath, defined.Pkg.Values.Files[0])
-	relativeStagedPath, err := filepath.Rel(tmpDir, stagedValuesPath)
-	require.NoError(t, err)
-	require.False(t, strings.HasPrefix(relativeStagedPath, ".."), "values must be staged in the caller-provided workspace")
+	tempDir := filepath.Dir(filepath.Dir(filepath.Dir(stagedValuesPath)))
+	defer func() {
+		require.NoError(t, defined.Cleanup())
+		require.NoDirExists(t, tempDir)
+	}()
 
 	pkgLayout, err := assemble.AssemblePackage(ctx, defined.Pkg, parentPath, defined.ImportedSchemas, assemble.AssembleOptions{
 		CachePath:     cachePath,

--- a/src/pkg/packager/skeleton_values_test.go
+++ b/src/pkg/packager/skeleton_values_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/feature"
+	"github.com/zarf-dev/zarf/src/pkg/packager/assemble"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+	"github.com/zarf-dev/zarf/src/pkg/packager/load"
+	"github.com/zarf-dev/zarf/src/test/testutil"
+)
+
+func TestMain(m *testing.M) {
+	if err := feature.Set([]feature.Feature{{Name: feature.Values, Enabled: true}}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestValuesBearingSkeletonOCIImport(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	cachePath := filepath.Join(t.TempDir(), "cache")
+	skeletonPath := filepath.Join(t.TempDir(), "skeleton")
+	require.NoError(t, os.MkdirAll(skeletonPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, "values.yaml"), []byte("shared: 1\nchild: value\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, "values.schema.json"), []byte(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"shared":{"type":"integer"},"child":{"type":"string"}}}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(skeletonPath, layout.ZarfYAML), []byte(`kind: ZarfPackageConfig
+metadata:
+  name: values-skeleton
+  version: 0.0.1
+values:
+  files:
+    - values.yaml
+  schema: values.schema.json
+components:
+  - name: first
+  - name: second
+`), 0o600))
+
+	skeletonRef, err := PublishSkeleton(ctx, skeletonPath, createRegistry(ctx, t), PublishSkeletonOptions{
+		CachePath:     cachePath,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.NoError(t, err)
+
+	parentPath := filepath.Join(t.TempDir(), "parent")
+	require.NoError(t, os.MkdirAll(parentPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, "values.yaml"), []byte("shared: parent\nparent: value\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, "values.schema.json"), []byte(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"shared":{"type":"string"},"parent":{"type":"string"}}}`), 0o600))
+	parentManifest := fmt.Sprintf(`kind: ZarfPackageConfig
+metadata:
+  name: values-parent
+  version: 0.0.1
+values:
+  files:
+    - values.yaml
+  schema: values.schema.json
+components:
+  - name: imported-first
+    import:
+      url: oci://%s
+      name: first
+  - name: imported-second
+    import:
+      url: oci://%s
+      name: second
+`, skeletonRef.String(), skeletonRef.String())
+	require.NoError(t, os.WriteFile(filepath.Join(parentPath, layout.ZarfYAML), []byte(parentManifest), 0o600))
+
+	defined, err := load.PackageDefinition(ctx, parentPath, load.DefinitionOptions{
+		CachePath:     cachePath,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.NoError(t, err)
+	require.Len(t, defined.Pkg.Values.Files, 2, "repeated imports must contribute values once")
+	require.Len(t, defined.ImportedSchemas, 1, "repeated imports must contribute schemas once")
+	require.FileExists(t, filepath.Join(parentPath, defined.Pkg.Values.Files[0]))
+	require.FileExists(t, filepath.Join(parentPath, defined.ImportedSchemas[0]))
+
+	pkgLayout, err := assemble.AssemblePackage(ctx, defined.Pkg, parentPath, defined.ImportedSchemas, assemble.AssembleOptions{
+		CachePath:     cachePath,
+		SkipSBOM:      true,
+		RemoteOptions: defaultTestRemoteOptions(),
+	})
+	require.NoError(t, err)
+	values, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ValuesYAML))
+	require.NoError(t, err)
+	require.YAMLEq(t, "shared: parent\nchild: value\nparent: value\n", string(values))
+
+	schemaBytes, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema))
+	require.NoError(t, err)
+	var schema struct {
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(schemaBytes, &schema))
+	require.Equal(t, "string", schema.Properties["shared"].Type, "parent schema must take precedence")
+	require.Equal(t, "string", schema.Properties["child"].Type)
+	require.Equal(t, "string", schema.Properties["parent"].Type)
+}

--- a/src/pkg/packager/values_preflight_test.go
+++ b/src/pkg/packager/values_preflight_test.go
@@ -355,6 +355,7 @@ func assembleLayout(t *testing.T, srcDir string) *layout.PackageLayout {
 	ctx := testutil.TestContext(t)
 	defined, err := load.PackageDefinition(ctx, srcDir, load.DefinitionOptions{})
 	require.NoError(t, err)
+	defer func() { require.NoError(t, defined.Cleanup()) }()
 	pkgLayout, err := assemble.AssemblePackage(ctx, defined.Pkg, srcDir, nil, assemble.AssembleOptions{SkipSBOM: true})
 	require.NoError(t, err)
 	return pkgLayout


### PR DESCRIPTION
## Description

Adds support for publishing skeleton packages with package values/schema and consuming them during create. Additionally reworks the imported-package remote to use a pinned the first-resolved descriptor for the remaining operation to prevent a mutable-tag drift issue.
## Related Issue

Fixes #4869

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
