### PR TITLE
fix(verify): honor configured temp dir for embedded trusted root

### DIFF
--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -398,10 +398,12 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 		return fmt.Errorf("package is signed but no verification material was provided (--key, --certificate-identity + --certificate-oidc-issuer): %w", ErrNoVerificationMaterial)
 	}
 
+	// Preserve a caller-provided staging directory while retaining Zarf's default.
+	if opts.TempDir == "" {
+		opts.TempDir = config.CommonOptions.TempDirectory
+	}
+
 	if hasBundleInfo {
-		if opts.TempDir == "" {
-			opts.TempDir = config.CommonOptions.TempDirectory
-		}
 		opts.BundlePath = bundlePath
 		// Auto-enable UseSignedTimestamps when the bundle contains timestamps.
 		// The bundle was signed with a TSA; using those timestamps is required to
@@ -436,9 +438,6 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 
 	// Legacy signature found
 	l.Warn("bundle format signature not found: legacy signature is being deprecated.")
-	if opts.TempDir == "" {
-		opts.TempDir = config.CommonOptions.TempDirectory
-	}
 	opts.Signature = signaturePath
 
 	opts.CommonVerifyOptions.NewBundleFormat = false

--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -399,7 +399,9 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 	}
 
 	if hasBundleInfo {
-		opts.TempDir = config.CommonOptions.TempDirectory
+		if opts.TempDir == "" {
+			opts.TempDir = config.CommonOptions.TempDirectory
+		}
 		opts.BundlePath = bundlePath
 		// Auto-enable UseSignedTimestamps when the bundle contains timestamps.
 		// The bundle was signed with a TSA; using those timestamps is required to
@@ -434,7 +436,9 @@ func (p *PackageLayout) VerifyPackageSignature(ctx context.Context, opts signing
 
 	// Legacy signature found
 	l.Warn("bundle format signature not found: legacy signature is being deprecated.")
-	opts.TempDir = config.CommonOptions.TempDirectory
+	if opts.TempDir == "" {
+		opts.TempDir = config.CommonOptions.TempDirectory
+	}
 	opts.Signature = signaturePath
 
 	opts.CommonVerifyOptions.NewBundleFormat = false


### PR DESCRIPTION
## Description

Ensures that the configured verify temp dir is honored when writing the embedded trusted root for keyless verification.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
