### PR TITLE
feat: add option to skip values schema validation

### DIFF
--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -88,6 +88,7 @@ $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-
       --registry-url string                     External registry url address to use for this Zarf cluster
       --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --skip-values-schema-validation           Skip validation of package values against the values schema.
       --storage-class string                    Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard
       --take-ownership                          Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)

--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -57,6 +57,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
       --set-values stringToString               Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
       --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
       --shasum string                           Shasum of the package to deploy. Required if deploying a remote https package.
+      --skip-values-schema-validation           Skip validation of package values against the values schema.
       --take-ownership                          Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -41,6 +41,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --set-values stringToString               Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
       --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --skip-values-schema-validation           Skip validation of package values against the values schema.
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -45,6 +45,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
       --oci-concurrency int                     Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --set-values stringToString               Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
       --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
+      --skip-values-schema-validation           Skip validation of package values against the values schema.
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
   -v, --values strings                          [alpha] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -37,23 +37,24 @@ import (
 )
 
 type initOptions struct {
-	setVariables        map[string]string
-	optionalComponents  string
-	storageClass        string
-	gitServer           state.GitServerInfo
-	registryInfo        state.RegistryInfo
-	artifactServer      state.ArtifactServerInfo
-	injectorPort        int
-	takeOwnership       bool
-	forceConflicts      bool
-	timeout             time.Duration
-	retries             int
-	confirm             bool
-	ociConcurrency      int
-	agentTLSCAPath      string
-	agentTLSCertPath    string
-	agentTLSKeyPath     string
-	agentMutationPolicy string
+	setVariables               map[string]string
+	optionalComponents         string
+	skipValuesSchemaValidation bool
+	storageClass               string
+	gitServer                  state.GitServerInfo
+	registryInfo               state.RegistryInfo
+	artifactServer             state.ArtifactServerInfo
+	injectorPort               int
+	takeOwnership              bool
+	forceConflicts             bool
+	timeout                    time.Duration
+	retries                    int
+	confirm                    bool
+	ociConcurrency             int
+	agentTLSCAPath             string
+	agentTLSCertPath           string
+	agentTLSKeyPath            string
+	agentMutationPolicy        string
 	packageVerifyFlags
 }
 
@@ -127,6 +128,7 @@ func newInitCommand() *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("adopt-existing-resources", "use --take-ownership instead")
 	cmd.Flags().BoolVar(&o.forceConflicts, "force-conflicts", false, lang.CmdPackageDeployFlagForceConflicts)
 	cmd.Flags().DurationVar(&o.timeout, "timeout", v.GetDuration(VPkgDeployTimeout), lang.CmdPackageDeployFlagTimeout)
