### PR TITLE
fix(tools): prevent panic in `tools sbom config`

### DIFF
--- a/src/cmd/syft.go
+++ b/src/cmd/syft.go
@@ -23,5 +23,34 @@ func newSbomCommand() *cobra.Command {
 	cmd.Short = lang.CmdToolsSbomShort
 	cmd.Aliases = []string{"s", "syft"}
 
+	configureSbomConfigCommand(cmd)
+
 	return ReplaceCommandName("syft", "zarf tools sbom", cmd)
+}
+
+func configureSbomConfigCommand(sbomCmd *cobra.Command) {
+	configCmd, _, err := sbomCmd.Find([]string{"config"})
+	if err != nil || configCmd == nil || configCmd.RunE == nil {
+		return
+	}
+
+	runE := configCmd.RunE
+	configCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		toolsCmd := sbomCmd.Parent()
+		if toolsCmd == nil {
+			return runE(cmd, args)
+		}
+
+		yqCmd, _, err := toolsCmd.Find([]string{"yq"})
+		if err != nil || yqCmd == nil {
+			return runE(cmd, args)
+		}
+
+		// Fangs walks every command flag while producing the Syft config summary. yq's
+		// value-backed unwrapScalar flag causes Fangs to panic during that traversal.
+		toolsCmd.RemoveCommand(yqCmd)
+		defer toolsCmd.AddCommand(yqCmd)
+
+		return runE(cmd, args)
+	}
 }

--- a/src/cmd/syft_test.go
+++ b/src/cmd/syft_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSbomConfigTemporarilyRemovesYQ(t *testing.T) {
+	root := &cobra.Command{Use: "zarf"}
+	tools := newToolsCommand()
+	root.AddCommand(tools)
+	root.SetArgs([]string{"tools", "sbom", "config"})
+	yqCmd, _, err := tools.Find([]string{"yq"})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	sbomCmd, _, err := tools.Find([]string{"sbom"})
+	require.NoError(t, err)
+	require.Same(t, tools, sbomCmd.Parent())
+	require.Same(t, tools, yqCmd.Parent())
+}


### PR DESCRIPTION
## Description

This PR adds a workaround for the vendored `syft` CLI to prevent a panic when invoking its `config` subcommand. There is a fundamental flaw in the way Anchore's `fangs` library parses CLI flags, making it less flexible than the way `pflag` processes those same flags. This conflicts with a custom flag defined by the vendored `yq` command.

This PR mitigates this issue by simply removing the vendored `yq` command from the `cobra` command graph when running `zarf tools sbom config`, ensuring the vendored `syft` command simply never sees that problematic custom flag from `yq`.

## Related Issue

Fixes #4338 

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
