### PR TITLE
fix: pass remote options when loading OCI init packages

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -225,6 +225,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		Filter:               filter,
 		Architecture:         config.GetArch(),
 		CachePath:            cachePath,
+		RemoteOptions:        defaultRemoteOptions(),
 	}
 	pkgLayout, err := packager.LoadPackage(ctx, packageSource, loadOpt)
 	if err != nil {

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -86,7 +86,16 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 		"inspect digest should return the same value for the tarball and the OCI source it was published from")
 }
 
-func (suite *PullInspectTestSuite) Test_1_Remote_Inspect() {
+func (suite *PullInspectTestSuite) Test_1_Init_Loads_OCI_Over_Plain_HTTP() {
+	suite.T().Log("E2E: Init package load oci:// over plain HTTP")
+
+	ref := fmt.Sprintf("oci://%s/simple-package:0.0.1", suite.Reference.String())
+	_, stdErr, err := e2e.Zarf(suite.T(), "init", ref, "--plain-http")
+	suite.Error(err, stdErr)
+	suite.Contains(stdErr, `zarf init can only deploy packages of kind "ZarfInitConfig"`)
+}
+
+func (suite *PullInspectTestSuite) Test_2_Remote_Inspect() {
 	suite.T().Log("E2E: Package Inspect oci://")
 
 	// Test inspect w/ bad ref.


### PR DESCRIPTION
## Description

Passes the configured remote options when loading an OCI init package, so `--plain-http` is respected. Adds a test covering this case.

## Related Issue

Fixes #5259 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
