### PR TITLE
fix: add values flags to dev deploy and init

### DIFF
--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -30,8 +30,11 @@ zarf dev deploy [flags]
       --oci-concurrency int                   Number of concurrent layer operations when pulling or pushing images or packages to/from OCI registries. (default 6)
       --registry-override stringArray         Specify a mapping of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)
       --retries int                           Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --set-values stringToString             Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
+      --skip-values-schema-validation         Skip validation of package values against the values schema.
       --take-ownership                        Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
       --timeout duration                      Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
+  -v, --values strings                        [beta] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
 ```
 
 ### Options inherited from parent commands

--- a/site/src/content/docs/commands/zarf_dev_deploy.md
+++ b/site/src/content/docs/commands/zarf_dev_deploy.md
@@ -31,7 +31,6 @@ zarf dev deploy [flags]
       --registry-override stringArray         Specify a mapping of domains to override on package create when pulling images (e.g. --registry-override docker.io=dockerio-reg.enterprise.intranet)
       --retries int                           Number of retries to perform for Zarf operations like git/image pushes (default 3)
       --set-values stringToString             Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
-      --skip-values-schema-validation         Skip validation of package values against the values schema.
       --take-ownership                        Adopts any pre-existing K8s resources into the Helm charts managed by Zarf. ONLY use when you have existing deployments you want Zarf to takeover.
       --timeout duration                      Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
   -v, --values strings                        [beta] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.

--- a/site/src/content/docs/commands/zarf_init.md
+++ b/site/src/content/docs/commands/zarf_init.md
@@ -88,6 +88,7 @@ $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-
       --registry-secret string                  Internal registry secret value. Only used when --registry-url is not set.
       --registry-url string                     External registry url address to use for this Zarf cluster
       --retries int                             Number of retries to perform for Zarf operations like git/image pushes (default 3)
+      --set-values stringToString               Set package values (key.path=value). Booleans and integers are type-inferred; everything else is a string (default [])
       --set-variables stringToString            Specify deployment variables to set on the command line (KEY=value) (default [])
       --skip-values-schema-validation           Skip validation of package values against the values schema.
       --storage-class string                    Specify the storage class to use for the registry and git server.  E.g. --storage-class=standard
@@ -95,6 +96,7 @@ $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-
       --timeout duration                        Timeout for health checks and Helm operations such as installs and rollbacks (default 15m0s)
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
+  -v, --values strings                          [beta] Values files to use for templating and Helm overrides. Multiple files can be passed in as a comma separated list, and the flag can be provided multiple times.
       --verify verifyMode[=always]              Signature verification mode (always|if-possible|never). (default if-possible)
 ```
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -514,19 +514,22 @@ func (o *devInspectValuesFilesOptions) run(ctx context.Context, args []string) e
 }
 
 type devDeployOptions struct {
-	createSetPkgTmpl   map[string]string
-	deploySetVariables map[string]string
-	registryOverrides  []string
-	flavor             string
-	registryURL        string
-	takeOwnership      bool
-	timeout            time.Duration
-	retries            int
-	optionalComponents string
-	noYOLO             bool
-	connected          bool
-	ociConcurrency     int
-	skipVersionCheck   bool
+	createSetPkgTmpl           map[string]string
+	deploySetVariables         map[string]string
+	valuesFiles                []string
+	setValues                  map[string]string
+	registryOverrides          []string
+	flavor                     string
+	registryURL                string
+	takeOwnership              bool
+	timeout                    time.Duration
+	retries                    int
+	optionalComponents         string
+	noYOLO                     bool
+	connected                  bool
+	ociConcurrency             int
+	skipValuesSchemaValidation bool
+	skipVersionCheck           bool
 }
 
 func newDevDeployCommand(v *viper.Viper) *cobra.Command {
@@ -553,6 +556,8 @@ func newDevDeployCommand(v *viper.Viper) *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.deploySetVariables, "deploy-set", v.GetStringMapString(VPkgDeploySet), "Alias for --deploy-set-variables")
 	_ = cmd.Flags().MarkDeprecated("deploy-set", "Use --deploy-set-variables instead")
 	cmd.Flags().StringToStringVar(&o.deploySetVariables, "deploy-set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdPackageDeployFlagSetVariables)
+	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
+	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
 
 	// Always require take-ownership flag (no viper)
 	cmd.Flags().BoolVar(&o.takeOwnership, "take-ownership", false, lang.CmdPackageDeployFlagTakeOwnership)
@@ -568,6 +573,7 @@ func newDevDeployCommand(v *viper.Viper) *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("no-yolo", "Use --connected=false instead")
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
+	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when deploying the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 
@@ -587,6 +593,11 @@ func (o *devDeployOptions) run(cmd *cobra.Command, args []string) error {
 
 	o.deploySetVariables = helpers.TransformAndMergeMap(
 		v.GetStringMapString(VPkgDeploySet), o.deploySetVariables, strings.ToUpper)
+	o.setValues = mergeMap(v.GetStringMapString(VPkgDeploySetValues), o.setValues)
+	values, err := parseValues(ctx, o.valuesFiles, o.setValues)
+	if err != nil {
+		return err
+	}
 
 	cachePath, err := getCachePath(ctx)
 	if err != nil {
@@ -598,20 +609,22 @@ func (o *devDeployOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	err = packager.DevDeploy(ctx, basePath, packager.DevDeployOptions{
-		AirgapMode:         o.noYOLO || !o.connected,
-		Flavor:             o.flavor,
-		RegistryURL:        o.registryURL,
-		RegistryOverrides:  overrides,
-		CreateSetVariables: o.createSetPkgTmpl,
-		DeploySetVariables: o.deploySetVariables,
-		OptionalComponents: o.optionalComponents,
-		Timeout:            o.timeout,
-		Retries:            o.retries,
-		OCIConcurrency:     o.ociConcurrency,
-		RemoteOptions:      defaultRemoteOptions(),
-		CachePath:          cachePath,
-		SkipVersionCheck:   o.skipVersionCheck,
-		TakeOwnership:      o.takeOwnership,
+		AirgapMode:                 o.noYOLO || !o.connected,
+		Flavor:                     o.flavor,
+		RegistryURL:                o.registryURL,
+		RegistryOverrides:          overrides,
+		CreateSetVariables:         o.createSetPkgTmpl,
+		DeploySetVariables:         o.deploySetVariables,
+		Values:                     values,
+		OptionalComponents:         o.optionalComponents,
+		Timeout:                    o.timeout,
+		Retries:                    o.retries,
+		OCIConcurrency:             o.ociConcurrency,
+		RemoteOptions:              defaultRemoteOptions(),
+		CachePath:                  cachePath,
+		SkipVersionCheck:           o.skipVersionCheck,
+		TakeOwnership:              o.takeOwnership,
+		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
 	})
 	var lintErr *lint.LintError
 	if errors.As(err, &lintErr) {

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -514,22 +514,21 @@ func (o *devInspectValuesFilesOptions) run(ctx context.Context, args []string) e
 }
 
 type devDeployOptions struct {
-	createSetPkgTmpl           map[string]string
-	deploySetVariables         map[string]string
-	valuesFiles                []string
-	setValues                  map[string]string
-	registryOverrides          []string
-	flavor                     string
-	registryURL                string
-	takeOwnership              bool
-	timeout                    time.Duration
-	retries                    int
-	optionalComponents         string
-	noYOLO                     bool
-	connected                  bool
-	ociConcurrency             int
-	skipValuesSchemaValidation bool
-	skipVersionCheck           bool
+	createSetPkgTmpl   map[string]string
+	deploySetVariables map[string]string
+	valuesFiles        []string
+	setValues          map[string]string
+	registryOverrides  []string
+	flavor             string
+	registryURL        string
+	takeOwnership      bool
+	timeout            time.Duration
+	retries            int
+	optionalComponents string
+	noYOLO             bool
+	connected          bool
+	ociConcurrency     int
+	skipVersionCheck   bool
 }
 
 func newDevDeployCommand(v *viper.Viper) *cobra.Command {
@@ -573,7 +572,6 @@ func newDevDeployCommand(v *viper.Viper) *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("no-yolo", "Use --connected=false instead")
 
 	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(VPkgOCIConcurrency), lang.CmdPackageFlagConcurrency)
-	cmd.Flags().BoolVar(&o.skipValuesSchemaValidation, "skip-values-schema-validation", false, lang.CmdPackageDeployFlagSkipValuesSchema)
 	cmd.Flags().BoolVar(&o.skipVersionCheck, "skip-version-check", false, "Ignore version requirements when deploying the package")
 	_ = cmd.Flags().MarkHidden("skip-version-check")
 
@@ -609,22 +607,21 @@ func (o *devDeployOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	err = packager.DevDeploy(ctx, basePath, packager.DevDeployOptions{
-		AirgapMode:                 o.noYOLO || !o.connected,
-		Flavor:                     o.flavor,
-		RegistryURL:                o.registryURL,
-		RegistryOverrides:          overrides,
-		CreateSetVariables:         o.createSetPkgTmpl,
-		DeploySetVariables:         o.deploySetVariables,
-		Values:                     values,
-		OptionalComponents:         o.optionalComponents,
-		Timeout:                    o.timeout,
-		Retries:                    o.retries,
-		OCIConcurrency:             o.ociConcurrency,
-		RemoteOptions:              defaultRemoteOptions(),
-		CachePath:                  cachePath,
-		SkipVersionCheck:           o.skipVersionCheck,
-		TakeOwnership:              o.takeOwnership,
-		SkipValuesSchemaValidation: o.skipValuesSchemaValidation,
+		AirgapMode:         o.noYOLO || !o.connected,
+		Flavor:             o.flavor,
+		RegistryURL:        o.registryURL,
+		RegistryOverrides:  overrides,
+		CreateSetVariables: o.createSetPkgTmpl,
+		DeploySetVariables: o.deploySetVariables,
+		Values:             values,
+		OptionalComponents: o.optionalComponents,
+		Timeout:            o.timeout,
+		Retries:            o.retries,
+		OCIConcurrency:     o.ociConcurrency,
+		RemoteOptions:      defaultRemoteOptions(),
+		CachePath:          cachePath,
+		SkipVersionCheck:   o.skipVersionCheck,
+		TakeOwnership:      o.takeOwnership,
 	})
 	var lintErr *lint.LintError
 	if errors.As(err, &lintErr) {

--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -38,6 +38,8 @@ import (
 
 type initOptions struct {
 	setVariables               map[string]string
+	valuesFiles                []string
+	setValues                  map[string]string
 	optionalComponents         string
 	skipValuesSchemaValidation bool
 	storageClass               string
@@ -79,6 +81,8 @@ func newInitCommand() *cobra.Command {
 	cmd.Flags().StringToStringVar(&o.setVariables, "set", v.GetStringMapString(VPkgDeploySet), "Alias for --set-variables")
 	_ = cmd.Flags().MarkDeprecated("set", "Use --set-variables instead")
 	cmd.Flags().StringToStringVar(&o.setVariables, "set-variables", v.GetStringMapString(VPkgDeploySet), lang.CmdInitFlagSetVariables)
+	cmd.Flags().StringSliceVarP(&o.valuesFiles, "values", "v", GetStringSlice(v, VPkgDeployValues), lang.CmdPackageDeployFlagValuesFiles)
+	cmd.Flags().StringToStringVar(&o.setValues, "set-values", v.GetStringMapString(VPkgDeploySetValues), lang.CmdPackageDeployFlagSetValues)
 
 	// Continue to require --confirm flag for init command to avoid accidental deployments
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, lang.CmdInitFlagConfirm)
@@ -196,6 +200,11 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	v := getViper()
 	o.setVariables = helpers.TransformAndMergeMap(
 		v.GetStringMapString(VPkgDeploySet), o.setVariables, strings.ToUpper)
+	o.setValues = mergeMap(v.GetStringMapString(VPkgDeploySetValues), o.setValues)
+	values, err := parseValues(ctx, o.valuesFiles, o.setValues)
+	if err != nil {
+		return err
+	}
 
 	cachePath, err := getCachePath(ctx)
 	if err != nil {
@@ -238,6 +247,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		Retries:                    o.retries,
 		OCIConcurrency:             o.ociConcurrency,
 		SetVariables:               o.setVariables,
+		Values:                     values,
 		StorageClass:               o.storageClass,
 		InjectorPort:               o.injectorPort,
 		InjectorImage:              o.injectorImage,

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -165,28 +165,9 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 		return DeployResult{}, err
 	}
 
-	if len(opts.Values) > 0 && !feature.IsEnabled(feature.Values) {
-		return DeployResult{}, fmt.Errorf("package-level values passed in but \"%s\" feature is not enabled."+
-			" Run again with --features=\"%s=true\"", feature.Values, feature.Values)
-	}
-
-	// Read the package values from values.yaml if it exists
-	valuesPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesYAML)
-	vals, err := value.ParseLocalFile(ctx, valuesPath)
+	vals, err := loadDeploymentValues(ctx, pkgLayout, opts.Values, opts.SkipValuesSchemaValidation)
 	if err != nil {
 		return DeployResult{}, err
-	}
-
-	// Package defaults are overridden by deploy values.
-	vals.DeepMerge(opts.Values)
-
-	// Validate merged values against schema if provided
-	if pkgLayout.HasValuesSchema() && !opts.SkipValuesSchemaValidation {
-		schemaPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema)
-		if err := vals.Validate(ctx, schemaPath, value.ValidateOptions{}); err != nil {
-			return DeployResult{}, fmt.Errorf("values validation failed: %w", err)
-		}
-		l.Debug("values validated against schema", "schemaPath", schemaPath)
 	}
 
 	d := deployer{
@@ -217,6 +198,32 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 		Values:             d.vals,
 	}
 	return deployResult, nil
+}
+
+// loadDeploymentValues loads a package's assembled values, applies deploy-time overrides, and validates the result.
+func loadDeploymentValues(ctx context.Context, pkgLayout *layout.PackageLayout, overrides value.Values, skipSchemaValidation bool) (value.Values, error) {
+	pkg := pkgLayout.AsV1alpha1()
+	if !feature.IsEnabled(feature.Values) && (len(pkg.Values.Files) > 0 || len(overrides) > 0) {
+		return nil, fmt.Errorf("package-level values passed in but \"%s\" feature is not enabled."+
+			" Run again with --features=\"%s=true\"", feature.Values, feature.Values)
+	}
+
+	valuesPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesYAML)
+	vals, err := value.ParseLocalFile(ctx, valuesPath)
+	if err != nil {
+		return nil, err
+	}
+	vals.DeepMerge(overrides)
+
+	if pkgLayout.HasValuesSchema() && !skipSchemaValidation {
+		schemaPath := filepath.Join(pkgLayout.DirPath(), layout.ValuesSchema)
+		if err := vals.Validate(ctx, schemaPath, value.ValidateOptions{}); err != nil {
+			return nil, fmt.Errorf("values validation failed: %w", err)
+		}
+		logger.From(ctx).Debug("values validated against schema", "schemaPath", schemaPath)
+	}
+
+	return vals, nil
 }
 
 func (d *deployer) isConnectedToCluster() bool {

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -6,6 +6,7 @@ package packager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"slices"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager/load"
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	"github.com/zarf-dev/zarf/src/pkg/utils"
+	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/types"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -39,6 +41,8 @@ type DevDeployOptions struct {
 	CreateSetVariables map[string]string
 	// DeploySetVariables are for package variables
 	DeploySetVariables map[string]string
+	// Values are values passed in at deploy time.
+	Values value.Values
 	// OptionalComponents to be deployed
 	OptionalComponents string
 	// Timeout for Helm operations
@@ -52,6 +56,8 @@ type DevDeployOptions struct {
 	SkipVersionCheck bool
 	// TakeOwnership adopts any pre-existing K8s resources into the Helm charts managed by Zarf
 	TakeOwnership bool
+	// SkipValuesSchemaValidation skips validation of the merged package values against the package schema.
+	SkipValuesSchemaValidation bool
 	types.RemoteOptions
 }
 
@@ -120,11 +126,16 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
+	values, err := loadDeploymentValues(ctx, pkgLayout, opts.Values, opts.SkipValuesSchemaValidation)
+	if err != nil {
+		return err
+	}
 
 	l.Info("starting package dev deploy", "name", pkg.Metadata.Name)
 
 	var d deployer
 	d.vc = variableConfig
+	d.vals = values
 	if !opts.AirgapMode {
 		// Set default builtin values so they exist in case any helm charts rely on them
 		d.s, err = state.Default()
@@ -156,15 +167,21 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 		}
 	}
 
+	if err := validateTemplateRefs(ctx, pkgLayout, values); err != nil {
+		return fmt.Errorf("package references values that cannot be resolved (value templates must be explicitly defined, even if empty): %w", err)
+	}
+
 	// Get a list of all the components we are deploying and actually deploy them
 	deployedComponents, err := d.deployComponents(ctx, pkgLayout, DeployOptions{
-		SetVariables:   opts.DeploySetVariables,
-		Timeout:        opts.Timeout,
-		Retries:        opts.Retries,
-		Connected:      !opts.AirgapMode,
-		OCIConcurrency: opts.OCIConcurrency,
-		RemoteOptions:  opts.RemoteOptions,
-		TakeOwnership:  opts.TakeOwnership,
+		SetVariables:               opts.DeploySetVariables,
+		Values:                     opts.Values,
+		Timeout:                    opts.Timeout,
+		Retries:                    opts.Retries,
+		Connected:                  !opts.AirgapMode,
+		OCIConcurrency:             opts.OCIConcurrency,
+		RemoteOptions:              opts.RemoteOptions,
+		TakeOwnership:              opts.TakeOwnership,
+		SkipValuesSchemaValidation: opts.SkipValuesSchemaValidation,
 	})
 	if err != nil {
 		return err

--- a/src/pkg/packager/dev.go
+++ b/src/pkg/packager/dev.go
@@ -56,8 +56,6 @@ type DevDeployOptions struct {
 	SkipVersionCheck bool
 	// TakeOwnership adopts any pre-existing K8s resources into the Helm charts managed by Zarf
 	TakeOwnership bool
-	// SkipValuesSchemaValidation skips validation of the merged package values against the package schema.
-	SkipValuesSchemaValidation bool
 	types.RemoteOptions
 }
 
@@ -126,7 +124,7 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 	if err != nil {
 		return err
 	}
-	values, err := loadDeploymentValues(ctx, pkgLayout, opts.Values, opts.SkipValuesSchemaValidation)
+	values, err := loadDeploymentValues(ctx, pkgLayout, opts.Values, false)
 	if err != nil {
 		return err
 	}
@@ -173,15 +171,14 @@ func DevDeploy(ctx context.Context, packagePath string, opts DevDeployOptions) (
 
 	// Get a list of all the components we are deploying and actually deploy them
 	deployedComponents, err := d.deployComponents(ctx, pkgLayout, DeployOptions{
-		SetVariables:               opts.DeploySetVariables,
-		Values:                     opts.Values,
-		Timeout:                    opts.Timeout,
-		Retries:                    opts.Retries,
-		Connected:                  !opts.AirgapMode,
-		OCIConcurrency:             opts.OCIConcurrency,
-		RemoteOptions:              opts.RemoteOptions,
-		TakeOwnership:              opts.TakeOwnership,
-		SkipValuesSchemaValidation: opts.SkipValuesSchemaValidation,
+		SetVariables:   opts.DeploySetVariables,
+		Values:         opts.Values,
+		Timeout:        opts.Timeout,
+		Retries:        opts.Retries,
+		Connected:      !opts.AirgapMode,
+		OCIConcurrency: opts.OCIConcurrency,
+		RemoteOptions:  opts.RemoteOptions,
+		TakeOwnership:  opts.TakeOwnership,
 	})
 	if err != nil {
 		return err

--- a/src/pkg/packager/dev_test.go
+++ b/src/pkg/packager/dev_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+	"github.com/zarf-dev/zarf/src/pkg/value"
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
@@ -54,4 +55,41 @@ func TestDevDeploy_filtersComponents(t *testing.T) {
 	require.NoError(t, err)
 	require.FileExists(t, selectedTarget)
 	require.NoFileExists(t, unselectedTarget)
+}
+
+func TestDevDeploy_appliesValues(t *testing.T) {
+	ctx := testutil.TestContext(t)
+
+	packageDir := t.TempDir()
+	source := filepath.Join(packageDir, "source.txt")
+	require.NoError(t, os.WriteFile(source, []byte("{{ .Values.message }}"), 0o600))
+
+	target := filepath.Join(t.TempDir(), "rendered.txt")
+	pkg := v1alpha1.ZarfPackage{
+		APIVersion: v1alpha1.APIVersion,
+		Kind:       v1alpha1.ZarfPackageConfig,
+		Metadata:   v1alpha1.ZarfMetadata{Name: "dev-deploy-values"},
+		Components: []v1alpha1.ZarfComponent{{
+			Name:     "values",
+			Required: helpers.BoolPtr(true),
+			Files: []v1alpha1.ZarfFile{{
+				Source:   source,
+				Target:   target,
+				Template: helpers.BoolPtr(true),
+			}},
+		}},
+	}
+	b, err := goyaml.Marshal(pkg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(packageDir, layout.ZarfYAML), b, 0o600))
+
+	err = DevDeploy(ctx, packageDir, DevDeployOptions{
+		CachePath: filepath.Join(packageDir, "cache"),
+		Values:    value.Values{"message": "from-deploy-values"},
+	})
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "from-deploy-values\n", string(contents))
 }


### PR DESCRIPTION
## Description

Add values flags to dev deploy. Purposely didn't add skip schema validation, as I feel at dev time the user should instead change their schema. 

Also adding the flags to `zarf init`

## Related Issue

Fixes #5231

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
