### PR TITLE
chore: upgrade cosign to v3.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,8 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/pterm/pterm v0.12.83
 	github.com/sergi/go-diff v1.4.0
-	github.com/sigstore/cosign/v3 v3.1.2
-	github.com/sigstore/sigstore-go v1.2.1
+	github.com/sigstore/cosign/v3 v3.1.3
+	github.com/sigstore/sigstore-go v1.2.2
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.8

--- a/go.sum
+++ b/go.sum
@@ -1551,8 +1551,8 @@ github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sigstore/cosign/v3 v3.1.2 h1:AlWkztipzFHLGfLECkUwcC2a2EbpzKOsElge1vcRNcs=
-github.com/sigstore/cosign/v3 v3.1.2/go.mod h1:BuXM5YXK96YuSih+9h1aMDgwdJDaZO9/8ZaPo/mUcr4=
+github.com/sigstore/cosign/v3 v3.1.3 h1:001JQRI/PJ/5T+g/kJ1KTvKFbb322+fomc+pHDZ/6sg=
+github.com/sigstore/cosign/v3 v3.1.3/go.mod h1:DmjtYkWDMdbG26X+QSOPB6QQGkLjRjQCIxxNs6wV6bA=
 github.com/sigstore/protobuf-specs v0.5.1 h1:/5OPaNuolRJmQfeZLayJGFXMpsRJEdgC6ah1/+7Px7U=
 github.com/sigstore/protobuf-specs v0.5.1/go.mod h1:DRBzpFuE+LnvQMN10/dU6nBeKwVLGEQ6o2FovN2Rats=
 github.com/sigstore/rekor v1.5.3 h1:0Tyolw3zreRgm7PUW8dccFLXGBThi08278jI8EXNSr4=
@@ -1561,8 +1561,8 @@ github.com/sigstore/rekor-tiles/v2 v2.3.0 h1:HhMgH61UP0t899V8Fjt7pz1YdgOBptbaQdn
 github.com/sigstore/rekor-tiles/v2 v2.3.0/go.mod h1:DEFiKSyQ4nF75QRVNdOPaIH3cmvMkO2B6xDZjNYngPc=
 github.com/sigstore/sigstore v1.10.8 h1:1Mgkxvkw4AXMfIP1DOjc6kw0GkUgA8pGVpveN/EfOq4=
 github.com/sigstore/sigstore v1.10.8/go.mod h1:f9+B/4iaYimvUkySyb2mvc73n3RLqNn24grHZM/ET8M=
-github.com/sigstore/sigstore-go v1.2.1 h1:YWP/rDbBaEBvtbkj6xtwsSj38ZCFEhTVVadNOXjVe3A=
-github.com/sigstore/sigstore-go v1.2.1/go.mod h1:I8BqVwAb/SaQJ5pBu5IDFY+ksq8O/1/kCag8XUgrsko=
+github.com/sigstore/sigstore-go v1.2.2 h1:xAJ8hxaoecC0HKBYVbrwUjkeAI+GJYu6vLqbxDlD2Q0=
+github.com/sigstore/sigstore-go v1.2.2/go.mod h1:MIFwBxAHJD+/lKgZzt9n/4Zhq/3T2+EuGX8iGrIsZgU=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8 h1:tofVQ+UWJgad/69I5zbqxdFCN5gpIn9tRQP7iBzIpBw=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8/go.mod h1:73AfJE8H6w5KGCFPBu4x/OG+i1Yxgmh0L/FtV7prd88=
 github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8 h1:8Mt7J36GcUEmbiJaiFhz2tud5ZIgkfVVCe2H/WJCHmw=

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/attest.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/attest.go
@@ -107,6 +107,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.TSAServerName, "timestamp-server-name", "",
 		"SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server")
+	_ = cmd.RegisterFlagCompletionFunc("timestamp-server-name", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
 		"url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr")

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/certificate.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/certificate.go
@@ -51,33 +51,43 @@ func (o *CertVerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.CertIdentity, "certificate-identity", "",
 		"The identity expected in a valid Fulcio certificate. Valid values include email address, DNS names, IP addresses, and URIs. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-identity", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertIdentityRegexp, "certificate-identity-regexp", "",
 		"A regular expression alternative to --certificate-identity. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-identity-regexp", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertOidcIssuer, "certificate-oidc-issuer", "",
 		"The OIDC issuer expected in a valid Fulcio certificate, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-oidc-issuer", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertOidcIssuerRegexp, "certificate-oidc-issuer-regexp", "",
 		"A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-oidc-issuer-regexp", cobra.NoFileCompletions)
 
 	// -- Cert extensions begin --
 	// Source: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
 	cmd.Flags().StringVar(&o.CertGithubWorkflowTrigger, "certificate-github-workflow-trigger", "",
 		"contains the event_name claim from the GitHub OIDC Identity token that contains the name of the event that triggered the workflow run")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-trigger", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowSha, "certificate-github-workflow-sha", "",
 		"contains the sha claim from the GitHub OIDC Identity token that contains the commit SHA that the workflow run was based upon.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-sha", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowName, "certificate-github-workflow-name", "",
 		"contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-name", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowRepository, "certificate-github-workflow-repository", "",
 		"contains the repository claim from the GitHub OIDC Identity token that contains the repository that the workflow run was based upon")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-repository", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowRef, "certificate-github-workflow-ref", "",
 		"contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-ref", cobra.NoFileCompletions)
 	// -- Cert extensions end --
+
 	cmd.Flags().StringVar(&o.CAIntermediates, "ca-intermediates", "",
 		"path to a file of intermediate CA certificates in PEM format which will be needed "+
 			"when building the certificate chains for the signing certificate. "+

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/copy.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/copy.go
@@ -45,4 +45,5 @@ func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Platform, "platform", "",
 		"only copy container image and its signatures for a specific platform image")
