### PR TITLE
fix(sbom)!: correct image detection for SBOM generation

### DIFF
--- a/src/pkg/images/common.go
+++ b/src/pkg/images/common.go
@@ -45,6 +45,8 @@ const (
 	DockerMediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
 	// DockerMediaTypeManifestList is the legacy Docker manifest list, replaced by OCI index
 	DockerMediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+	// DockerMediaTypeConfig is the legacy Docker image configuration format.
+	DockerMediaTypeConfig = "application/vnd.docker.container.image.v1+json"
 )
 
 // Legacy Docker image layers
@@ -64,14 +66,34 @@ func isLayer(mediaType string) bool {
 	return false
 }
 
-// OnlyHasImageLayers returns true when an OCI manifest only contains container image layers.
-func OnlyHasImageLayers(manifest ocispec.Manifest) bool {
+func isEmptyDescriptor(descriptor ocispec.Descriptor) bool {
+	return descriptor.MediaType == ocispec.DescriptorEmptyJSON.MediaType &&
+		descriptor.Digest == ocispec.DescriptorEmptyJSON.Digest &&
+		descriptor.Size == ocispec.DescriptorEmptyJSON.Size
+}
+
+// onlyHasImageLayers returns true when an OCI manifest only contains container image layers.
+func onlyHasImageLayers(manifest ocispec.Manifest) bool {
+	if len(manifest.Layers) == 0 {
+		return false
+	}
+
 	for _, layer := range manifest.Layers {
-		if !isLayer(string(layer.MediaType)) {
+		if isEmptyDescriptor(layer) || !isLayer(string(layer.MediaType)) {
 			return false
 		}
 	}
 	return true
+}
+
+// IsContainerImage reports whether an OCI manifest describes a container image.
+func IsContainerImage(manifest ocispec.Manifest) bool {
+	switch manifest.Config.MediaType {
+	case ocispec.MediaTypeImageConfig, DockerMediaTypeConfig:
+		return onlyHasImageLayers(manifest)
+	default:
+		return false
+	}
 }
 
 // IsManifest reports whether the media type represents an OCI manifest.

--- a/src/pkg/images/common_test.go
+++ b/src/pkg/images/common_test.go
@@ -121,3 +121,56 @@ func TestInspectIndex(t *testing.T) {
 		require.ElementsMatch(t, []string{"amd64"}, platforms)
 	})
 }
+
+func TestIsContainerImage(t *testing.T) {
+	tests := map[string]struct {
+		manifest ocispec.Manifest
+		isImage  bool
+	}{
+		"accepts OCI image": {
+			manifest: ocispec.Manifest{
+				Config: ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig},
+				Layers: []ocispec.Descriptor{{MediaType: ocispec.MediaTypeImageLayerGzip}},
+			},
+			isImage: true,
+		},
+		"accepts docker image": {
+			manifest: ocispec.Manifest{
+				Config: ocispec.Descriptor{MediaType: DockerMediaTypeConfig},
+				Layers: []ocispec.Descriptor{{MediaType: DockerLayer}},
+			},
+			isImage: true,
+		},
+		"rejects image config without layers": {
+			manifest: ocispec.Manifest{
+				Config: ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig},
+			},
+			isImage: false,
+		},
+		"rejects OCI empty descriptor layer": {
+			manifest: ocispec.Manifest{
+				Config: ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig},
+				Layers: []ocispec.Descriptor{ocispec.DescriptorEmptyJSON},
+			},
+			isImage: false,
+		},
+		"rejects image layer with unknown config mediatype": {
+			manifest: ocispec.Manifest{
+				Config: ocispec.Descriptor{
+					MediaType: "application/vnd.unknown.config.v1+json",
+				},
+				Layers: []ocispec.Descriptor{{
+					MediaType: ocispec.MediaTypeImageLayerGzip,
+				}},
+			},
+			isImage: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, IsContainerImage(test.manifest), test.isImage)
+		})
+	}
+}

