### PR TITLE
test: add unit coverage for generated SBOM contents

### DIFF
--- a/src/pkg/packager/assemble/sbom_test.go
+++ b/src/pkg/packager/assemble/sbom_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/anchore/syft/syft/format/syftjson/model"
+	"github.com/anchore/syft/syft/pkg"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -51,31 +53,12 @@ func TestCreateImageSBOMNonExistentCachePath(t *testing.T) {
 	require.NotEmpty(t, b)
 }
 
-// sbomDocument captures the syft-json fields the content tests assert on.
-type sbomDocument struct {
-	Artifacts []struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-		Type    string `json:"type"`
-	} `json:"artifacts"`
-	ArtifactRelationships []struct {
-		Parent string `json:"parent"`
-		Child  string `json:"child"`
-		Type   string `json:"type"`
-	} `json:"artifactRelationships"`
-	Source struct {
-		Type string `json:"type"`
-	} `json:"source"`
-	Descriptor struct {
-		Name string `json:"name"`
-	} `json:"descriptor"`
-	Schema struct {
-		URL string `json:"url"`
-	} `json:"schema"`
-}
-
-func (d sbomDocument) findArtifact(name string) (version string, pkgType string, ok bool) {
-	for _, a := range d.Artifacts {
+// findArtifact looks a package up by name in a syft document. Decoding into
+// syft's own model rather than a local projection means a change to the
+// syft-json shape surfaces here, which is the point: the document is a zarf
+// output, so its schema is part of what these tests are guarding.
+func findArtifact(doc model.Document, name string) (version string, pkgType pkg.Type, ok bool) {
+	for _, a := range doc.Artifacts {
 		if a.Name == name {
 			return a.Version, a.Type, true
 		}
@@ -125,15 +108,15 @@ L:Zlib
 	b, err := createImageSBOM(ctx, t.TempDir(), outputPath, img, "docker.io/foo/bar:latest")
 	require.NoError(t, err)
 
-	var doc sbomDocument
+	var doc model.Document
 	require.NoError(t, json.Unmarshal(b, &doc))
 
-	version, pkgType, ok := doc.findArtifact("musl")
+	version, pkgType, ok := findArtifact(doc, "musl")
 	require.True(t, ok, "expected musl package in image SBOM artifacts")
 	require.Equal(t, "1.2.4-r2", version)
-	require.Equal(t, "apk", pkgType)
+	require.Equal(t, pkg.ApkPkg, pkgType)
 
-	version, _, ok = doc.findArtifact("zlib")
+	version, _, ok = findArtifact(doc, "zlib")
 	require.True(t, ok, "expected zlib package in image SBOM artifacts")
 	require.Equal(t, "1.3-r2", version)
 
@@ -175,15 +158,15 @@ func TestCreateFileSBOMContents(t *testing.T) {
 	b, err := createFileSBOM(ctx, component, outputPath, buildPath)
 	require.NoError(t, err)
 
-	var doc sbomDocument
+	var doc model.Document
 	require.NoError(t, json.Unmarshal(b, &doc))
 
-	version, pkgType, ok := doc.findArtifact("flask")
+	version, pkgType, ok := findArtifact(doc, "flask")
 	require.True(t, ok, "expected flask package in file SBOM artifacts")
 	require.Equal(t, "2.0.1", version)
-	require.Equal(t, "python", pkgType)
+	require.Equal(t, pkg.PythonPkg, pkgType)
 
-	_, _, ok = doc.findArtifact("requests")
+	_, _, ok = findArtifact(doc, "requests")
 	require.True(t, ok, "expected requests package in file SBOM artifacts")
 
 	require.Equal(t, "zarf", doc.Descriptor.Name)

--- a/src/pkg/packager/assemble/sbom_test.go
+++ b/src/pkg/packager/assemble/sbom_test.go
@@ -7,7 +7,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -76,7 +78,9 @@ func layerFromFiles(t *testing.T, files map[string]string) v1.Layer {
 		require.NoError(t, err)
 	}
 	require.NoError(t, tw.Close())
-	layer, err := tarball.LayerFromReader(bytes.NewReader(buf.Bytes()))
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	})
 	require.NoError(t, err)
 	return layer
 }
@@ -146,7 +150,9 @@ func TestCreateFileSBOMContents(t *testing.T) {
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	entry := filepath.Join(component.Name, string(layout.FilesComponentDir), layout.ComponentFileRelPath(0, "requirements.txt"))
+	// tar entry names are always slash-separated, so filepath.Join would emit
+	// backslashes on Windows and the extractor would reject the entry.
+	entry := path.Join(component.Name, string(layout.FilesComponentDir), filepath.ToSlash(layout.ComponentFileRelPath(0, "requirements.txt")))
 	content := "flask==2.0.1\nrequests==2.31.0\n"
 	require.NoError(t, tw.WriteHeader(&tar.Header{Name: entry, Mode: 0o644, Size: int64(len(content))}))
 	_, err := tw.Write([]byte(content))

--- a/src/pkg/packager/assemble/sbom_test.go
+++ b/src/pkg/packager/assemble/sbom_test.go
@@ -4,12 +4,20 @@
 package assemble
 
 import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -41,4 +49,148 @@ func TestCreateImageSBOMNonExistentCachePath(t *testing.T) {
 	b, err := createImageSBOM(ctx, cachePath, outputPath, img, "docker.io/foo/bar:latest")
 	require.NoError(t, err)
 	require.NotEmpty(t, b)
+}
+
+// sbomDocument captures the syft-json fields the content tests assert on.
+type sbomDocument struct {
+	Artifacts []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		Type    string `json:"type"`
+	} `json:"artifacts"`
+	ArtifactRelationships []struct {
+		Parent string `json:"parent"`
+		Child  string `json:"child"`
+		Type   string `json:"type"`
+	} `json:"artifactRelationships"`
+	Source struct {
+		Type string `json:"type"`
+	} `json:"source"`
+	Descriptor struct {
+		Name string `json:"name"`
+	} `json:"descriptor"`
+	Schema struct {
+		URL string `json:"url"`
+	} `json:"schema"`
+}
+
+func (d sbomDocument) findArtifact(name string) (version string, pkgType string, ok bool) {
+	for _, a := range d.Artifacts {
+		if a.Name == name {
+			return a.Version, a.Type, true
+		}
+	}
+	return "", "", false
+}
+
+func layerFromFiles(t *testing.T, files map[string]string) v1.Layer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	layer, err := tarball.LayerFromReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	return layer
+}
+
+func TestCreateImageSBOMContents(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+
+	apkInstalledDB := `P:musl
+V:1.2.4-r2
+A:aarch64
+T:the musl c library
+L:MIT
+
+P:zlib
+V:1.3-r2
+A:aarch64
+T:A compression library
+L:Zlib
+`
+	layer := layerFromFiles(t, map[string]string{
+		"lib/apk/db/installed": apkInstalledDB,
+	})
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+
+	outputPath := t.TempDir()
+	b, err := createImageSBOM(ctx, t.TempDir(), outputPath, img, "docker.io/foo/bar:latest")
+	require.NoError(t, err)
+
+	var doc sbomDocument
+	require.NoError(t, json.Unmarshal(b, &doc))
+
+	version, pkgType, ok := doc.findArtifact("musl")
+	require.True(t, ok, "expected musl package in image SBOM artifacts")
+	require.Equal(t, "1.2.4-r2", version)
+	require.Equal(t, "apk", pkgType)
+
+	version, _, ok = doc.findArtifact("zlib")
+	require.True(t, ok, "expected zlib package in image SBOM artifacts")
+	require.Equal(t, "1.3-r2", version)
+
+	require.Equal(t, "zarf", doc.Descriptor.Name)
+	require.NotEmpty(t, doc.Source.Type)
+	require.NotEmpty(t, doc.Schema.URL)
+	require.NotEmpty(t, doc.ArtifactRelationships)
+}
+
+func TestCreateFileSBOMContents(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.TestContext(t)
+
+	component := v1alpha1.ZarfComponent{
+		Name: "test-component",
+		Files: []v1alpha1.ZarfFile{
+			{Target: "requirements.txt"},
+		},
+	}
+
+	// Lay out the component tar the way assemble produces it:
+	// <component>/files/<idx>/<basename(target)>
+	buildPath := t.TempDir()
+	componentsDir := filepath.Join(buildPath, string(layout.ComponentsDir))
+	require.NoError(t, os.MkdirAll(componentsDir, 0o755))
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	entry := filepath.Join(component.Name, string(layout.FilesComponentDir), layout.ComponentFileRelPath(0, "requirements.txt"))
+	content := "flask==2.0.1\nrequests==2.31.0\n"
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: entry, Mode: 0o644, Size: int64(len(content))}))
+	_, err := tw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, os.WriteFile(filepath.Join(componentsDir, component.Name+".tar"), buf.Bytes(), 0o644))
+
+	outputPath := t.TempDir()
+	b, err := createFileSBOM(ctx, component, outputPath, buildPath)
+	require.NoError(t, err)
+
+	var doc sbomDocument
+	require.NoError(t, json.Unmarshal(b, &doc))
+
+	version, pkgType, ok := doc.findArtifact("flask")
+	require.True(t, ok, "expected flask package in file SBOM artifacts")
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "python", pkgType)
+
+	_, _, ok = doc.findArtifact("requests")
+	require.True(t, ok, "expected requests package in file SBOM artifacts")
+
+	require.Equal(t, "zarf", doc.Descriptor.Name)
+	require.NotEmpty(t, doc.ArtifactRelationships)
+
+	// The returned bytes are also written to zarf-component-<name>.json.
+	fileContent, err := os.ReadFile(filepath.Join(outputPath, "zarf-component-test-component.json"))
+	require.NoError(t, err)
+	require.Equal(t, fileContent, b)
 }


### PR DESCRIPTION
Fixes #5159

The existing SBOM tests only asserted non-empty output. This adds content-level assertions against the parsed syft-json documents:

- **createImageSBOM**: an image layer carrying an apk installed database must yield the expected packages (name/version/type apk), the zarf descriptor, source and schema metadata, and artifact relationships.
- **createFileSBOM**: a component tar carrying a requirements.txt must yield the expected python packages, the zarf descriptor and relationships, and write identical bytes to zarf-component-<name>.json.

Fixture expectations are derived from current output on main, so a Syft upgrade produces a focused, reviewable diff instead of silent drift.

Test-only change; go test ./src/pkg/packager/assemble/ green locally.