+	_ = cmd.RegisterFlagCompletionFunc("platform", cobra.NoFileCompletions)
 }

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/registry.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/registry.go
@@ -71,12 +71,15 @@ func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.AuthConfig.Username, "registry-username", "",
 		"registry basic auth username")
+	_ = cmd.RegisterFlagCompletionFunc("registry-username", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.AuthConfig.Password, "registry-password", "",
 		"registry basic auth password")
+	_ = cmd.RegisterFlagCompletionFunc("registry-password", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.AuthConfig.RegistryToken, "registry-token", "",
 		"registry bearer auth token")
+	_ = cmd.RegisterFlagCompletionFunc("registry-token", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.RegistryCACert, "registry-cacert", "",
 		"path to the X.509 CA certificate file in PEM format to be used for the connection to the registry")
@@ -92,6 +95,7 @@ func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RegistryServerName, "registry-server-name", "",
 		"SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry")
+	_ = cmd.RegisterFlagCompletionFunc("registry-server-name", cobra.NoFileCompletions)
 
 	o.RefOpts.AddFlags(cmd)
 }

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/root.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/root.go
@@ -51,6 +51,7 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().DurationVarP(&o.Timeout, "timeout", "t", DefaultTimeout,
 		"timeout for commands")
+	_ = cmd.RegisterFlagCompletionFunc("timeout", cobra.NoFileCompletions)
 }
 
 func BindViper(cmd *cobra.Command, args []string) {

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/verify.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/options/verify.go
@@ -35,6 +35,7 @@ type CommonVerifyOptions struct {
 	UseSignedTimestamps   bool
 	NewBundleFormat       bool
 	TrustedRootPath       string
+	AllowCertificateChain bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -74,6 +75,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"expect the signature/attestation to be packaged in a Sigstore bundle")
 	_ = cmd.Flags().MarkDeprecated("new-bundle-format", "this will be the only supported format in future versions")
+
+	cmd.Flags().BoolVar(&o.AllowCertificateChain, "allow-certificate-chain", false,
+		"allow X.509 certificate chains in bundle verification material for v0.3+ bundles")
 }
 
 var verifyOutputTypes = []string{"json", "text"} // First one is the default

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/sign.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/sign.go
@@ -208,7 +208,7 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		}
 	}
 
-	bundleBytes, _, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
+	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
 	if err != nil {
 		return err
 	}
@@ -266,7 +266,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		}
 	}
 
-	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)
+	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)
 	if err != nil {
 		return fmt.Errorf("getting keypair and token: %w", err)
 	}
@@ -304,7 +304,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			Data: payload,
 		}
 
-		bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, cbundleOpts)
+		bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, ko.SigningConfig, ko.TrustedMaterial, cbundleOpts)
 		if err != nil {
 			return fmt.Errorf("signing bundle: %w", err)
 		}
@@ -467,8 +467,6 @@ func fetchLocalSignedPayload(sig oci.Signature) (*cosign.LocalSignedPayload, err
 	}
 	if sigCert != nil {
 		signedPayload.Cert = base64.StdEncoding.EncodeToString(sigCert.Raw)
-	} else {
-		signedPayload.Cert = ""
 	}
 
 	signedPayload.Bundle, err = sig.Bundle()

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/sign_blob.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/sign_blob.go
@@ -82,7 +82,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		ko.DefaultLoadOptions = &[]signature.LoadOption{}
 	}
 
-	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
+	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting keypair and token: %w", err)
 	}
@@ -123,7 +123,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		}
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
-	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
+	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}
@@ -147,11 +147,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if ko.BundlePath != "" {
-		pubKeyPem, err := keypair.GetPublicKeyPem()
-		if err != nil {
-			return nil, fmt.Errorf("getting public key pem: %w", err)
-		}
-		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents)
 		if err != nil {
 			return nil, fmt.Errorf("creating legacy bundle: %w", err)
 		}

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon/common.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon/common.go
@@ -75,24 +75,24 @@ func (c *SignerVerifier) Close() {
 // For an ephemeral key, it also uses the key to fetch an OIDC token, the pair of which are later used to get a Fulcio cert.
 //
 // Ensure the returned SignerVerifier is closed via calling SignerVerifier.Close.
-func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, []byte, string, error) {
+func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, []byte, []byte, string, error) {
 	var keypair sign.Keypair
 	var ephemeralKeypair bool
 	var idToken string
 	var sv *SignerVerifier
-	var certBytes []byte
 	var err error
 
 	sv, ephemeralKeypair, err = signerFromKeyOpts(ctx, cert, certChain, ko)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("getting signer: %w", err)
+		return nil, nil, nil, "", fmt.Errorf("getting signer: %w", err)
 	}
 	keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
 	if err != nil {
 		sv.Close()
-		return nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
+		return nil, nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
 	}
-	certBytes = sv.Cert
+	certBytes := sv.Cert
+	chainBytes := sv.Chain
 
 	if ephemeralKeypair || ko.IssueCertificateForExistingKey {
 		idToken, err = auth.RetrieveIDToken(ctx, auth.IDTokenConfig{
@@ -108,11 +108,11 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 		})
 		if err != nil {
 			sv.Close()
-			return nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
+			return nil, nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
 		}
 	}
 
-	return keypair, certBytes, idToken, nil
+	return keypair, certBytes, chainBytes, idToken, nil
 }
 
 // ShouldUploadToTlog determines whether the user wants to upload the entry to Rekor.
@@ -362,10 +362,10 @@ type CommonBundleOpts struct {
 }
 
 // NewAttestationBundle uses signing config and trusted root to sign an attestation and create a bundle.
