### PR TITLE
ci: switch from shallow checkout

### DIFF
--- a/.github/workflows/test-site.yml
+++ b/.github/workflows/test-site.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/site/hack/build-versions.mjs
+++ b/site/hack/build-versions.mjs
@@ -27,6 +27,15 @@ function git(args, opts = {}) {
   return execFileSync("git", args, { cwd: repoDir, stdio: "inherit", ...opts });
 }
 
+function hasCommit(ref) {
+  try {
+    git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function npm(args, cwd) {
   execFileSync("npm", args, { cwd, stdio: "inherit", env: process.env });
 }
@@ -161,11 +170,18 @@ async function stageVersionedAssets(worktree, slug) {
 async function stageVersion({ ref, slug }) {
   const worktree = path.join(worktreeRoot, slug);
   console.log(`\n=== Staging ${slug} from ${ref} ===`);
-  // CI often uses a shallow clone without tag commits; fetch the tag's commit.
-  try {
-    git(["fetch", "--depth=1", zarfGitRepo, "tag", ref, "--no-tags"]);
-  } catch {
-    console.warn(`git fetch of tag ${ref} failed; assuming it is already present`);
+  // Tags are already available in CI's full checkout; shallow local clones fetch on demand.
+  if (!hasCommit(ref)) {
+    try {
+      git(["fetch", "--depth=1", zarfGitRepo, "tag", ref, "--no-tags"]);
+    } catch (error) {
+      if (!hasCommit(ref)) {
+        throw new Error(`git fetch of tag ${ref} failed and the tag is not available locally`, {
+          cause: error,
+        });
+      }
+      console.warn(`git fetch of tag ${ref} failed; using the locally available tag`);
+    }
   }
   git(["worktree", "add", "--detach", worktree, ref]);
   try {


### PR DESCRIPTION
## Description

See failing [test site workflow](https://github.com/zarf-dev/zarf/actions/runs/31216923230/job/92992501984?pr=5197). The default for checkout is shallow which can result in problems for depth-limited tag fetches. 

This updates the workflow as well as modifies the tag fetch to skip when it exists locally, fetch only the missing tags, and if a fetch fails proceed only when the commit is now locally resolvable - otherwise report the original fetch failure that was previously being swallowed.

## Related Issue

No associated issue

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