--- a/src/pkg/packager/assemble/sbom.go
+++ b/src/pkg/packager/assemble/sbom.go
@@ -439,7 +439,7 @@ func imageHasOnlyContainerLayers(img v1.Image) (bool, error) {
 	if err := json.Unmarshal(raw, &manifest); err != nil {
 		return false, err
 	}
-	return images.OnlyHasImageLayers(manifest), nil
+	return images.IsContainerImage(manifest), nil
 }
 
 func collectPlatformImagesFromIndex(parent v1.ImageIndex, indexDigest v1.Hash, ref string) ([]platformImage, error) {
@@ -473,7 +473,7 @@ func collectPlatformImagesFromIndex(parent v1.ImageIndex, indexDigest v1.Hash, r
 			if err := json.Unmarshal(rawManifest, &childManifest); err != nil {
 				return nil, fmt.Errorf("failed to parse platform manifest for %s: %w", ref, err)
 			}
-			if !images.OnlyHasImageLayers(childManifest) {
+			if !images.IsContainerImage(childManifest) {
 				continue
 			}
 			platformImages = append(platformImages, platformImage{

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -5,13 +5,19 @@
 package test
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2"
 
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/test/testutil"
@@ -72,4 +78,84 @@ func TestCreateSBOM(t *testing.T) {
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.27.3-rootless.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-zarf-component-k3s.html"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "zarf-component-k3s.json"))
+}
+
+func TestCreateSBOMSkipsOCIArtifact(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	registryURL := testutil.SetupInMemoryRegistryDynamic(ctx, t)
+
+	// Create a runtime image with a single layer that is a tar archive
+	runtimeRef := fmt.Sprintf("%s/runtime:latest", registryURL)
+	runtimeRepo := testutil.NewRepo(t, runtimeRef)
+	tarLayer, gzipLayer := createGzipTarLayer(t)
+	runtimeLayer := testutil.PushBlob(ctx, t, runtimeRepo, ocispec.MediaTypeImageLayerGzip, gzipLayer)
+	runtimeConfig := testutil.PushBlob(ctx, t, runtimeRepo, ocispec.MediaTypeImageConfig, fmt.Appendf(nil, `{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[%q]}}`, digest.FromBytes(tarLayer)))
+	runtimeManifest := testutil.PushManifest(ctx, t, runtimeRepo, runtimeConfig, []ocispec.Descriptor{runtimeLayer})
+	require.NoError(t, runtimeRepo.Tag(ctx, runtimeManifest, "latest"))
+
+	// Create an OCI artifact with a single layer that is not a tar archive
+	artifactRef := fmt.Sprintf("%s/data-artifact:latest", registryURL)
+	artifactRepo := testutil.NewRepo(t, artifactRef)
+	artifactLayer, err := oras.PushBytes(ctx, artifactRepo, ocispec.MediaTypeImageLayer, []byte("this payload is not a tar archive"))
+	require.NoError(t, err)
+	artifactManifest, err := oras.PackManifest(ctx, artifactRepo, oras.PackManifestVersion1_0, "application/vnd.example.data.config.v1+json", oras.PackManifestOptions{
+		Layers: []ocispec.Descriptor{artifactLayer},
+	})
+	require.NoError(t, err)
+	require.NoError(t, artifactRepo.Tag(ctx, artifactManifest, "latest"))
+
+	// Create a Zarf package that includes both the runtime image and the OCI artifact
+	pkgDir := t.TempDir()
+	pkgDefinition := fmt.Sprintf(`kind: ZarfPackageConfig
+metadata:
+  name: sbom-oci-artifact
+  version: 0.0.1
+components:
+  - name: images
+    required: true
+    images:
+      - %s
+      - %s
+`, runtimeRef, artifactRef)
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "zarf.yaml"), []byte(pkgDefinition), 0o600))
+
+	// Create the Zarf package and verify that the SBOM is only generated for the runtime image and not for the OCI artifact
+	buildDir := t.TempDir()
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", pkgDir, "-o", buildDir, "--plain-http", "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+	require.Contains(t, stdErr, "creating image SBOM reference="+runtimeRef)
+	require.NotContains(t, stdErr, "creating image SBOM reference="+artifactRef)
+
+	// Verify that the SBOM for the runtime image exists and the SBOM for the OCI artifact does not exist
+	pkgPath := filepath.Join(buildDir, fmt.Sprintf("zarf-package-sbom-oci-artifact-%s-0.0.1.tar.zst", e2e.Arch))
+	pkgLayout, err := layout.LoadFromTar(ctx, pkgPath, layout.PackageLayoutOptions{})
+	require.NoError(t, err)
+	sbomDir := t.TempDir()
+	require.NoError(t, pkgLayout.GetSBOM(ctx, sbomDir))
+	require.FileExists(t, filepath.Join(sbomDir, normalizeSBOMName(runtimeRef)+".json"))
+	require.NoFileExists(t, filepath.Join(sbomDir, normalizeSBOMName(artifactRef)+".json"))
+}
+
+func createGzipTarLayer(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	var tarBuffer bytes.Buffer
+	tarWriter := tar.NewWriter(&tarBuffer)
+	contents := []byte("hello from a container image\n")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{Name: "hello.txt", Mode: 0o644, Size: int64(len(contents))}))
+	_, err := tarWriter.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+
+	var gzipBuffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&gzipBuffer)
+	_, err = gzipWriter.Write(tarBuffer.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	return tarBuffer.Bytes(), gzipBuffer.Bytes()
+}
+
+func normalizeSBOMName(identifier string) string {
+	return strings.NewReplacer("/", "_", ":", "_").Replace(identifier)
 }


### PR DESCRIPTION
## Description

This PR creates a more restrictive function, `IsContainerImage` to verify an OCI manifest has a known container `Config` `MediaType` _as well as_ `Layers` composed entirely of known image layer `MediaType`s.

~~I intentionally did not alter the existing `OnlyHasImageLayers` function because it's part of the public API surface and the new scope doesn't quite fit the naming.~~ The previous `OnlyHasImageLayers` function has been privatized per @AustinAbro321.

I also added a regression test to the existing SBOM creation e2e suite. Please let me know if there's a more appropriate place for it.

## Related Issue

Fixes #4756 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
