### PR TITLE
feat: warn on image push failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,16 @@ destroy: ## Run `zarf destroy` on the current cluster
 	rm -fr build
 
 # Note: the path to the main.go file is not used due to https://github.com/golang/go/issues/51831#issuecomment-1074188363
+.PHONY: vendor
+vendor: vendor/modules.txt ## Update vendored Go dependencies when module metadata changes
+
+vendor/modules.txt: go.mod go.sum
+	go mod vendor
+
 .PHONY: build
 build: ## Build the Zarf CLI for the machines OS and architecture
 	go mod tidy
-	go mod vendor
+	$(MAKE) vendor
 	$(MAKE) $(BUILD_CLI_FOR_SYSTEM)
 
 build-cli-linux-amd: ## Build the Zarf CLI for Linux on AMD64

--- a/src/pkg/images/push.go
+++ b/src/pkg/images/push.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	defaultRetries         = 3
-	imagePushRetryAttempts = 2
+	defaultComponentPushAttempts = 3
+	imagePushAttempts            = 2
 )
 
 // PushOptions is the configuration for pushing images.
@@ -60,7 +60,7 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 		return fmt.Errorf("registry uses Zarf-managed mTLS, but no cluster is available to obtain its client certificate")
 	}
 	if cfg.Retries < 1 {
-		cfg.Retries = defaultRetries
+		cfg.Retries = defaultComponentPushAttempts
 	}
 	if cfg.ResponseHeaderTimeout <= 0 {
 		cfg.ResponseHeaderTimeout = 10 * time.Second
@@ -184,14 +184,14 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 				err = retry.Do(
 					func() error { return pushImage(img, offlineNameCRC) },
 					retry.OnRetry(func(attempt uint, err error) {
-						if attempt == imagePushRetryAttempts-1 {
+						if attempt == imagePushAttempts-1 {
 							return
 						}
 						ociConcurrency = 1
 						l.Warn("retrying image push", "error", err, "concurrency", ociConcurrency)
 					}),
 					retry.Context(ctx),
-					retry.Attempts(imagePushRetryAttempts),
+					retry.Attempts(imagePushAttempts),
 					retry.Delay(500*time.Millisecond),
 					retry.LastErrorOnly(true),
 				)
@@ -210,14 +210,14 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 			err = retry.Do(
 				func() error { return pushImage(img, offlineName) },
 				retry.OnRetry(func(attempt uint, err error) {
-					if attempt == imagePushRetryAttempts-1 {
+					if attempt == imagePushAttempts-1 {
 						return
 					}
 					ociConcurrency = 1
 					l.Warn("retrying image push", "error", err, "concurrency", ociConcurrency)
 				}),
 				retry.Context(ctx),
-				retry.Attempts(imagePushRetryAttempts),
+				retry.Attempts(imagePushAttempts),
 				retry.Delay(500*time.Millisecond),
 				retry.LastErrorOnly(true),
 			)

--- a/src/pkg/images/push.go
+++ b/src/pkg/images/push.go
@@ -28,7 +28,10 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/transform"
 )
 
-const defaultRetries = 3
+const (
+	defaultRetries         = 3
+	imagePushRetryAttempts = 2
+)
 
 // PushOptions is the configuration for pushing images.
 type PushOptions struct {
@@ -180,13 +183,17 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 
 				err = retry.Do(
 					func() error { return pushImage(img, offlineNameCRC) },
-					retry.OnRetry(func(_ uint, err error) {
+					retry.OnRetry(func(attempt uint, err error) {
+						if attempt == imagePushRetryAttempts-1 {
+							return
+						}
 						ociConcurrency = 1
-						l.Debug("retrying image push", "error", err, "concurrency", ociConcurrency)
+						l.Warn("retrying image push", "error", err, "concurrency", ociConcurrency)
 					}),
 					retry.Context(ctx),
-					retry.Attempts(2),
+					retry.Attempts(imagePushRetryAttempts),
 					retry.Delay(500*time.Millisecond),
+					retry.LastErrorOnly(true),
 				)
 				if err != nil {
 					return err
@@ -202,13 +209,17 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 
 			err = retry.Do(
 				func() error { return pushImage(img, offlineName) },
-				retry.OnRetry(func(_ uint, err error) {
+				retry.OnRetry(func(attempt uint, err error) {
+					if attempt == imagePushRetryAttempts-1 {
+						return
+					}
 					ociConcurrency = 1
-					l.Debug("retrying image push", "error", err, "concurrency", ociConcurrency)
+					l.Warn("retrying image push", "error", err, "concurrency", ociConcurrency)
 				}),
 				retry.Context(ctx),
-				retry.Attempts(2),
+				retry.Attempts(imagePushRetryAttempts),
 				retry.Delay(500*time.Millisecond),
+				retry.LastErrorOnly(true),
 			)
 			if err != nil {
 				return err
@@ -217,11 +228,13 @@ func Push(ctx context.Context, imageList []transform.Image, sourceDirectory stri
 			pushed = append(pushed, img)
 		}
 		return nil
-	}, retry.Context(ctx), retry.Attempts(uint(cfg.Retries)), retry.Delay(500*time.Millisecond), retry.OnRetry(func(attempt uint, _ error) {
-		if uint(cfg.Retries) > 2 && attempt == uint(cfg.Retries)-2 {
-			cfg.ResponseHeaderTimeout = 60 * time.Second // this should really never happen
+	}, retry.Context(ctx), retry.Attempts(uint(cfg.Retries)), retry.Delay(500*time.Millisecond), retry.LastErrorOnly(true), retry.OnRetry(func(attempt uint, err error) {
+		if attempt == uint(cfg.Retries)-1 {
+			return
 		}
-		l.Debug("retrying component image(s) push", "responseTimeout", cfg.ResponseHeaderTimeout)
+		// S3-backed registries may take longer to finalize an upload and respond.
+		cfg.ResponseHeaderTimeout = 60 * time.Second
+		l.Warn("retrying component image(s) push", "error", err, "responseTimeout", cfg.ResponseHeaderTimeout)
 	}))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

This implements warnings on image push failures as they happen, then only shows the last error on failure. 

Additionally, this sets `responseHeaderTimeout` to a minute after the first failure since we've heard of failures #5267

(I'm also sneaking in a makefile change because running `go mod vendor` every time takes too long even when there are no changes)

## Related Issue

Fixes #4751 

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