+	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(VPkgRetries), lang.CmdPackageFlagRetries)
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
@@ -223,21 +225,22 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}()
 
 	opts := packager.DeployOptions{
-		GitServer:           o.gitServer,
-		RegistryInfo:        o.registryInfo,
-		ArtifactServer:      o.artifactServer,
-		TakeOwnership:       o.takeOwnership,
-		ForceConflicts:      o.forceConflicts,
-		Timeout:             o.timeout,
-		Retries:             o.retries,
-		OCIConcurrency:      o.ociConcurrency,
-		SetVariables:        o.setVariables,
-		StorageClass:        o.storageClass,
-		InjectorPort:        o.injectorPort,
-		RemoteOptions:       defaultRemoteOptions(),
-		IsInteractive:       !o.confirm,
-		AgentTLS:            agentTLS,
-		AgentMutationPolicy: state.MutationPolicy(o.agentMutationPolicy),
+		GitServer:                  o.gitServer,
+		RegistryInfo:               o.registryInfo,
+		ArtifactServer:             o.artifactServer,
+		TakeOwnership:              o.takeOwnership,
+		ForceConflicts:             o.forceConflicts,
+		Timeout:                    o.timeout,
+		Retries:                    o.retries,
+		OCIConcurrency:             o.ociConcurrency,
+		SetVariables:               o.setVariables,
+		StorageClass:               o.storageClass,
+		InjectorPort:               o.injectorPort,
+		RemoteOptions:              defaultRemoteOptions(),
+		IsInteractive:              !o.confirm,
+		AgentTLS:                   agentTLS,
+		AgentMutationPolicy:        state.MutationPolicy(o.agentMutationPolicy),
+		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
 	}
 	_, err = deploy(ctx, pkgLayout, opts, o.setVariables, o.optionalComponents)
 	if err != nil {

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -278,20 +278,21 @@ func (o *packageCreateOptions) run(ctx context.Context, args []string) error {
 }
 
 type packageDeployOptions struct {
-	valuesFiles        []string
-	namespaceOverride  string
-	confirm            bool
-	takeOwnership      bool
-	connected          bool
-	forceConflicts     bool
-	timeout            time.Duration
-	retries            int
-	setVariables       map[string]string
-	setValues          map[string]string
-	optionalComponents string
-	shasum             string
-	skipVersionCheck   bool
-	ociConcurrency     int
+	valuesFiles                []string
+	namespaceOverride          string
+	confirm                    bool
+	takeOwnership              bool
+	connected                  bool
+	forceConflicts             bool
+	timeout                    time.Duration
+	retries                    int
+	setVariables               map[string]string
+	setValues                  map[string]string
+	optionalComponents         string
+	shasum                     string
+	skipValuesSchemaValidation bool
+	skipVersionCheck           bool
+	ociConcurrency             int
 	packageVerifyFlags
 }
 
@@ -330,6 +331,7 @@ func newPackageDeployCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringVar(&o.optionalComponents, "components", v.GetString(VPkgDeployComponents), lang.CmdPackageDeployFlagComponents)
 	cmd.Flags().StringVar(&o.shasum, "shasum", v.GetString(VPkgDeployShasum), lang.CmdPackageDeployFlagShasum)
 	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", v.GetString(VPkgDeployNamespace), lang.CmdPackageDeployFlagNamespace)
+	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when deploying the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
@@ -392,18 +394,19 @@ func (o *packageDeployOptions) run(cmd *cobra.Command, args []string) (err error
 	}()
 
 	deployOpts := packager.DeployOptions{
-		Values:            values,
-		TakeOwnership:     o.takeOwnership,
-		Connected:         o.connected,
-		ForceConflicts:    o.forceConflicts,
-		Timeout:           o.timeout,
-		Retries:           o.retries,
-		OCIConcurrency:    o.ociConcurrency,
-		SetVariables:      o.setVariables,
-		NamespaceOverride: o.namespaceOverride,
-		RemoteOptions:     defaultRemoteOptions(),
-		IsInteractive:     !o.confirm,
-		SkipVersionCheck:  o.skipVersionCheck,
+		Values:                     values,
+		TakeOwnership:              o.takeOwnership,
+		Connected:                  o.connected,
+		ForceConflicts:             o.forceConflicts,
+		Timeout:                    o.timeout,
+		Retries:                    o.retries,
+		OCIConcurrency:             o.ociConcurrency,
+		SetVariables:               o.setVariables,
+		NamespaceOverride:          o.namespaceOverride,
+		RemoteOptions:              defaultRemoteOptions(),
+		IsInteractive:              !o.confirm,
+		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
+		SkipVersionCheck:           o.skipVersionCheck,
 	}
 
 	deployedComponents, err := deploy(ctx, pkgLayout, deployOpts, o.setVariables, o.optionalComponents)
@@ -788,13 +791,14 @@ func (o *packageInspectDigestOptions) run(ctx context.Context, args []string) er
 }
 
 type packageInspectValuesFilesOptions struct {
-	components     string
-	kubeVersion    string
-	setVariables   map[string]string
-	valuesFiles    []string
-	setValues      map[string]string
-	outputWriter   io.Writer
-	ociConcurrency int
+	components                 string
+	kubeVersion                string
+	setVariables               map[string]string
+	valuesFiles                []string
+	setValues                  map[string]string
+	skipValuesSchemaValidation bool
+	outputWriter               io.Writer
+	ociConcurrency             int
 	packageVerifyFlags
 }
 