-func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, string, pb_go_v1.HashAlgorithm, error) {
-	keypair, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
+func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, pb_go_v1.HashAlgorithm, error) {
+	keypair, certBytes, chainBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
 	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
+		return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
 	}
 	if closer, ok := keypair.(interface{ Close() }); ok {
 		defer closer.Close()
@@ -380,22 +380,17 @@ func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certCha
 	if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
 		tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
 		if err != nil {
-			return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
+			return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
 
-	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, signingConfig, trustedMaterial, signOpts)
+	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, signingConfig, trustedMaterial, signOpts)
 	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
+		return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
 	}
 
-	pubKeyPem, err := keypair.GetPublicKeyPem()
-	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting public key pem: %w", err)
-	}
-
-	return bundle, keypair.GetPublicKey(), pubKeyPem, keypair.GetHashAlgorithm(), nil
+	return bundle, keypair.GetPublicKey(), keypair.GetHashAlgorithm(), nil
 }
 
 type BundleComponents struct {
@@ -586,7 +581,7 @@ func RekorBundleFromProtoTlogEntry(entry *protorekor.TransparencyLogEntry) *cbun
 }
 
 // NewLegacyBundleFromProtoBundleComponents creates a legacy bundle from a protobuf bundle.
-func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents, pubKeyPem string) ([]byte, error) {
+func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents) ([]byte, error) {
 	signedPayload := cosign.LocalSignedPayload{
 		Base64Signature: base64.StdEncoding.EncodeToString(bc.Signature),
 	}
@@ -594,8 +589,6 @@ func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents, pubKeyPem st
 	if len(bc.Certificates) > 0 {
 		certPem, _ := EncodeCertificatesToPEM(bc.Certificates)
 		signedPayload.Cert = base64.StdEncoding.EncodeToString(certPem)
-	} else if pubKeyPem != "" {
-		signedPayload.Cert = base64.StdEncoding.EncodeToString([]byte(pubKeyPem))
 	}
 
 	if len(bc.RekorEntries) > 0 {

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify.go
@@ -32,9 +32,11 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/attestation"
 	"github.com/sigstore/cosign/v3/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	"github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
@@ -76,6 +78,7 @@ type VerifyCommand struct {
 	MaxWorkers                   int
 	ExperimentalOCI11            bool
 	NewBundleFormat              bool
+	AllowCertificateChain        bool
 }
 
 // Exec runs the verification command
@@ -118,6 +121,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	if c.AllowHTTPRegistry || c.AllowInsecure {
 		c.NameOptions = append(c.NameOptions, name.Insecure)
 	}
+	if c.AllowCertificateChain {
+		ociremoteOpts = append(ociremoteOpts, ociremote.WithBundleOptions(sgbundle.AllowCertificateChain()))
+	}
 
 	co := &cosign.CheckOpts{
 		Annotations:                  c.Annotations.Annotations,
@@ -137,6 +143,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		ExperimentalOCI11:            c.ExperimentalOCI11,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_attestation.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_attestation.go
@@ -32,7 +32,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/cue"
 	"github.com/sigstore/cosign/v3/pkg/cosign/rego"
 	"github.com/sigstore/cosign/v3/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/policy"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
 // VerifyAttestationCommand verifies a signature on a supplied container image
@@ -106,6 +108,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	if c.AllowHTTPRegistry || c.AllowInsecure {
 		c.NameOptions = append(c.NameOptions, name.Insecure)
 	}
+	if c.AllowCertificateChain {
+		ociremoteOpts = append(ociremoteOpts, ociremote.WithBundleOptions(sgbundle.AllowCertificateChain()))
+	}
 
 	co := &cosign.CheckOpts{
 		RegistryClientOpts:           ociremoteOpts,
@@ -121,6 +126,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		MaxWorkers:                   c.MaxWorkers,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_blob.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_blob.go
@@ -37,7 +37,6 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
-	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sgverify "github.com/sigstore/sigstore-go/pkg/verify"
 
@@ -70,6 +69,7 @@ type VerifyBlobCmd struct {
 	UseSignedTimestamps          bool
 	IgnoreTlog                   bool
 	HashAlgorithm                crypto.Hash
+	AllowCertificateChain        bool
 }
 
 // nolint
@@ -114,8 +114,9 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		Offline:                      c.Offline,
 		IgnoreTlog:                   c.IgnoreTlog,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
-		NewBundleFormat:              c.KeyOpts.NewBundleFormat && checkNewBundle(c.BundlePath),
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
+	co.NewBundleFormat = c.KeyOpts.NewBundleFormat && checkNewBundle(c.BundlePath, co.BundleOptions()...)
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
 	// User provides a key or certificate. Otherwise, verification requires a Fulcio certificate
@@ -138,7 +139,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	}
 
 	if co.NewBundleFormat {
-		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath)
+		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath, co.BundleOptions()...)
 		if err != nil {
 			return err
 		}
@@ -189,26 +190,14 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		if err != nil {
 			return err
 		}
-		// A certificate is required in the bundle unless we specified with
-		//  --key, --sk, or --certificate.
-		if b.Cert == "" && co.SigVerifier == nil && cert == nil {
-			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
-		}
-		// We have to condition on this because sign-blob may not output the signing
-		// key to the bundle when there is no tlog upload.
 		if b.Cert != "" {
-			// b.Cert can either be a certificate or public key
 			certBytes := []byte(b.Cert)
 			if isb64(certBytes) {
 				certBytes, _ = base64.StdEncoding.DecodeString(b.Cert)
 			}
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
-				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
-				if err != nil {
-					return fmt.Errorf("loading verifier from bundle: %w", err)
-				}
+				return fmt.Errorf("loading verifier certificate from bundle: %w", err)
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
 			if cert != nil && !cert.Equal(bundleCert) {
@@ -216,6 +205,12 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			}
 			cert = bundleCert
 		}
+		// A verifier must come either from a certificate from the bundle,
+		// or provided via --key, --sk, or --certificate.
+		if co.SigVerifier == nil && cert == nil {
+			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
+		}
+
 		opts = append(opts, static.WithBundle(b.Bundle))
 	}
 	if c.RFC3161TimestampPath != "" {

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -38,7 +38,6 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	"github.com/sigstore/cosign/v3/pkg/policy"
-	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sgverify "github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -77,6 +76,8 @@ type VerifyBlobAttestationCommand struct {
 	Digest        string
 	DigestAlg     string
 	HashAlgorithm crypto.Hash
+
+	AllowCertificateChain bool
 }
 
 // Exec runs the verification command
@@ -124,8 +125,9 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		Offline:                      c.Offline,
 		IgnoreTlog:                   c.IgnoreTlog,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
-		NewBundleFormat:              c.NewBundleFormat && checkNewBundle(c.BundlePath),
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
+	co.NewBundleFormat = c.NewBundleFormat && checkNewBundle(c.BundlePath, co.BundleOptions()...)
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
 	// User provides a key or certificate. Otherwise, verification requires a Fulcio certificate
@@ -206,7 +208,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	}
 
 	if co.NewBundleFormat {
-		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath)
+		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath, co.BundleOptions()...)
 		if err != nil {
 			return err
 		}
