### PR TITLE
fix: packager.Remove() uses ZarfDefaultTimeout as default timeout

### DIFF
--- a/src/pkg/packager/remove.go
+++ b/src/pkg/packager/remove.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/zarf-dev/zarf/src/api"
+	"github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/internal/packager/helm"
 	"github.com/zarf-dev/zarf/src/internal/packager/requirements"
 	"github.com/zarf-dev/zarf/src/pkg/feature"
@@ -31,7 +32,8 @@ import (
 
 // RemoveOptions are the options for Remove.
 type RemoveOptions struct {
-	Cluster           *cluster.Cluster
+	Cluster *cluster.Cluster
+	// Timeout for Helm operations
 	Timeout           time.Duration
 	NamespaceOverride string
 	SkipVersionCheck  bool
@@ -49,6 +51,10 @@ func Remove(ctx context.Context, definition api.PackageDefinition, opts RemoveOp
 		if err := requirements.ValidateVersionRequirements(pkg); err != nil {
 			return fmt.Errorf("%w If you cannot upgrade Zarf you may skip this check with --skip-version-check. Unexpected behavior or errors may occur", err)
 		}
+	}
+
+	if opts.Timeout == 0 {
+		opts.Timeout = config.ZarfDefaultTimeout
 	}
 
 	definition, err := filters.Apply(definition, filters.ByLocalOS(runtime.GOOS))


### PR DESCRIPTION
## Description

Update `Remove` function of package `packager` to time out at  `ZarfDefaultTimeout` (15 minutes)
* `Remove` checks for unset value of `opts.Timeout`, and sets to `ZarfDefaultTimeout` if found
* Add doc comment to `RemoveOptions.Timeout` corresponding to that of `DeployOptions.Timeout`

## Related Issue

Fixes #5252