@@ -826,6 +830,7 @@ func newPackageInspectValuesFilesCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
+	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
@@ -871,11 +876,12 @@ func (o *packageInspectValuesFilesOptions) run(cmd *cobra.Command, args []string
 	}()
 
 	resourceOpts := packager.InspectPackageResourcesOptions{
-		SetVariables:  o.setVariables,
-		Values:        values,
-		KubeVersion:   o.kubeVersion,
-		IsInteractive: true,
-		RemoteOptions: defaultRemoteOptions(),
+		SetVariables:               o.setVariables,
+		Values:                     values,
+		KubeVersion:                o.kubeVersion,
+		IsInteractive:              true,
+		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
+		RemoteOptions:              defaultRemoteOptions(),
 	}
 	resources, err := packager.InspectPackageResources(ctx, pkgLayout, resourceOpts)
 	if err != nil {
@@ -895,13 +901,14 @@ func (o *packageInspectValuesFilesOptions) run(cmd *cobra.Command, args []string
 }
 
 type packageInspectManifestsOptions struct {
-	components     string
-	kubeVersion    string
-	setVariables   map[string]string
-	valuesFiles    []string
-	setValues      map[string]string
-	outputWriter   io.Writer
-	ociConcurrency int
+	components                 string
+	kubeVersion                string
+	setVariables               map[string]string
+	valuesFiles                []string
+	setValues                  map[string]string
+	skipValuesSchemaValidation bool
+	outputWriter               io.Writer
+	ociConcurrency             int
 	packageVerifyFlags
 }
 
@@ -932,6 +939,7 @@ func newPackageInspectManifestsCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
 	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
 	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
+	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
 	return cmd
 }
@@ -977,11 +985,12 @@ func (o *packageInspectManifestsOptions) run(cmd *cobra.Command, args []string) 
 	}()
 
 	resourceOpts := packager.InspectPackageResourcesOptions{
-		SetVariables:  o.setVariables,
-		Values:        values,
-		KubeVersion:   o.kubeVersion,
-		IsInteractive: true,
-		RemoteOptions: defaultRemoteOptions(),
+		SetVariables:               o.setVariables,
+		Values:                     values,
+		KubeVersion:                o.kubeVersion,
+		IsInteractive:              true,
+		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
+		RemoteOptions:              defaultRemoteOptions(),
 	}
 
 	resources, err := packager.InspectPackageResources(ctx, pkgLayout, resourceOpts)

--- a/src/cmd/package_test.go
+++ b/src/cmd/package_test.go
@@ -132,30 +132,6 @@ func TestPackageList(t *testing.T) {
 	}
 }
 
-func TestSkipValuesSchemaValidationFlags(t *testing.T) {
-	t.Parallel()
-	v := viper.New()
-
-	commands := []*cobra.Command{
-		newPackageDeployCommand(v),
-		newPackageInspectManifestsCommand(v),
-		newPackageInspectValuesFilesCommand(v),
-		newInitCommand(),
-	}
-	for _, cmd := range commands {
-		flag := cmd.Flags().Lookup("skip-values-schema-validation")
-		require.NotNil(t, flag, cmd.Use)
-		require.Equal(t, "false", flag.DefValue, cmd.Use)
-	}
-
-	for _, cmd := range []*cobra.Command{
-		newDevInspectManifestsCommand(v),
-		newDevInspectValuesFilesCommand(v),
-	} {
-		require.Nil(t, cmd.Flags().Lookup("skip-values-schema-validation"), cmd.Use)
-	}
-}
-
 func TestPackageInspectManifests(t *testing.T) {
 	t.Parallel()
 	// Some sub-cases exercise package-level values, which are gated behind the values feature.

--- a/src/cmd/package_test.go
+++ b/src/cmd/package_test.go
@@ -132,6 +132,30 @@ func TestPackageList(t *testing.T) {
 	}
 }
 