@@ -301,32 +303,25 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		if err != nil {
 			return err
 		}
-		// A certificate is required in the bundle unless we specified with
-		//  --key, --sk, or --certificate.
-		if b.Cert == "" && co.SigVerifier == nil && cert == nil {
-			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
-		}
-		// We have to condition on this because sign-blob may not output the signing
-		// key to the bundle when there is no tlog upload.
 		if b.Cert != "" {
-			// b.Cert can either be a certificate or public key
 			certBytes := []byte(b.Cert)
 			if isb64(certBytes) {
 				certBytes, _ = base64.StdEncoding.DecodeString(b.Cert)
 			}
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
-				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
-				if err != nil {
-					return fmt.Errorf("loading verifier from bundle: %w", err)
-				}
+				return fmt.Errorf("loading verifier certificate from bundle: %w", err)
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
 			if cert != nil && !cert.Equal(bundleCert) {
 				return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
 			}
 			cert = bundleCert
+		}
+		// A verifier must come either from a certificate from the bundle,
+		// or provided via --key, --sk, or --certificate.
+		if co.SigVerifier == nil && cert == nil {
+			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
 		}
 
 		encodedSig, err = base64.StdEncoding.DecodeString(b.Base64Signature)

--- a/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_bundle.go
+++ b/vendor/github.com/sigstore/cosign/v3/cmd/cosign/cli/verify/verify_bundle.go
@@ -38,8 +38,8 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 )
 
-func checkNewBundle(bundlePath string) bool {
-	_, err := sgbundle.LoadJSONFromPath(bundlePath)
+func checkNewBundle(bundlePath string, opts ...sgbundle.Option) bool {
+	_, err := sgbundle.LoadJSONFromPath(bundlePath, opts...)
 	return err == nil
 }
 

--- a/vendor/github.com/sigstore/cosign/v3/pkg/blob/load.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/blob/load.go
@@ -15,6 +15,7 @@
 package blob
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -103,9 +104,13 @@ func LoadFileOrURLWithChecksum(fileRef string, checksum string) ([]byte, error) 
 	}
 
 	checksumAlgo.Write(fileContent)
-	computedChecksum := hex.EncodeToString(checksumAlgo.Sum(nil))
-	if computedChecksum != checksumValue {
-		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, computedChecksum)
+	computedChecksum := checksumAlgo.Sum(nil)
+	// Compare the digests rather than their hex spellings: hex is case-insensitive
+	// and checksums are frequently published in upper case, which a plain string
+	// comparison would reject. A value that is not valid hex cannot match either.
+	expectedChecksum, err := hex.DecodeString(checksumValue)
+	if err != nil || !bytes.Equal(computedChecksum, expectedChecksum) {
+		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, hex.EncodeToString(computedChecksum))
 	}
 
 	return fileContent, nil

