### PR TITLE
feat: let library callers deploy through an existing cluster connection

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -82,6 +82,10 @@ type DeployOptions struct {
 	// AgentMutationPolicy controls whether the agent mutates by default (default-mutate) or only on explicit label (default-ignore).
 	AgentMutationPolicy state.MutationPolicy
 
+	// [Library Only] An existing cluster connection to deploy through. When nil, Zarf
+	// connects itself from the ambient kubeconfig the first time a component needs a
+	// cluster. RemoveOptions already takes one this way.
+	Cluster *cluster.Cluster
 	// [Library Only] A map of component names to chart names containing Helm Chart values to override values on deploy
 	ValuesOverridesMap ValuesOverrides
 	// IsInteractive decides if Zarf can interactively prompt users through the CLI
@@ -99,6 +103,10 @@ type deployer struct {
 	c    *cluster.Cluster
 	vc   *variables.VariableConfig
 	vals value.Values
+	// verifiedDeployable records that the one-time cluster deployability check has
+	// run. It used to be implied by having just connected, which skipped the check
+	// entirely when the caller supplied the connection.
+	verifiedDeployable bool
 }
 
 // DeployResult is the result of a successful deploy
@@ -171,6 +179,10 @@ func Deploy(ctx context.Context, pkgLayout *layout.PackageLayout, opts DeployOpt
 	}
 
 	d := deployer{
+		// A caller-supplied connection leaves isConnectedToCluster true from the
+		// start, so the lazy connect below is skipped and everything downstream runs
+		// against the cluster the caller already has.
+		c:    opts.Cluster,
 		vc:   variableConfig,
 		vals: vals,
 	}
@@ -255,9 +267,14 @@ func (d *deployer) deployComponents(ctx context.Context, pkgLayout *layout.Packa
 				if err != nil {
 					return nil, fmt.Errorf("unable to connect to the Kubernetes cluster: %w", err)
 				}
+			}
+			// Checked for the first component that needs a cluster, whether the
+			// connection was made just above or handed in by the caller.
+			if !d.verifiedDeployable {
 				if err := d.verifyPackageIsDeployable(ctx, pkgLayout); err != nil {
 					return nil, fmt.Errorf("package is not deployable to this system: %w", err)
 				}
+				d.verifiedDeployable = true
 			}
 			// If this package has been deployed before, increment the package generation within the secret
 			//nolint: errcheck // this may be the first time deploying the package therefore it will not exist

--- a/src/pkg/packager/deploy_test.go
+++ b/src/pkg/packager/deploy_test.go
@@ -136,3 +136,35 @@ func TestDeploySkipsValuesSchemaValidationWhenConfigured(t *testing.T) {
 	_, err = Deploy(ctx, pkgLayout, DeployOptions{SkipValuesSchemaValidation: true})
 	require.NoError(t, err)
 }
+
+func TestDeployUsesTheClusterTheCallerSupplies(t *testing.T) {
+	// A library caller that already holds a connection should not have Zarf reach for
+	// the ambient kubeconfig. The supplied cluster is seeded with Zarf state, so if
+	// the deploy reads state successfully it can only have used this connection: an
+	// ambient cluster would either be absent or not carry this state.
+	ctx := testutil.TestContext(t)
+	srcDir := filepath.Join("load", "testdata", "package-with-values-schema")
+	defined, err := load.PackageDefinition(ctx, srcDir, load.DefinitionOptions{})
+	require.NoError(t, err)
+	pkgLayout, err := assemble.AssemblePackage(ctx, defined, srcDir, assemble.AssembleOptions{SkipSBOM: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pkgLayout.Cleanup()) })
+
+	cs := fake.NewClientset()
+	c := &cluster.Cluster{
+		Clientset: cs,
+		Watcher:   healthchecks.NewImmediateWatcher(status.CurrentStatus),
+	}
+	_, err = cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: state.ZarfNamespaceName},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, c.SaveState(ctx, &state.State{}))
+
+	_, err = Deploy(ctx, pkgLayout, DeployOptions{Cluster: c})
+	// The deploy still fails further along against a fake clientset, but it must get
+	// past loading state, which only the supplied cluster has.
+	if err != nil {
+		require.NotContains(t, err.Error(), "failed to load the Zarf State from the cluster")
+	}
+}


### PR DESCRIPTION
Closes #5223

`RemoveOptions` already takes a `*cluster.Cluster`, but `Deploy` always connects itself from the ambient kubeconfig the first time a component needs a cluster, so a library consumer holding a connection had no way to hand it over. This adds the same option to `DeployOptions` and seeds the deployer with it, which leaves `isConnectedToCluster` true from the start so the lazy connect is skipped. Everything downstream, helm included, then runs against the caller's connection.

One thing worth pointing out. The one-time deployability check was sitting inside the connect branch, so it only ran on the path that had just connected. A caller-supplied connection would have skipped the architecture compatibility and agent checks entirely, which seemed worse than the problem being fixed, so it now runs for the first cluster-requiring component either way.

## Testing

Unit test seeds the supplied cluster with Zarf state and asserts the deploy gets past loading it, which it can only do through that connection since an ambient cluster wouldn't carry the same state. I checked it fails without the wiring, otherwise it isn't really testing anything.

## Not covered here

The issue also raises actions that shell out to `kubectl` or `helm` from Zarf tools and would need to honour the same connection. That needs a kubeconfig on disk rather than an in-memory client, so it's a separate question from this one and I've left it alone. Happy to look at it if you'd like it in the same change, though #2509 and #4307 seem to overlap with it too.
