### PR TITLE
feat(zoci): add transport parameter to NewRemoteWithOptions

### DIFF
--- a/src/pkg/zoci/common.go
+++ b/src/pkg/zoci/common.go
@@ -6,7 +6,9 @@ package zoci
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"time"
 
@@ -66,6 +68,9 @@ type PublishOptions struct {
 type RemoteClientOptions struct {
 	// CachePath stores OCI layers locally when non-empty.
 	CachePath string
+	// Transport configures HTTP transport behavior such as proxies and mTLS.
+	// It is cloned before use and is never modified.
+	Transport *http.Transport
 	types.RemoteOptions
 }
 
@@ -87,6 +92,9 @@ func NewRemoteWithOptions(ctx context.Context, url string, platform ocispec.Plat
 	modifiers := []oci.Modifier{
 		oci.WithInsecureSkipVerify(options.InsecureSkipTLSVerify),
 	}
+	if options.Transport != nil {
+		modifiers = append(modifiers, oci.WithTransport(options.Transport))
+	}
 	if options.CachePath != "" {
 		cacheModifier, err := GetOCICacheModifier(ctx, options.CachePath)
 		if err != nil {
@@ -102,9 +110,13 @@ func NewRemoteWithOptions(ctx context.Context, url string, platform ocispec.Plat
 
 	// negotiate if required after the remote has been instantiated for any canonical updates (docker.io etc)
 	if options.PlainHTTP {
-		plainHTTP, err := ocischeme.From(ctx).UsePlainHTTP(ctx, remote.Repo().Reference.Registry, ocischeme.ProbeOptions{
+		probeOptions := ocischeme.ProbeOptions{
 			InsecureSkipTLSVerify: options.InsecureSkipTLSVerify,
-		})
+		}
+		if options.Transport != nil {
+			probeOptions.Transport = transportForProbe(options.Transport, options.InsecureSkipTLSVerify)
+		}
+		plainHTTP, err := ocischeme.From(ctx).UsePlainHTTP(ctx, remote.Repo().Reference.Registry, probeOptions)
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve registry transport: %w", err)
 		}
@@ -112,6 +124,22 @@ func NewRemoteWithOptions(ctx context.Context, url string, platform ocispec.Plat
 	}
 
 	return remote, nil
+}
+
+// transportForProbe returns a copy of transport with the same TLS verification
+// setting that oci.WithInsecureSkipVerify applies to the remote client.
+func transportForProbe(transport *http.Transport, insecureSkipTLSVerify bool) *http.Transport {
+	if transport == nil {
+		return nil
+	}
+	probeTransport := transport.Clone()
+	if probeTransport.TLSClientConfig == nil {
+		probeTransport.TLSClientConfig = &tls.Config{}
+	} else {
+		probeTransport.TLSClientConfig = probeTransport.TLSClientConfig.Clone()
+	}
+	probeTransport.TLSClientConfig.InsecureSkipVerify = insecureSkipTLSVerify //nolint:gosec // Controlled by --insecure-skip-tls-verify.
+	return probeTransport
 }
 
 func newRemote(ctx context.Context, url string, platform ocispec.Platform, mods ...oci.Modifier) (*Remote, error) {

--- a/src/pkg/zoci/common_test.go
+++ b/src/pkg/zoci/common_test.go
@@ -75,3 +75,46 @@ func TestNewRemoteWithOptionsTransportNegotiation(t *testing.T) {
 		})
 	}
 }
+
+func TestNewRemoteWithOptionsUsesCustomTransportForNegotiation(t *testing.T) {
+	newServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	t.Run("trusted TLS configuration", func(t *testing.T) {
+		server := newServer(t)
+		transport, ok := server.Client().Transport.(*http.Transport)
+		require.True(t, ok)
+
+		remote, err := NewRemoteWithOptions(context.Background(), "oci://"+strings.TrimPrefix(server.URL, "https://")+"/test:latest", oci.PlatformForArch("amd64"), RemoteClientOptions{
+			Transport: transport,
+			RemoteOptions: types.RemoteOptions{
+				PlainHTTP: true,
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, remote.Repo().PlainHTTP)
+	})
+
+	t.Run("insecure TLS option", func(t *testing.T) {
+		server := newServer(t)
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		require.True(t, ok)
+		transport := defaultTransport.Clone()
+
+		remote, err := NewRemoteWithOptions(context.Background(), "oci://"+strings.TrimPrefix(server.URL, "https://")+"/test:latest", oci.PlatformForArch("amd64"), RemoteClientOptions{
+			Transport: transport,
+			RemoteOptions: types.RemoteOptions{
+				PlainHTTP:             true,
+				InsecureSkipTLSVerify: true,
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, remote.Repo().PlainHTTP)
+	})
+}


### PR DESCRIPTION
## Description

NewRemote is deprecated in favor of NewRemoteWithOptions however users that need send in a custom transport cannot switch over

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