--- a/vendor/github.com/sigstore/cosign/v3/pkg/cosign/bundle/sign.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/cosign/bundle/sign.go
@@ -15,6 +15,7 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
@@ -27,6 +28,7 @@ import (
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -36,7 +38,7 @@ type SignOptions struct {
 	CertificateProvider sign.CertificateProvider
 }
 
-func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
+func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, certChain []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
 	var bundleOpts sign.BundleOptions
 
 	if trustedMaterial != nil {
@@ -60,6 +62,8 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		bundleOpts.CertificateProviderOptions = &sign.CertificateProviderOptions{
 			IDToken: idToken,
 		}
+	case cert != nil && len(certChain) > 0:
+		bundleOpts.CertificateChainProvider = &localCertChainProvider{cert: cert, chain: certChain}
 	case cert != nil:
 		bundleOpts.CertificateProvider = &localCertProvider{cert}
 	default:
@@ -141,7 +145,6 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 	defer spinner.Stop()
 
 	bundle, err := sign.Bundle(content, keypair, bundleOpts)
-
 	if err != nil {
 		return nil, fmt.Errorf("error signing bundle: %w", err)
 	}
@@ -167,6 +170,42 @@ func (c *localCertProvider) GetCertificate(_ context.Context, _ sign.Keypair, _ 
 		return nil, fmt.Errorf("could not decode cert")
 	}
 	return certBlock.Bytes, nil
+}
+
+type localCertChainProvider struct {
+	cert  []byte
+	chain []byte
+}
+
+func (c *localCertChainProvider) GetCertificateChain(_ context.Context, _ sign.Keypair, _ *sign.CertificateProviderOptions) ([][]byte, error) {
+	leafCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(c.cert)
+	if err != nil || len(leafCerts) == 0 {
+		return nil, fmt.Errorf("could not decode leaf certificate")
+	}
+	chainCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(c.chain)
+	if err != nil || len(chainCerts) == 0 {
+		return nil, fmt.Errorf("could not decode certificate chain")
+	}
+
+	leaf := leafCerts[0]
+	derChain := [][]byte{leaf.Raw}
+	for _, cert := range chainCerts {
+		if cert.Equal(leaf) {
+			continue
+		}
+		if isSelfSigned(cert) {
+			continue
+		}
+		derChain = append(derChain, cert.Raw)
+	}
+	return derChain, nil
+}
+
+func isSelfSigned(cert *x509.Certificate) bool {
+	if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+		return false
+	}
+	return cert.CheckSignatureFrom(cert) == nil
 }
 
 type cachingCertProvider struct {

--- a/vendor/github.com/sigstore/cosign/v3/pkg/cosign/pkcs11key/pkcs11key.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/cosign/pkcs11key/pkcs11key.go
@@ -173,6 +173,12 @@ func GetKeyWithURIConfig(config *Pkcs11UriConfig, askForPinIfNeeded bool) (*Key,
 	if err != nil {
 		return nil, err
 	}
+	// FindKeyPair returns a nil signer with a nil error when no matching
+	// key pair is found, so we must check explicitly to avoid handing back
+	// a Key with a nil signer, which would later panic on use.
+	if signer == nil {
+		return nil, fmt.Errorf("%w: no key pair found for id=%q label=%q in slot/token", SignerNotSet, config.KeyID, config.KeyLabel)
+	}
 
 	// Key's corresponding cert might not exist,
 	// therefore, we do not fail if it is the case.

--- a/vendor/github.com/sigstore/cosign/v3/pkg/cosign/verify.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/cosign/verify.go
@@ -76,6 +76,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	tsaverification "github.com/sigstore/timestamp-authority/v2/pkg/verification"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // Identity specifies an issuer/subject to verify a signature against.
@@ -176,6 +177,19 @@ type CheckOpts struct {
 
 	// NewBundleFormat enables the new bundle format (Cosign Bundle Spec) and the new verifier.
 	NewBundleFormat bool
+
+	// AllowCertificateChain permits bundles with version >= v0.3 to contain
+	// X.509 certificate chains in the verification material.
+	AllowCertificateChain bool
+}
+
+// BundleOptions returns sigstore-go bundle options based on CheckOpts.
+func (co *CheckOpts) BundleOptions() []sgbundle.Option {
+	var opts []sgbundle.Option
+	if co.AllowCertificateChain {
+		opts = append(opts, sgbundle.AllowCertificateChain())
+	}
+	return opts
 }
 
 type verifyTrustedMaterial struct {
@@ -1782,7 +1796,7 @@ func HasLocalAttestationBundles(path string) (bool, error) {
 
 // GetLocalBundles retrieves v3 sigstore bundles from a local OCI layout.
 // Returns bundles, target image hash, and error. Invalid bundles are logged and skipped.
-func GetLocalBundles(path string) ([]*sgbundle.Bundle, *v1.Hash, error) {
+func GetLocalBundles(path string, bundleOpts ...sgbundle.Option) ([]*sgbundle.Bundle, *v1.Hash, error) {
 	descriptors, hash, err := getLocalBundleDescriptors(path)
 	if err != nil {
 		return nil, nil, err
@@ -1796,9 +1810,14 @@ func GetLocalBundles(path string) ([]*sgbundle.Bundle, *v1.Hash, error) {
 			continue
 		}
 
-		bundle := &sgbundle.Bundle{}
-		if err := bundle.UnmarshalJSON(bundleBytes); err != nil {
+		pb := &protobundle.Bundle{}
+		if err := protojson.Unmarshal(bundleBytes, pb); err != nil {
 			ui.Warnf(context.Background(), "Failed to unmarshal bundle %s: %v", descriptor.digest.Hex, err)
+			continue
+		}
+		bundle, err := sgbundle.NewBundle(pb, bundleOpts...)
+		if err != nil {
+			ui.Warnf(context.Background(), "Failed to create bundle %s: %v", descriptor.digest.Hex, err)
 			continue
 		}
 
@@ -1993,7 +2012,7 @@ func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef nam
 
 // verifyLocalImageAttestationsSigstoreBundle verifies attestations from local sigstore bundles
 func verifyLocalImageAttestationsSigstoreBundle(ctx context.Context, path string, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
-	bundles, hash, err := GetLocalBundles(path)
+	bundles, hash, err := GetLocalBundles(path, co.BundleOptions()...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/vendor/github.com/sigstore/cosign/v3/pkg/oci/remote/options.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/oci/remote/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
 const (
@@ -45,6 +46,7 @@ type options struct {
 	ROpt              []remote.Option
 	NameOpts          []name.Option
 	OriginalOptions   []Option
+	BundleOpts        []sgbundle.Option
 }
 
 var defaultOptions = []remote.Option{
@@ -155,5 +157,13 @@ func GetEnvTargetRepository() (name.Repository, error) {
 func WithNameOptions(opts ...name.Option) Option {
 	return func(o *options) {
 		o.NameOpts = opts
+	}
+}
+
+// WithBundleOptions is a functional option for passing sigstore-go bundle
+// options (e.g. AllowCertificateChain) when parsing bundles.
+func WithBundleOptions(opts ...sgbundle.Option) Option {
+	return func(o *options) {
+		o.BundleOpts = append(o.BundleOpts, opts...)
 	}
 }

--- a/vendor/github.com/sigstore/cosign/v3/pkg/oci/remote/signatures.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/oci/remote/signatures.go
@@ -28,7 +28,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/empty"
 	"github.com/sigstore/cosign/v3/pkg/oci/internal/signature"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const maxLayers = 1000
@@ -81,8 +83,11 @@ func Bundle(ref name.Reference, opts ...Option) (*sgbundle.Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	b := &sgbundle.Bundle{}
-	err = b.UnmarshalJSON(bundleBytes)
+	pb := &protobundle.Bundle{}
+	if err := protojson.Unmarshal(bundleBytes, pb); err != nil {
+		return nil, err
+	}
+	b, err := sgbundle.NewBundle(pb, o.BundleOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/sigstore/cosign/v3/pkg/signature/keys.go
+++ b/vendor/github.com/sigstore/cosign/v3/pkg/signature/keys.go
@@ -69,6 +69,9 @@ func VerifierForKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.
 		return nil, fmt.Errorf("pem to public key: %w", err)
 	}
 
+	if hashAlgorithm == 0 {
+		return signature.LoadDefaultVerifier(pubKey)
+	}
 	return signature.LoadVerifier(pubKey, hashAlgorithm)
 }
 
@@ -92,6 +95,9 @@ func LoadPublicKeyRaw(raw []byte, hashAlgorithm crypto.Hash) (signature.Verifier
 	pub, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
 		return nil, err
+	}
+	if hashAlgorithm == 0 {
+		return signature.LoadDefaultVerifier(pub)
 	}
 	return signature.LoadVerifier(pub, hashAlgorithm)
 }
@@ -169,7 +175,7 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 }
 
 func PublicKeyFromKeyRef(ctx context.Context, keyRef string) (signature.Verifier, error) {
-	return PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, crypto.SHA256)
+	return PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, 0)
 }
 
 func PublicKeyFromKeyRefWithHashAlgo(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash) (signature.Verifier, error) {

--- a/vendor/github.com/sigstore/sigstore-go/internal/certificate/certificate.go
+++ b/vendor/github.com/sigstore/sigstore-go/internal/certificate/certificate.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"bytes"
+	"crypto/x509"
+)
+
+func IsSelfSigned(certificate *x509.Certificate) bool {
+	if !bytes.Equal(certificate.RawSubject, certificate.RawIssuer) {
+		return false
+	}
+	return certificate.CheckSignatureFrom(certificate) == nil
+}

--- a/vendor/github.com/sigstore/sigstore-go/pkg/bundle/bundle.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/bundle/bundle.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/mod/semver"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/sigstore/sigstore-go/internal/certificate"
 	"github.com/sigstore/sigstore-go/internal/limits"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -53,15 +54,20 @@ func ErrValidationError(err error) error {
 
 type Bundle struct {
 	*protobundle.Bundle
-	hasInclusionPromise bool
-	hasInclusionProof   bool
+	hasInclusionPromise   bool
+	hasInclusionProof     bool
+	allowCertificateChain bool
 }
 
-func NewBundle(pbundle *protobundle.Bundle) (*Bundle, error) {
+func NewBundle(pbundle *protobundle.Bundle, opts ...Option) (*Bundle, error) {
 	bundle := &Bundle{
 		Bundle:              pbundle,
 		hasInclusionPromise: false,
 		hasInclusionProof:   false,
+	}
+
+	for _, opt := range opts {
+		opt(bundle)
 	}
 
 	err := bundle.validate()
@@ -109,13 +115,17 @@ func (b *Bundle) validate() error {
 		}
 	}
 
-	// if bundle version >= v0.3, require verification material to not be X.509 certificate chain (only single certificate is allowed)
+	// if bundle version >= v0.3, only allow certificate chain if option is set
 	if semver.Compare(bundleVersion, "v0.3") >= 0 {
-		certs := b.VerificationMaterial.GetX509CertificateChain()
+		if !b.allowCertificateChain {
+			certs := b.VerificationMaterial.GetX509CertificateChain()
 
-		if certs != nil {
-			return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
+			if certs != nil {
+				return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
+			}
 		}
+	} else if b.allowCertificateChain {
+		return errors.New("certificate chain verification is only supported for bundle v0.3 and later")
 	}
 
 	// if bundle version is >= v0.4, return error as this version is not supported
@@ -205,9 +215,13 @@ func validateBundle(b *protobundle.Bundle) error {
 	return nil
 }
 
-func LoadJSONFromPath(path string) (*Bundle, error) {
+func LoadJSONFromPath(path string, opts ...Option) (*Bundle, error) {
 	var bundle Bundle
 	bundle.Bundle = new(protobundle.Bundle)
+
+	for _, opt := range opts {
+		opt(&bundle)
+	}
 
 	contents, err := os.ReadFile(path)
 	if err != nil {
@@ -259,8 +273,25 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 		if err != nil {
 			return nil, ErrValidationError(err)
 		}
+		var intermediates []*x509.Certificate
+		if b.allowCertificateChain {
+			for _, cert := range certs[1:] {
+				intermediate, err := x509.ParseCertificate(cert.RawBytes)
+				if err != nil {
+					return nil, ErrValidationError(err)
+				}
+				if certificate.IsSelfSigned(intermediate) {
+					return nil, ErrValidationError(errors.New("self-signed certificate found in certificate chain"))
+				}
+				if !intermediate.IsCA {
+					return nil, ErrValidationError(errors.New("non-CA certificate found in certificate chain"))
+				}
+				intermediates = append(intermediates, intermediate)
+			}
+		}
 		cert := &Certificate{
-			certificate: parsedCert,
+			certificate:   parsedCert,
+			intermediates: intermediates,
 		}
 		return cert, nil
 	case *protobundle.VerificationMaterial_Certificate:

--- a/vendor/github.com/sigstore/sigstore-go/pkg/bundle/options.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/bundle/options.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+// Option configures optional behaviour when constructing a Bundle.
+type Option func(*Bundle)
+
+// AllowCertificateChain permits bundles with version >= v0.3 to contain
+// X.509 certificate chains in their verification material. By default,
+// v0.3+ bundles require a single certificate rather than a chain.
+func AllowCertificateChain() Option {
+	return func(b *Bundle) {
+		b.allowCertificateChain = true
+	}
+}

--- a/vendor/github.com/sigstore/sigstore-go/pkg/bundle/verification_content.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/bundle/verification_content.go
@@ -24,7 +24,8 @@ import (
 )
 
 type Certificate struct {
-	certificate *x509.Certificate
+	certificate   *x509.Certificate
+	intermediates []*x509.Certificate
 }
 
 func NewCertificate(cert *x509.Certificate) *Certificate {
@@ -56,6 +57,10 @@ func (c *Certificate) Certificate() *x509.Certificate {
 	return c.certificate
 }
 
+func (c *Certificate) Intermediates() []*x509.Certificate {
+	return c.intermediates
+}
+
 func (c *Certificate) PublicKey() verify.PublicKeyProvider {
 	return nil
 }
@@ -84,6 +89,10 @@ func (pk *PublicKey) ValidAtTime(t time.Time, tm root.TrustedMaterial) bool {
 }
 
 func (pk *PublicKey) Certificate() *x509.Certificate {
+	return nil
+}
+
+func (pk *PublicKey) Intermediates() []*x509.Certificate {
 	return nil
 }
 

--- a/vendor/github.com/sigstore/sigstore-go/pkg/sign/certificate.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/sign/certificate.go
@@ -42,6 +42,10 @@ type CertificateProvider interface {
 	GetCertificate(context.Context, Keypair, *CertificateProviderOptions) ([]byte, error)
 }
 
+type CertificateChainProvider interface {
+	GetCertificateChain(context.Context, Keypair, *CertificateProviderOptions) ([][]byte, error)
+}
+
 type Fulcio struct {
 	options *FulcioOptions
 	client  *http.Client

--- a/vendor/github.com/sigstore/sigstore-go/pkg/sign/signer.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/sign/signer.go
@@ -17,12 +17,14 @@ package sign
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/pem"
 	"errors"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 
+	"github.com/sigstore/sigstore-go/internal/certificate"
 	verifyBundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -36,6 +38,10 @@ type BundleOptions struct {
 	// Typically a Fulcio instance; resulting bundle will contain a certificate
 	// for its verification material content instead of a public key.
 	CertificateProvider CertificateProvider
+	// Optional certificate chain provider for private Fulcio deployments
+	// with Intermediate CAs. Takes precedence over CertificateProvider
+	// and stores a full X509CertificateChain in the bundle.
+	CertificateChainProvider CertificateChainProvider
 	// Optional options for certificate provider
 	//
 	// Some certificate authorities may require options to be set
@@ -74,7 +80,43 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	// Add verification information to bundle
 	var verifierPEM []byte
-	if opts.CertificateProvider != nil {
+	switch {
+	case opts.CertificateChainProvider != nil:
+		certificateChain, err := opts.CertificateChainProvider.GetCertificateChain(opts.Context, keypair, opts.CertificateProviderOptions)
+		if err != nil {
+			return nil, err
+		}
+		if len(certificateChain) == 0 {
+			return nil, errors.New("certificates provider returned no certificates")
+		}
+
+		certificateChainProto := &protocommon.X509CertificateChain{}
+		certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{
+			RawBytes: certificateChain[0],
+		})
+		for _, certBytes := range certificateChain[1:] {
+			parsed, err := x509.ParseCertificate(certBytes)
+			if err != nil {
+				return nil, err
+			}
+			if certificate.IsSelfSigned(parsed) {
+				return nil, errors.New("certificate chain must not contain a self-signed (root) certificate")
+			}
+			certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{
+				RawBytes: certBytes,
+			})
+		}
+		bundle.VerificationMaterial = &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: certificateChainProto,
+			},
+		}
+
+		verifierPEM = pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certificateChain[0],
+		})
+	case opts.CertificateProvider != nil:
 		pubKeyBytes, err := opts.CertificateProvider.GetCertificate(opts.Context, keypair, opts.CertificateProviderOptions)
 		if err != nil {
 			return nil, err
@@ -92,7 +134,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			Type:  "CERTIFICATE",
 			Bytes: pubKeyBytes,
 		})
-	} else {
+	default:
 		bundle.VerificationMaterial = &protobundle.VerificationMaterial{
 			Content: &protobundle.VerificationMaterial_PublicKey{
 				PublicKey: &protocommon.PublicKeyIdentifier{
@@ -139,7 +181,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 		// Verification will fail if a timestamp authority is not provided for Rekor v2.
 		if len(opts.TimestampAuthorities) == 0 {
 			// Only use the Rekor integrated timestamp if there's a certificate, otherwise don't require time
-			if opts.CertificateProvider != nil {
+			if opts.CertificateProvider != nil || opts.CertificateChainProvider != nil {
 				verifierOptions = append(verifierOptions, verify.WithIntegratedTimestamps(len(opts.TransparencyLogs)))
 			} else {
 				verifierOptions = append(verifierOptions, verify.WithNoObserverTimestamps())
@@ -150,7 +192,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 	// A time verification policy must be provided. If no signed timestamp or integrated timestamp was
 	// retrieved, verify a certificate with the current time or don't verify time for a key
 	if len(opts.TimestampAuthorities) == 0 && len(opts.TransparencyLogs) == 0 {
-		if opts.CertificateProvider != nil {
+		if opts.CertificateProvider != nil || opts.CertificateChainProvider != nil {
 			verifierOptions = append(verifierOptions, verify.WithCurrentTime())
 		} else {
 			verifierOptions = append(verifierOptions, verify.WithNoObserverTimestamps())
@@ -163,7 +205,11 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			return nil, err
 		}
 
-		protobundle, err := verifyBundle.NewBundle(bundle)
+		var bundleOpts []verifyBundle.Option
+		if opts.CertificateChainProvider != nil {
+			bundleOpts = append(bundleOpts, verifyBundle.AllowCertificateChain())
+		}
+		protobundle, err := verifyBundle.NewBundle(bundle, bundleOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/sigstore/sigstore-go/pkg/verify/certificate.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/verify/certificate.go
@@ -23,7 +23,17 @@ import (
 )
 
 func VerifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial) ([][]*x509.Certificate, error) { // nolint: revive
+	return verifyLeafCertificate(observerTimestamp, leafCert, trustedMaterial, nil)
+}
+
+func verifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial, intermediates []*x509.Certificate) ([][]*x509.Certificate, error) {
 	for _, ca := range trustedMaterial.FulcioCertificateAuthorities() {
+		if fca, ok := ca.(*root.FulcioCertificateAuthority); ok && len(intermediates) > 0 {
+			withIntermediates := *fca
+			withIntermediates.Intermediates = append([]*x509.Certificate{}, fca.Intermediates...)
+			withIntermediates.Intermediates = append(withIntermediates.Intermediates, intermediates...)
+			ca = &withIntermediates
+		}
 		chains, err := ca.Verify(leafCert, observerTimestamp)
 		if err == nil {
 			return chains, nil

--- a/vendor/github.com/sigstore/sigstore-go/pkg/verify/certificate_identity.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/verify/certificate_identity.go
@@ -118,6 +118,9 @@ func (s *SubjectAlternativeNameMatcher) MarshalJSON() ([]byte, error) {
 // Verify checks if the actualCert matches the SANMatcher's Value and
 // Regexp – if those values have been provided.
 func (s SubjectAlternativeNameMatcher) Verify(actualCert certificate.Summary) error {
+	if s.SubjectAlternativeName == "" && s.Regexp.String() == "" {
+		return errors.New("when verifying a certificate identity, there must be subject alternative name criteria")
+	}
 	if s.SubjectAlternativeName != "" &&
 		actualCert.SubjectAlternativeName != s.SubjectAlternativeName {
 		return &ErrValueMismatch{"SAN", string(s.SubjectAlternativeName), string(actualCert.SubjectAlternativeName)}
@@ -150,6 +153,9 @@ func (i *IssuerMatcher) MarshalJSON() ([]byte, error) {
 }
 
 func (i IssuerMatcher) Verify(actualCert certificate.Summary) error {
+	if i.Issuer == "" && i.Regexp.String() == "" {
+		return errors.New("when verifying a certificate identity, must specify Issuer criteria")
+	}
 	if i.Issuer != "" &&
 		actualCert.Issuer != i.Issuer {
 		return &ErrValueMismatch{"issuer", string(i.Issuer), string(actualCert.Issuer)}

--- a/vendor/github.com/sigstore/sigstore-go/pkg/verify/interface.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/verify/interface.go
@@ -69,6 +69,7 @@ type VerificationContent interface {
 	CompareKey(any, root.TrustedMaterial) bool
 	ValidAtTime(time.Time, root.TrustedMaterial) bool
 	Certificate() *x509.Certificate
+	Intermediates() []*x509.Certificate
 	PublicKey() PublicKeyProvider
 }
 

--- a/vendor/github.com/sigstore/sigstore-go/pkg/verify/signed_entity.go
+++ b/vendor/github.com/sigstore/sigstore-go/pkg/verify/signed_entity.go
@@ -663,10 +663,13 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 			leafCert.UnhandledCriticalExtensions = unhandledExts
 		}
 
+		// If the bundle verification material contains an X509CertificateChain,
+		// extract the Intermediate CA certificates to use during certificate path validation.
+		intermediates := verificationContent.Intermediates()
+
 		var chains [][]*x509.Certificate
 		for _, verifiedTs := range verifiedTimestamps {
-			// verify the leaf certificate against the root
-			chains, err = VerifyLeafCertificate(verifiedTs.Timestamp, leafCert, v.trustedMaterial)
+			chains, err = verifyLeafCertificate(verifiedTs.Timestamp, leafCert, v.trustedMaterial, intermediates)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify leaf certificate: %w", err)
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2824,7 +2824,7 @@ github.com/shibumi/go-pathspec
 # github.com/shopspring/decimal v1.4.0
 ## explicit; go 1.10
 github.com/shopspring/decimal
-# github.com/sigstore/cosign/v3 v3.1.2
+# github.com/sigstore/cosign/v3 v3.1.3
 ## explicit; go 1.26.0
 github.com/sigstore/cosign/v3/cmd/cosign/cli/fulcio
 github.com/sigstore/cosign/v3/cmd/cosign/cli/options
@@ -2951,8 +2951,9 @@ github.com/sigstore/sigstore/pkg/signature/kms/cliplugin/internal/signerverifier
 github.com/sigstore/sigstore/pkg/signature/options
 github.com/sigstore/sigstore/pkg/signature/payload
 github.com/sigstore/sigstore/pkg/tuf
-# github.com/sigstore/sigstore-go v1.2.1
-## explicit; go 1.25.0
+# github.com/sigstore/sigstore-go v1.2.2
+## explicit; go 1.25.8
+github.com/sigstore/sigstore-go/internal/certificate
 github.com/sigstore/sigstore-go/internal/limits
 github.com/sigstore/sigstore-go/pkg/bundle
 github.com/sigstore/sigstore-go/pkg/fulcio/certificate


### PR DESCRIPTION
## Description

Noticed [GHSA-fx35-mq7g-6g98](https://github.com/sigstore/cosign/security/advisories/GHSA-fx35-mq7g-6g98) and the accompanying release of v3.1.3.

## Related Issue

No associated issue

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