+func TestSkipValuesSchemaValidationFlags(t *testing.T) {
+	t.Parallel()
+	v := viper.New()
+
+	commands := []*cobra.Command{
+		newPackageDeployCommand(v),
+		newPackageInspectManifestsCommand(v),
+		newPackageInspectValuesFilesCommand(v),
+		newInitCommand(),
+	}
+	for _, cmd := range commands {
+		flag := cmd.Flags().Lookup("skip-values-schema-validation")
+		require.NotNil(t, flag, cmd.Use)
+		require.Equal(t, "false", flag.DefValue, cmd.Use)
+	}
+
+	for _, cmd := range []*cobra.Command{
+		newDevInspectManifestsCommand(v),
+		newDevInspectValuesFilesCommand(v),
+	} {
+		require.Nil(t, cmd.Flags().Lookup("skip-values-schema-validation"), cmd.Use)
+	}
+}
+
 func TestPackageInspectManifests(t *testing.T) {
 	t.Parallel()
 	// Some sub-cases exercise package-level values, which are gated behind the values feature.

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -320,6 +320,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
 	CmdPackageDeployInvalidCLIVersionWarn      = "CLIVersion is set to '%s' which can cause issues with package creation and deployment. To avoid such issues, please set the value to the valid semantic version for this version of Zarf."
 	CmdPackageDeployFlagNamespace              = "[Alpha] Override the namespace for package deployment. Requires the package to have only one distinct namespace defined."
 	CmdPackageDeployFlagValuesFiles            = CmdPackageCreateFlagValuesFiles
+	CmdPackageDeployFlagSkipValuesSchema       = "Skip validation of package values against the values schema."
 
 	CmdPackageMirrorFlagComponents = "Comma-separated list of components to mirror.  This list will be respected regardless of a component's 'required' or 'default' status.  Globbing component names with '*' and deselecting components with a leading '-' are also supported."
 	CmdPackageMirrorFlagNoChecksum = "Turns off the addition of a checksum to image tags (as would be used by the Zarf Agent) while mirroring images."

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -85,6 +85,8 @@ type DeployOptions struct {
 	ValuesOverridesMap ValuesOverrides
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
+	// SkipValuesSchemaValidation skips validation of the merged package values against the package schema.
+	SkipValuesSchemaValidation bool
 	// SkipVersionCheck skips version requirement validation
 	SkipVersionCheck bool
 }
@@ -174,7 +176,7 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 	vals.DeepMerge(opts.Values)
 
 	// Validate merged values against schema if provided
-	if pkgLayout.HasValuesSchema() {
+	if pkgLayout.HasValuesSchema() && !opts.SkipValuesSchemaValidation {
 		schemaPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema)
 		if err := vals.Validate(ctx, schemaPath, value.ValidateOptions{}); err != nil {
 			return DeployResult{}, fmt.Errorf("values validation failed: %w", err)

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -5,14 +5,17 @@ package packager
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/internal/healthchecks"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/packager/assemble"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/state"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -114,5 +117,27 @@ func TestVerifyPackageIsDeployableSkipsAgentCertCheckWhenAgentIsNotConfigured(t 
 
 	d := deployer{c: c}
 	err = d.verifyPackageIsDeployable(ctx, &layout.PackageLayout{})
+	require.NoError(t, err)
+}
+
+func TestDeploySkipsValuesSchemaValidationWhenConfigured(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	srcDir := filepath.Join("load", "testdata", "package-with-invalid-values")
+	pkg := v1alpha1.ZarfPackage{
+		Kind:     v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{Name: "invalid-values"},
+		Values: v1alpha1.ZarfValues{
+			Files:  []string{"values/values.yaml"},
+			Schema: "values.schema.json",
+		},
+	}
+	pkgLayout, err := assemble.AssemblePackage(ctx, pkg, srcDir, nil, assemble.AssembleOptions{SkipSBOM: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pkgLayout.Cleanup()) })
+
+	_, err = Deploy(ctx, pkgLayout, DeployOptions{})
+	require.ErrorContains(t, err, "values validation failed")
+
+	_, err = Deploy(ctx, pkgLayout, DeployOptions{SkipValuesSchemaValidation: true})
 	require.NoError(t, err)
 }

--- a/src/pkg/packager/inspect.go
+++ b/src/pkg/packager/inspect.go
@@ -51,6 +51,8 @@ type InspectPackageResourcesOptions struct {
 	// Values merge on top of the package's values.yaml and feed chart overrides and manifest Go-templates.
 	Values      value.Values
 	KubeVersion string
+	// SkipValuesSchemaValidation skips validation of the merged package values against the package schema.
+	SkipValuesSchemaValidation bool
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
 	IsInteractive bool
 	types.RemoteOptions
@@ -80,7 +82,7 @@ func InspectPackageResources(ctx context.Context, pkgLayout *layout.PackageLayou
 	}
 	vals.DeepMerge(opts.Values)
 
-	if pkgLayout.HasValuesSchema() {
+	if pkgLayout.HasValuesSchema() && !opts.SkipValuesSchemaValidation {
 		schemaPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema)
 		if err := vals.Validate(ctx, schemaPath, value.ValidateOptions{SkipRequired: true}); err != nil {
 			return nil, fmt.Errorf("inspect values validation failed: %w", err)

--- a/src/pkg/packager/inspect_test.go
+++ b/src/pkg/packager/inspect_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/feature"
+	"github.com/zarf-dev/zarf/src/pkg/packager/assemble"
 	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
@@ -35,6 +37,31 @@ func assertContainsAll(t *testing.T, resources []Resource, expectedContent []str
 	for _, expected := range expectedContent {
 		require.Contains(t, allContent, expected)
 	}
+}
+
+func TestInspectPackageResourcesSkipsValuesSchemaValidationWhenConfigured(t *testing.T) {
+	setupInspectTests(t)
+	ctx := testutil.TestContext(t)
+	srcDir := filepath.Join("load", "testdata", "package-with-invalid-values")
+	pkg := v1alpha1.ZarfPackage{
+		Kind:     v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{Name: "invalid-values"},
+		Values: v1alpha1.ZarfValues{
+			Files:  []string{"values/values.yaml"},
+			Schema: "values.schema.json",
+		},
+	}
+	pkgLayout, err := assemble.AssemblePackage(ctx, pkg, srcDir, nil, assemble.AssembleOptions{SkipSBOM: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pkgLayout.Cleanup()) })
+
+	_, err = InspectPackageResources(ctx, pkgLayout, InspectPackageResourcesOptions{})
+	require.ErrorContains(t, err, "inspect values validation failed")
+
+	_, err = InspectPackageResources(ctx, pkgLayout, InspectPackageResourcesOptions{
+		SkipValuesSchemaValidation: true,
+	})
+	require.NoError(t, err)
 }
 
 func TestInspectDefinitionResources(t *testing.T) {


### PR DESCRIPTION
## Description

Adds a option (library and CLI flag) `SkipValuesSchemaValidation`/`--skip-values-schema-validation` that bypasses values schema validation for deploy, init, and relevant inspect commands.

This is helpful for:
- library consumers that perform schema validation separately before the deployment
- temporary situations where schemas of packages are incorrect or a user needs more time to conform to schema changes (and knowingly accepts skipping)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
