### PR TITLE
refactor(state): move agent information into a sub-struct

### DIFF
--- a/src/cmd/initialize.go
+++ b/src/cmd/initialize.go
@@ -382,9 +382,9 @@ func validateExistingStateMatchesInput(ctx context.Context, registryInfo state.R
 		return fmt.Errorf("cannot change artifact server information after initial init, to update run `zarf tools update-creds artifact`")
 	}
 	if agentTLS != nil {
-		if !bytes.Equal(agentTLS.CA, s.AgentTLS.CA) ||
-			!bytes.Equal(agentTLS.Cert, s.AgentTLS.Cert) ||
-			!bytes.Equal(agentTLS.Key, s.AgentTLS.Key) {
+		if !bytes.Equal(agentTLS.CA, s.AgentInfo.TLS.CA) ||
+			!bytes.Equal(agentTLS.Cert, s.AgentInfo.TLS.Cert) ||
+			!bytes.Equal(agentTLS.Key, s.AgentInfo.TLS.Key) {
 			return fmt.Errorf("cannot change agent TLS certificates after initial init, to update run `zarf tools update-creds agent`")
 		}
 	}

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -340,7 +340,7 @@ func (o *updateCredsOptions) run(cmd *cobra.Command, args []string, v *viper.Vip
 	}
 
 	if services.Has(state.AgentKey) {
-		if oldState.AgentTLSUserProvided && o.agentTLSCAPath == "" {
+		if oldState.AgentInfo.TLSUserProvided && o.agentTLSCAPath == "" {
 			return fmt.Errorf("current agent TLS certificates are user-provided; provide --agent-tls-ca, --agent-tls-cert, and --agent-tls-key to update them, or explicitly define service list without `agent`")
 		}
 		if o.agentTLSCAPath != "" {
@@ -486,9 +486,9 @@ func printCredentialUpdates(ctx context.Context, oldState *state.State, newState
 		l.Info("artifact server push token", "changed", oA.PushToken != nA.PushToken)
 	}
 	if services.Has(state.AgentKey) {
-		oT := oldState.AgentTLS
-		nT := newState.AgentTLS
-		l.Info("agent TLS source", "userProvided", newState.AgentTLSUserProvided)
+		oT := oldState.AgentInfo.TLS
+		nT := newState.AgentInfo.TLS
+		l.Info("agent TLS source", "userProvided", newState.AgentInfo.TLSUserProvided)
 		l.Info("agent certificate authority", "changed", string(oT.CA) != string(nT.CA))
 		l.Info("agent public certificate", "changed", string(oT.Cert) != string(nT.Cert))
 		l.Info("agent private key", "changed", string(oT.Key) != string(nT.Key))
@@ -801,7 +801,7 @@ func (o *updateAgentCredsOptions) run(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := state.MergeOptions{Services: state.NewServiceSet(state.AgentKey)}
-	if oldState.AgentTLSUserProvided && o.agentTLSCAPath == "" {
+	if oldState.AgentInfo.TLSUserProvided && o.agentTLSCAPath == "" {
 		return fmt.Errorf("current agent TLS certificates are user-provided; provide --agent-tls-ca, --agent-tls-cert, and --agent-tls-key to update them")
 	}
 	if o.agentTLSCAPath != "" {

--- a/src/cmd/zarf_tools.go
+++ b/src/cmd/zarf_tools.go
@@ -796,7 +796,7 @@ func (o *updateAgentCredsOptions) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if !oldState.AgentIsConfigured() {
+	if !oldState.AgentInfo.IsConfigured() {
 		return errors.New("no agent is configured in the Zarf state; nothing to update")
 	}
 

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -178,7 +178,7 @@ func (r *renderer) adoptAndUpdateNamespaces(ctx context.Context) error {
 }
 
 func (r *renderer) shouldAddAgentIgnoreLabels() bool {
-	return r.connectedDeploy && r.state != nil && r.state.AgentIsConfigured()
+	return r.connectedDeploy && r.state != nil && r.state.AgentInfo.IsConfigured()
 }
 
 func (r *renderer) editHelmResources(ctx context.Context, resources []releaseutil.Manifest, finalManifestsOutput *bytes.Buffer) error {

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -167,7 +167,11 @@ func TestRendererShouldAddAgentIgnoreLabels(t *testing.T) {
 			renderer: renderer{
 				connectedDeploy: true,
 				state: &state.State{
-					AgentInfo: state.AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}},
+					AgentInfo: state.AgentInfo{TLS: pki.GeneratedPKI{
+						CA:   []byte("ca"),
+						Cert: []byte("cert"),
+						Key:  []byte("key"),
+					}},
 				},
 			},
 			expected: true,

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -167,7 +167,7 @@ func TestRendererShouldAddAgentIgnoreLabels(t *testing.T) {
 			renderer: renderer{
 				connectedDeploy: true,
 				state: &state.State{
-					AgentTLS: pki.GeneratedPKI{Cert: []byte("cert")},
+					AgentInfo: state.AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}},
 				},
 			},
 			expected: true,
@@ -184,7 +184,7 @@ func TestRendererShouldAddAgentIgnoreLabels(t *testing.T) {
 			name: "airgap deploy with configured agent",
 			renderer: renderer{
 				state: &state.State{
-					AgentTLS: pki.GeneratedPKI{Cert: []byte("cert")},
+					AgentInfo: state.AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}},
 				},
 			},
 			expected: false,

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -73,11 +73,11 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 		// Don't template component-specific variables for every component
 		switch componentName {
 		case "zarf-agent":
-			agentTLS := s.AgentTLS
+			agentTLS := s.AgentInfo.TLS
 			builtinMap["AGENT_CRT"] = base64.StdEncoding.EncodeToString(agentTLS.Cert)
 			builtinMap["AGENT_KEY"] = base64.StdEncoding.EncodeToString(agentTLS.Key)
 			builtinMap["AGENT_CA"] = base64.StdEncoding.EncodeToString(agentTLS.CA)
-			builtinMap["AGENT_MUTATION_POLICY"] = string(s.AgentMutationPolicy)
+			builtinMap["AGENT_MUTATION_POLICY"] = string(s.AgentInfo.MutationPolicy)
 
 		case "zarf-seed-registry", "zarf-registry":
 			builtinMap["SEED_REGISTRY"] = state.LocalhostRegistryAddress(s.IPFamily, s.InjectorInfo.Port)

--- a/src/internal/packager/template/template.go
+++ b/src/internal/packager/template/template.go
@@ -41,6 +41,7 @@ func GetZarfTemplates(ctx context.Context, componentName string, s *state.State)
 	templateMap = make(map[string]*variables.TextTemplate)
 
 	if s != nil {
+		s.Reconcile()
 		regInfo := s.RegistryInfo
 		gitInfo := s.GitServer
 

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -295,7 +295,7 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 				return nil, err
 			}
 		}
-		if opts.InternalServices.Has(state.AgentKey) && !s.AgentIsConfigured() {
+		if opts.InternalServices.Has(state.AgentKey) && !s.AgentInfo.IsConfigured() {
 			if err := c.initAgent(ctx, s, opts.AgentTLS); err != nil {
 				return nil, err
 			}

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -527,8 +527,8 @@ func (c *Cluster) LoadState(ctx context.Context) (*state.State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
-	// Reconcile Port/NodePort for backwards compatibility with older state
-	s.RegistryInfo.ReconcilePort()
+	// Reconcile compatibility fields from older state versions.
+	s.Reconcile()
 	// If registry mode is not set then this is an old Zarf cluster and we can assume it's either external or nodeport
 	if s.RegistryInfo.RegistryMode == "" {
 		if s.RegistryInfo.IsInternal() {
@@ -542,11 +542,8 @@ func (c *Cluster) LoadState(ctx context.Context) (*state.State, error) {
 
 // SaveState takes a given state.State and persists it to k8s Cluster secrets.
 func (c *Cluster) SaveState(ctx context.Context, s *state.State) error {
-	// Sync NodePort from Port so older Zarf versions can read the state.
-	s.RegistryInfo.ReconcilePort()
-	// Sync deprecated agent fields so older Zarf versions can read the state.
-	// FIXME: likely unnecessary
-	s.ReconcileAgentInfo()
+	// Sync compatibility fields so older Zarf versions can read the state.
+	s.Reconcile()
 	state.DebugPrint(ctx, s)
 
 	data, err := json.Marshal(&s)

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -362,7 +362,7 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 		s.InjectorInfo.Port = opts.InjectorPort
 	}
 
-	if opts.AgentMutationPolicy != "" {
+	if s.AgentInfo.IsConfigured() && opts.AgentMutationPolicy != "" {
 		agentInfo := s.AgentInfo
 		agentInfo.MutationPolicy = opts.AgentMutationPolicy
 		s.SetAgentInfo(agentInfo)

--- a/src/pkg/cluster/cluster.go
+++ b/src/pkg/cluster/cluster.go
@@ -363,7 +363,9 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 	}
 
 	if opts.AgentMutationPolicy != "" {
-		s.AgentMutationPolicy = opts.AgentMutationPolicy
+		agentInfo := s.AgentInfo
+		agentInfo.MutationPolicy = opts.AgentMutationPolicy
+		s.SetAgentInfo(agentInfo)
 	}
 
 	// Save the state back to K8s
@@ -375,17 +377,19 @@ func (c *Cluster) InitState(ctx context.Context, opts InitStateOptions) (*state.
 }
 
 func (c *Cluster) initAgent(ctx context.Context, s *state.State, agentTLS *pki.GeneratedPKI) error {
+	agentInfo := s.AgentInfo
 	if agentTLS != nil {
-		s.AgentTLS = *agentTLS
-		s.AgentTLSUserProvided = true
+		agentInfo.TLS = *agentTLS
+		agentInfo.TLSUserProvided = true
 	} else {
 		generatedAgentTLS, err := pki.GeneratePKI(state.ZarfAgentHost)
 		if err != nil {
 			return err
 		}
-		s.AgentTLS = generatedAgentTLS
-		s.AgentTLSUserProvided = false
+		agentInfo.TLS = generatedAgentTLS
+		agentInfo.TLSUserProvided = false
 	}
+	s.SetAgentInfo(agentInfo)
 	return c.ignoreExistingNamespacesForAgent(ctx)
 }
 
@@ -519,7 +523,7 @@ func (c *Cluster) LoadState(ctx context.Context) (*state.State, error) {
 	}
 
 	s := &state.State{}
-	err = json.Unmarshal(secret.Data[state.ZarfStateDataKey], &s)
+	err = json.Unmarshal(secret.Data[state.ZarfStateDataKey], s)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", stateErr, err)
 	}
@@ -540,6 +544,9 @@ func (c *Cluster) LoadState(ctx context.Context) (*state.State, error) {
 func (c *Cluster) SaveState(ctx context.Context, s *state.State) error {
 	// Sync NodePort from Port so older Zarf versions can read the state.
 	s.RegistryInfo.ReconcilePort()
+	// Sync deprecated agent fields so older Zarf versions can read the state.
+	// FIXME: likely unnecessary
+	s.ReconcileAgentInfo()
 	state.DebugPrint(ctx, s)
 
 	data, err := json.Marshal(&s)

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -681,7 +681,7 @@ func TestInitStateServicesGating(t *testing.T) {
 			InternalServices: state.NewServiceSet(state.AgentKey),
 		})
 		require.NoError(t, err)
-		require.True(t, s.AgentIsConfigured())
+		require.True(t, s.AgentInfo.IsConfigured())
 		require.False(t, s.AgentInfo.TLSUserProvided)
 
 		ns, err := c.Clientset.CoreV1().Namespaces().Get(ctx, "app", metav1.GetOptions{})

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -608,7 +608,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		require.Empty(t, s.ArtifactServer.Address)
 		require.False(t, s.GitServer.IsConfigured())
 		require.NotEmpty(t, s.RegistryInfo.Address)
-		require.NotEmpty(t, s.AgentTLS.Cert)
+		require.NotEmpty(t, s.AgentInfo.TLS.Cert)
 	})
 
 	t.Run("new cluster without agent service leaves agent TLS empty", func(t *testing.T) {
@@ -618,8 +618,8 @@ func TestInitStateServicesGating(t *testing.T) {
 			InternalServices: state.NewServiceSet(state.RegistryKey),
 		})
 		require.NoError(t, err)
-		require.Empty(t, s.AgentTLS.Cert)
-		require.False(t, s.AgentTLSUserProvided)
+		require.Empty(t, s.AgentInfo.TLS.Cert)
+		require.False(t, s.AgentInfo.TLSUserProvided)
 	})
 
 	t.Run("new cluster with all services populates everything", func(t *testing.T) {
@@ -632,7 +632,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		require.True(t, s.GitServer.IsConfigured())
 		require.True(t, s.ArtifactServer.IsInternal())
 		require.NotEmpty(t, s.RegistryInfo.Address)
-		require.NotEmpty(t, s.AgentTLS.Cert)
+		require.NotEmpty(t, s.AgentInfo.TLS.Cert)
 	})
 
 	t.Run("re-init adds a missing git service without overwriting existing registry", func(t *testing.T) {
@@ -682,7 +682,7 @@ func TestInitStateServicesGating(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.True(t, s.AgentIsConfigured())
-		require.False(t, s.AgentTLSUserProvided)
+		require.False(t, s.AgentInfo.TLSUserProvided)
 
 		ns, err := c.Clientset.CoreV1().Namespaces().Get(ctx, "app", metav1.GetOptions{})
 		require.NoError(t, err)
@@ -704,8 +704,8 @@ func TestInitStateServicesGating(t *testing.T) {
 			AgentTLS:         &agentTLS,
 		})
 		require.NoError(t, err)
-		require.Equal(t, agentTLS, s.AgentTLS)
-		require.True(t, s.AgentTLSUserProvided)
+		require.Equal(t, agentTLS, s.AgentInfo.TLS)
+		require.True(t, s.AgentInfo.TLSUserProvided)
 	})
 
 	t.Run("new cluster with external git URL persists without being in InternalServices", func(t *testing.T) {
@@ -776,6 +776,49 @@ func TestInitStateServicesGating(t *testing.T) {
 		require.False(t, s.RegistryInfo.IsInternal())
 		require.Equal(t, 0, s.InjectorInfo.Port, "injector port must reset when mode changes")
 	})
+}
+
+func TestStateAgentInfoCompatibility(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := &Cluster{Clientset: fake.NewClientset()}
+	legacy := struct {
+		AgentTLS             pki.GeneratedPKI     `json:"agentTLS"`
+		AgentTLSUserProvided bool                 `json:"agentTLSUserProvided"`
+		AgentMutationPolicy  state.MutationPolicy `json:"agentMutationPolicy"`
+	}{
+		AgentTLS: pki.GeneratedPKI{
+			CA:   []byte("ca"),
+			Cert: []byte("cert"),
+			Key:  []byte("key"),
+		},
+		AgentTLSUserProvided: true,
+		AgentMutationPolicy:  state.MutationPolicyLabeled,
+	}
+	legacyData, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	_, err = c.Clientset.CoreV1().Secrets(state.ZarfNamespaceName).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: state.ZarfNamespaceName, Name: state.ZarfStateSecretName},
+		Data:       map[string][]byte{state.ZarfStateDataKey: legacyData},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	loaded, err := c.LoadState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, legacy.AgentTLS, loaded.AgentInfo.TLS)
+	require.True(t, loaded.AgentInfo.TLSUserProvided)
+	require.Equal(t, state.MutationPolicyLabeled, loaded.AgentInfo.MutationPolicy)
+
+	require.NoError(t, c.SaveState(ctx, loaded))
+	persisted, err := c.Clientset.CoreV1().Secrets(state.ZarfNamespaceName).Get(ctx, state.ZarfStateSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(persisted.Data[state.ZarfStateDataKey], &raw))
+	require.Contains(t, raw, "agentInfo")
+	require.Contains(t, raw, "agentTLS")
+	require.Contains(t, raw, "agentTLSUserProvided")
+	require.Contains(t, raw, "agentMutationPolicy")
 }
 
 func TestIgnoreExistingNamespacesForAgent(t *testing.T) {

--- a/src/pkg/cluster/cluster_test.go
+++ b/src/pkg/cluster/cluster_test.go
@@ -611,15 +611,17 @@ func TestInitStateServicesGating(t *testing.T) {
 		require.NotEmpty(t, s.AgentInfo.TLS.Cert)
 	})
 
-	t.Run("new cluster without agent service leaves agent TLS empty", func(t *testing.T) {
+	t.Run("new cluster without agent service leaves agent configuration empty", func(t *testing.T) {
 		ctx := context.Background()
 		c := newFakeInitStateCluster(ctx, t, nil)
 		s, err := c.InitState(ctx, InitStateOptions{
-			InternalServices: state.NewServiceSet(state.RegistryKey),
+			InternalServices:    state.NewServiceSet(state.RegistryKey),
+			AgentMutationPolicy: state.MutationPolicyAll,
 		})
 		require.NoError(t, err)
 		require.Empty(t, s.AgentInfo.TLS.Cert)
 		require.False(t, s.AgentInfo.TLSUserProvided)
+		require.Empty(t, s.AgentInfo.MutationPolicy)
 	})
 
 	t.Run("new cluster with all services populates everything", func(t *testing.T) {

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -772,7 +772,7 @@ func (d *deployer) verifyPackageIsDeployable(ctx context.Context, pkgLayout *lay
 		// don't return the err here as state may not yet be setup
 		return nil
 	}
-	if !s.AgentIsConfigured() {
+	if !s.AgentInfo.IsConfigured() {
 		return nil
 	}
 	return pki.CheckForExpiredCert(ctx, s.AgentInfo.TLS)

--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -775,7 +775,7 @@ func (d *deployer) verifyPackageIsDeployable(ctx context.Context, pkgLayout *lay
 	if !s.AgentIsConfigured() {
 		return nil
 	}
-	return pki.CheckForExpiredCert(ctx, s.AgentTLS)
+	return pki.CheckForExpiredCert(ctx, s.AgentInfo.TLS)
 }
 
 func setupState(ctx context.Context, c *cluster.Cluster, connected bool) (*state.State, error) {

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -190,15 +190,14 @@ type AgentInfo struct {
 	MutationPolicy MutationPolicy `json:"mutationPolicy"`
 }
 
-// IsConfigured returns true when the agent TLS certificate is configured.
+// IsConfigured returns true when a complete agent TLS bundle is configured.
 func (ai AgentInfo) IsConfigured() bool {
-	return len(ai.TLS.Cert) > 0
+	return len(ai.TLS.CA) > 0 && len(ai.TLS.Cert) > 0 && len(ai.TLS.Key) > 0
 }
 
 // AgentIsConfigured returns true when Zarf has agent TLS configured.
 //
-// Deprecated: Use AgentInfo.IsConfigured instead. State is reconciled here to
-// support legacy state fields during the transition.
+// Deprecated: Use AgentInfo.IsConfigured instead.
 func (s *State) AgentIsConfigured() bool {
 	s.Reconcile()
 	return s.AgentInfo.IsConfigured()

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -193,11 +193,18 @@ type AgentInfo struct {
 
 // AgentIsConfigured returns true when Zarf has agent TLS configured.
 func (s *State) AgentIsConfigured() bool {
-	s.ReconcileAgentInfo()
+	s.Reconcile()
 	return len(s.AgentInfo.TLS.Cert) > 0
 }
 
-// ReconcileAgentInfo syncs AgentInfo with deprecated agent fields at serialization boundaries.
+// Reconcile synchronizes compatibility fields with their canonical replacements.
+// Call it when State crosses an application boundary or before reading compatibility-sensitive fields.
+func (s *State) Reconcile() {
+	s.RegistryInfo.ReconcilePort()
+	s.ReconcileAgentInfo()
+}
+
+// ReconcileAgentInfo syncs AgentInfo with deprecated agent fields.
 // When AgentInfo is empty, the deprecated fields are assumed to be the source of truth so
 // callers that still construct State with the legacy fields remain supported.
 func (s *State) ReconcileAgentInfo() {
@@ -231,9 +238,9 @@ func (ai AgentInfo) isZero() bool {
 	return len(ai.TLS.CA) == 0 && len(ai.TLS.Cert) == 0 && len(ai.TLS.Key) == 0 && !ai.TLSUserProvided && ai.MutationPolicy == ""
 }
 
-// MarshalJSON emits both the canonical agentInfo object and the legacy fields so older Zarf versions can read state written by newer versions.
+// MarshalJSON emits canonical state and compatibility fields so older Zarf versions can read state written by newer versions.
 func (s State) MarshalJSON() ([]byte, error) {
-	s.ReconcileAgentInfo()
+	s.Reconcile()
 	type stateAlias State
 	return json.Marshal(stateAlias(s))
 }
@@ -254,11 +261,12 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	if _, ok := raw["agentInfo"]; ok {
 		// The nested object is authoritative, including when it is explicitly empty.
 		s.syncLegacyAgentFields()
-		return nil
+	} else {
+		s.AgentInfo = s.legacyAgentInfo()
+		s.syncLegacyAgentFields()
 	}
 
-	s.AgentInfo = s.legacyAgentInfo()
-	s.syncLegacyAgentFields()
+	s.Reconcile()
 	return nil
 }
 
@@ -648,6 +656,7 @@ func Default() (*State, error) {
 		return nil, err
 	}
 	state.ArtifactServer.FillInEmptyValues()
+	state.Reconcile()
 	return state, nil
 }
 
@@ -667,7 +676,7 @@ type MergeOptions struct {
 // Merge merges init options for provided services into the provided state to create a new state struct
 func Merge(oldState *State, opts MergeOptions) (*State, error) {
 	newState := *oldState
-	newState.ReconcileAgentInfo()
+	newState.Reconcile()
 	var err error
 	if opts.Services.Has(RegistryKey) {
 		// TODO: Replace use of reflections with explicit setting
@@ -733,6 +742,7 @@ func Merge(oldState *State, opts MergeOptions) (*State, error) {
 		newState.SetAgentInfo(agentInfo)
 	}
 
+	newState.Reconcile()
 	return &newState, nil
 }
 

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -6,7 +6,6 @@ package state
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -236,38 +235,6 @@ func (s *State) syncLegacyAgentFields() {
 
 func (ai AgentInfo) isZero() bool {
 	return len(ai.TLS.CA) == 0 && len(ai.TLS.Cert) == 0 && len(ai.TLS.Key) == 0 && !ai.TLSUserProvided && ai.MutationPolicy == ""
-}
-
-// MarshalJSON emits canonical state and compatibility fields so older Zarf versions can read state written by newer versions.
-func (s State) MarshalJSON() ([]byte, error) {
-	s.Reconcile()
-	type stateAlias State
-	return json.Marshal(stateAlias(s))
-}
-
-// UnmarshalJSON reads the canonical agentInfo object when it is present and otherwise migrates legacy agent fields.
-func (s *State) UnmarshalJSON(data []byte) error {
-	type stateAlias State
-	var decoded stateAlias
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
-	}
-
-	*s = State(decoded)
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	if _, ok := raw["agentInfo"]; ok {
-		// The nested object is authoritative, including when it is explicitly empty.
-		s.syncLegacyAgentFields()
-	} else {
-		s.AgentInfo = s.legacyAgentInfo()
-		s.syncLegacyAgentFields()
-	}
-
-	s.Reconcile()
-	return nil
 }
 
 // InjectorInfo contains information on how to run the long lived Daemonset Injector

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -6,6 +6,7 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -162,11 +163,13 @@ type State struct {
 	StorageClass string `json:"storageClass"`
 	// The IP family of the cluster, can be ipv4, ipv6, or dual
 	IPFamily IPFamily `json:"ipFamily,omitempty"`
-	// PKI certificate information for the agent pods Zarf manages
+	// AgentInfo contains information Zarf uses to configure the agent.
+	AgentInfo AgentInfo `json:"agentInfo"`
+	// Deprecated: Use AgentInfo.TLS instead. Kept for backwards compatibility with state JSON written by older Zarf versions.
 	AgentTLS pki.GeneratedPKI `json:"agentTLS"`
-	// AgentTLSUserProvided indicates whether the agent TLS certs were provided by the user rather than auto-generated
+	// Deprecated: Use AgentInfo.TLSUserProvided instead. Kept for backwards compatibility with state JSON written by older Zarf versions.
 	AgentTLSUserProvided bool `json:"agentTLSUserProvided,omitempty"`
-	// AgentMutationPolicy controls the conditions required for the agent to mutate resources
+	// Deprecated: Use AgentInfo.MutationPolicy instead. Kept for backwards compatibility with state JSON written by older Zarf versions.
 	AgentMutationPolicy MutationPolicy `json:"agentMutationPolicy"`
 	InjectorInfo        InjectorInfo   `json:"injectorInfo"`
 
@@ -178,9 +181,85 @@ type State struct {
 	ArtifactServer ArtifactServerInfo `json:"artifactServer"`
 }
 
+// AgentInfo contains information Zarf uses to configure the agent.
+type AgentInfo struct {
+	// TLS contains certificate information for the agent pods Zarf manages.
+	TLS pki.GeneratedPKI `json:"tls"`
+	// TLSUserProvided indicates whether the agent TLS certs were provided by the user rather than auto-generated.
+	TLSUserProvided bool `json:"tlsUserProvided,omitempty"`
+	// MutationPolicy controls the conditions required for the agent to mutate resources.
+	MutationPolicy MutationPolicy `json:"mutationPolicy"`
+}
+
 // AgentIsConfigured returns true when Zarf has agent TLS configured.
 func (s *State) AgentIsConfigured() bool {
-	return len(s.AgentTLS.Cert) > 0
+	s.ReconcileAgentInfo()
+	return len(s.AgentInfo.TLS.Cert) > 0
+}
+
+// ReconcileAgentInfo syncs AgentInfo with deprecated agent fields at serialization boundaries.
+// When AgentInfo is empty, the deprecated fields are assumed to be the source of truth so
+// callers that still construct State with the legacy fields remain supported.
+func (s *State) ReconcileAgentInfo() {
+	if s.AgentInfo.isZero() {
+		s.AgentInfo = s.legacyAgentInfo()
+	}
+	s.syncLegacyAgentFields()
+}
+
+// SetAgentInfo updates AgentInfo and its deprecated compatibility fields together.
+func (s *State) SetAgentInfo(agentInfo AgentInfo) {
+	s.AgentInfo = agentInfo
+	s.syncLegacyAgentFields()
+}
+
+func (s *State) legacyAgentInfo() AgentInfo {
+	return AgentInfo{
+		TLS:             s.AgentTLS,
+		TLSUserProvided: s.AgentTLSUserProvided,
+		MutationPolicy:  s.AgentMutationPolicy,
+	}
+}
+
+func (s *State) syncLegacyAgentFields() {
+	s.AgentTLS = s.AgentInfo.TLS
+	s.AgentTLSUserProvided = s.AgentInfo.TLSUserProvided
+	s.AgentMutationPolicy = s.AgentInfo.MutationPolicy
+}
+
+func (ai AgentInfo) isZero() bool {
+	return len(ai.TLS.CA) == 0 && len(ai.TLS.Cert) == 0 && len(ai.TLS.Key) == 0 && !ai.TLSUserProvided && ai.MutationPolicy == ""
+}
+
+// MarshalJSON emits both the canonical agentInfo object and the legacy fields so older Zarf versions can read state written by newer versions.
+func (s State) MarshalJSON() ([]byte, error) {
+	s.ReconcileAgentInfo()
+	type stateAlias State
+	return json.Marshal(stateAlias(s))
+}
+
+// UnmarshalJSON reads the canonical agentInfo object when it is present and otherwise migrates legacy agent fields.
+func (s *State) UnmarshalJSON(data []byte) error {
+	type stateAlias State
+	var decoded stateAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	*s = State(decoded)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["agentInfo"]; ok {
+		// The nested object is authoritative, including when it is explicitly empty.
+		s.syncLegacyAgentFields()
+		return nil
+	}
+
+	s.AgentInfo = s.legacyAgentInfo()
+	s.syncLegacyAgentFields()
+	return nil
 }
 
 // InjectorInfo contains information on how to run the long lived Daemonset Injector
@@ -588,6 +667,7 @@ type MergeOptions struct {
 // Merge merges init options for provided services into the provided state to create a new state struct
 func Merge(oldState *State, opts MergeOptions) (*State, error) {
 	newState := *oldState
+	newState.ReconcileAgentInfo()
 	var err error
 	if opts.Services.Has(RegistryKey) {
 		// TODO: Replace use of reflections with explicit setting
@@ -635,20 +715,22 @@ func Merge(oldState *State, opts MergeOptions) (*State, error) {
 		}
 	}
 	if opts.Services.Has(AgentKey) {
+		agentInfo := newState.AgentInfo
 		if opts.AgentTLS != nil {
-			newState.AgentTLS = *opts.AgentTLS
-			newState.AgentTLSUserProvided = true
+			agentInfo.TLS = *opts.AgentTLS
+			agentInfo.TLSUserProvided = true
 		} else {
 			agentTLS, err := pki.GeneratePKI(ZarfAgentHost)
 			if err != nil {
 				return nil, err
 			}
-			newState.AgentTLS = agentTLS
-			newState.AgentTLSUserProvided = false
+			agentInfo.TLS = agentTLS
+			agentInfo.TLSUserProvided = false
 		}
 		if opts.AgentMutationPolicy != "" {
-			newState.AgentMutationPolicy = opts.AgentMutationPolicy
+			agentInfo.MutationPolicy = opts.AgentMutationPolicy
 		}
+		newState.SetAgentInfo(agentInfo)
 	}
 
 	return &newState, nil
@@ -667,9 +749,11 @@ func DebugPrint(ctx context.Context, state *State) {
 
 func sanitizeState(s *State) *State {
 	// Overwrite the AgentTLS information
-	s.AgentTLS.CA = []byte("**sanitized**")
-	s.AgentTLS.Cert = []byte("**sanitized**")
-	s.AgentTLS.Key = []byte("**sanitized**")
+	agentInfo := s.AgentInfo
+	agentInfo.TLS.CA = []byte("**sanitized**")
+	agentInfo.TLS.Cert = []byte("**sanitized**")
+	agentInfo.TLS.Key = []byte("**sanitized**")
+	s.SetAgentInfo(agentInfo)
 
 	// Overwrite the GitServer passwords
 	s.GitServer.PushPassword = "**sanitized**"

--- a/src/pkg/state/state.go
+++ b/src/pkg/state/state.go
@@ -190,10 +190,18 @@ type AgentInfo struct {
 	MutationPolicy MutationPolicy `json:"mutationPolicy"`
 }
 
+// IsConfigured returns true when the agent TLS certificate is configured.
+func (ai AgentInfo) IsConfigured() bool {
+	return len(ai.TLS.Cert) > 0
+}
+
 // AgentIsConfigured returns true when Zarf has agent TLS configured.
+//
+// Deprecated: Use AgentInfo.IsConfigured instead. State is reconciled here to
+// support legacy state fields during the transition.
 func (s *State) AgentIsConfigured() bool {
 	s.Reconcile()
-	return len(s.AgentInfo.TLS.Cert) > 0
+	return s.AgentInfo.IsConfigured()
 }
 
 // Reconcile synchronizes compatibility fields with their canonical replacements.

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 )
 
-func TestAgentIsConfigured(t *testing.T) {
+func TestAgentInfoIsConfigured(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, (&State{}).AgentIsConfigured())
-	require.False(t, (&State{AgentInfo: AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Key: []byte("key")}}}).AgentIsConfigured())
-	require.True(t, (&State{AgentInfo: AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}}}).AgentIsConfigured())
+	require.False(t, (AgentInfo{}).IsConfigured())
+	require.False(t, (AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Key: []byte("key")}}).IsConfigured())
+	require.True(t, (AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}}).IsConfigured())
 }
 
 func TestStateReconcile(t *testing.T) {

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -26,6 +26,28 @@ func TestAgentIsConfigured(t *testing.T) {
 	require.True(t, (&State{AgentInfo: AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}}}).AgentIsConfigured())
 }
 
+func TestStateReconcile(t *testing.T) {
+	t.Parallel()
+
+	legacyTLS := pki.GeneratedPKI{Cert: []byte("legacy-cert")}
+	s := State{
+		AgentTLS:             legacyTLS,
+		AgentTLSUserProvided: true,
+		AgentMutationPolicy:  MutationPolicyLabeled,
+		RegistryInfo: RegistryInfo{
+			NodePort: 1234,
+		},
+	}
+
+	s.Reconcile()
+
+	require.Equal(t, legacyTLS, s.AgentInfo.TLS)
+	require.True(t, s.AgentInfo.TLSUserProvided)
+	require.Equal(t, MutationPolicyLabeled, s.AgentInfo.MutationPolicy)
+	require.Equal(t, 1234, s.RegistryInfo.Port)
+	require.Equal(t, 1234, s.RegistryInfo.NodePort)
+}
+
 func TestStateAgentInfoJSONCompatibility(t *testing.T) {
 	t.Parallel()
 

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -6,6 +6,7 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,8 +22,89 @@ func TestAgentIsConfigured(t *testing.T) {
 	t.Parallel()
 
 	require.False(t, (&State{}).AgentIsConfigured())
-	require.False(t, (&State{AgentTLS: pki.GeneratedPKI{CA: []byte("ca"), Key: []byte("key")}}).AgentIsConfigured())
-	require.True(t, (&State{AgentTLS: pki.GeneratedPKI{Cert: []byte("cert")}}).AgentIsConfigured())
+	require.False(t, (&State{AgentInfo: AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Key: []byte("key")}}}).AgentIsConfigured())
+	require.True(t, (&State{AgentInfo: AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}}}).AgentIsConfigured())
+}
+
+func TestStateAgentInfoJSONCompatibility(t *testing.T) {
+	t.Parallel()
+
+	agentInfo := AgentInfo{
+		TLS: pki.GeneratedPKI{
+			CA:   []byte("ca"),
+			Cert: []byte("cert"),
+			Key:  []byte("key"),
+		},
+		TLSUserProvided: true,
+		MutationPolicy:  MutationPolicyLabeled,
+	}
+
+	t.Run("loads legacy fields", func(t *testing.T) {
+		legacy := struct {
+			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
+			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
+			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
+		}{
+			AgentTLS:             agentInfo.TLS,
+			AgentTLSUserProvided: agentInfo.TLSUserProvided,
+			AgentMutationPolicy:  agentInfo.MutationPolicy,
+		}
+		data, err := json.Marshal(legacy)
+		require.NoError(t, err)
+
+		var got State
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, agentInfo, got.AgentInfo)
+		require.Equal(t, agentInfo.TLS, got.AgentTLS)
+		require.True(t, got.AgentTLSUserProvided)
+		require.Equal(t, agentInfo.MutationPolicy, got.AgentMutationPolicy)
+	})
+
+	t.Run("nested fields take precedence and synchronize legacy fields", func(t *testing.T) {
+		legacyTLS := pki.GeneratedPKI{Cert: []byte("legacy-cert")}
+		// FIXME: why not just actually use the state struct here?
+		data, err := json.Marshal(struct {
+			AgentInfo            AgentInfo        `json:"agentInfo"`
+			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
+			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
+			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
+		}{
+			AgentInfo:            agentInfo,
+			AgentTLS:             legacyTLS,
+			AgentMutationPolicy:  MutationPolicyAll,
+			AgentTLSUserProvided: false,
+		})
+		require.NoError(t, err)
+
+		var got State
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, agentInfo, got.AgentInfo)
+		require.Equal(t, agentInfo.TLS, got.AgentTLS)
+		require.True(t, got.AgentTLSUserProvided)
+		require.Equal(t, agentInfo.MutationPolicy, got.AgentMutationPolicy)
+	})
+
+	t.Run("writes both formats", func(t *testing.T) {
+		data, err := json.Marshal(State{AgentInfo: agentInfo})
+		require.NoError(t, err)
+
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &raw))
+		require.Contains(t, raw, "agentInfo")
+		require.Contains(t, raw, "agentTLS")
+		require.Contains(t, raw, "agentTLSUserProvided")
+		require.Contains(t, raw, "agentMutationPolicy")
+
+		var legacy struct {
+			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
+			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
+			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
+		}
+		require.NoError(t, json.Unmarshal(data, &legacy))
+		require.Equal(t, agentInfo.TLS, legacy.AgentTLS)
+		require.True(t, legacy.AgentTLSUserProvided)
+		require.Equal(t, agentInfo.MutationPolicy, legacy.AgentMutationPolicy)
+	})
 }
 
 func TestRegistryInfoKnownPlainHTTP(t *testing.T) {
@@ -491,14 +573,14 @@ func TestMergeStateAgent(t *testing.T) {
 		agentTLS, err := pki.GeneratePKI("example.com")
 		require.NoError(t, err)
 		oldState := &State{
-			AgentTLS: agentTLS,
+			AgentInfo: AgentInfo{TLS: agentTLS},
 		}
 		newState, err := Merge(oldState, MergeOptions{
 			Services: NewServiceSet(AgentKey),
 		})
 		require.NoError(t, err)
-		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)
-		require.False(t, newState.AgentTLSUserProvided)
+		require.NotEqual(t, oldState.AgentInfo.TLS, newState.AgentInfo.TLS)
+		require.False(t, newState.AgentInfo.TLSUserProvided)
 	})
 
 	t.Run("user-provided certs are used and provenance is set", func(t *testing.T) {
@@ -514,22 +596,24 @@ func TestMergeStateAgent(t *testing.T) {
 			AgentTLS: &userTLS,
 		})
 		require.NoError(t, err)
-		require.Equal(t, userTLS, newState.AgentTLS)
-		require.True(t, newState.AgentTLSUserProvided)
+		require.Equal(t, userTLS, newState.AgentInfo.TLS)
+		require.True(t, newState.AgentInfo.TLSUserProvided)
 	})
 
 	t.Run("auto-generate resets user-provided provenance", func(t *testing.T) {
 		t.Parallel()
 		oldState := &State{
-			AgentTLS:             pki.GeneratedPKI{CA: []byte("old-ca")},
-			AgentTLSUserProvided: true,
+			AgentInfo: AgentInfo{
+				TLS:             pki.GeneratedPKI{CA: []byte("old-ca")},
+				TLSUserProvided: true,
+			},
 		}
 		newState, err := Merge(oldState, MergeOptions{
 			Services: NewServiceSet(AgentKey),
 		})
 		require.NoError(t, err)
-		require.NotEqual(t, oldState.AgentTLS, newState.AgentTLS)
-		require.False(t, newState.AgentTLSUserProvided)
+		require.NotEqual(t, oldState.AgentInfo.TLS, newState.AgentInfo.TLS)
+		require.False(t, newState.AgentInfo.TLSUserProvided)
 	})
 }
 

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -48,7 +48,7 @@ func TestStateReconcile(t *testing.T) {
 	require.Equal(t, 1234, s.RegistryInfo.NodePort)
 }
 
-func TestStateAgentInfoJSONCompatibility(t *testing.T) {
+func TestStateAgentInfoSerialization(t *testing.T) {
 	t.Parallel()
 
 	agentInfo := AgentInfo{
@@ -61,72 +61,28 @@ func TestStateAgentInfoJSONCompatibility(t *testing.T) {
 		MutationPolicy:  MutationPolicyLabeled,
 	}
 
-	t.Run("loads legacy fields", func(t *testing.T) {
-		legacy := struct {
-			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
-			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
-			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
-		}{
-			AgentTLS:             agentInfo.TLS,
-			AgentTLSUserProvided: agentInfo.TLSUserProvided,
-			AgentMutationPolicy:  agentInfo.MutationPolicy,
-		}
-		data, err := json.Marshal(legacy)
-		require.NoError(t, err)
+	s := State{}
+	s.SetAgentInfo(agentInfo)
 
-		var got State
-		require.NoError(t, json.Unmarshal(data, &got))
-		require.Equal(t, agentInfo, got.AgentInfo)
-		require.Equal(t, agentInfo.TLS, got.AgentTLS)
-		require.True(t, got.AgentTLSUserProvided)
-		require.Equal(t, agentInfo.MutationPolicy, got.AgentMutationPolicy)
-	})
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
 
-	t.Run("nested fields take precedence and synchronize legacy fields", func(t *testing.T) {
-		legacyTLS := pki.GeneratedPKI{Cert: []byte("legacy-cert")}
-		// FIXME: why not just actually use the state struct here?
-		data, err := json.Marshal(struct {
-			AgentInfo            AgentInfo        `json:"agentInfo"`
-			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
-			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
-			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
-		}{
-			AgentInfo:            agentInfo,
-			AgentTLS:             legacyTLS,
-			AgentMutationPolicy:  MutationPolicyAll,
-			AgentTLSUserProvided: false,
-		})
-		require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Contains(t, raw, "agentInfo")
+	require.Contains(t, raw, "agentTLS")
+	require.Contains(t, raw, "agentTLSUserProvided")
+	require.Contains(t, raw, "agentMutationPolicy")
 
-		var got State
-		require.NoError(t, json.Unmarshal(data, &got))
-		require.Equal(t, agentInfo, got.AgentInfo)
-		require.Equal(t, agentInfo.TLS, got.AgentTLS)
-		require.True(t, got.AgentTLSUserProvided)
-		require.Equal(t, agentInfo.MutationPolicy, got.AgentMutationPolicy)
-	})
-
-	t.Run("writes both formats", func(t *testing.T) {
-		data, err := json.Marshal(State{AgentInfo: agentInfo})
-		require.NoError(t, err)
-
-		var raw map[string]json.RawMessage
-		require.NoError(t, json.Unmarshal(data, &raw))
-		require.Contains(t, raw, "agentInfo")
-		require.Contains(t, raw, "agentTLS")
-		require.Contains(t, raw, "agentTLSUserProvided")
-		require.Contains(t, raw, "agentMutationPolicy")
-
-		var legacy struct {
-			AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
-			AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
-			AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
-		}
-		require.NoError(t, json.Unmarshal(data, &legacy))
-		require.Equal(t, agentInfo.TLS, legacy.AgentTLS)
-		require.True(t, legacy.AgentTLSUserProvided)
-		require.Equal(t, agentInfo.MutationPolicy, legacy.AgentMutationPolicy)
-	})
+	var legacy struct {
+		AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
+		AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
+		AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
+	}
+	require.NoError(t, json.Unmarshal(data, &legacy))
+	require.Equal(t, agentInfo.TLS, legacy.AgentTLS)
+	require.True(t, legacy.AgentTLSUserProvided)
+	require.Equal(t, agentInfo.MutationPolicy, legacy.AgentMutationPolicy)
 }
 
 func TestRegistryInfoKnownPlainHTTP(t *testing.T) {

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -6,7 +6,6 @@ package state
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -46,43 +45,6 @@ func TestStateReconcile(t *testing.T) {
 	require.Equal(t, MutationPolicyLabeled, s.AgentInfo.MutationPolicy)
 	require.Equal(t, 1234, s.RegistryInfo.Port)
 	require.Equal(t, 1234, s.RegistryInfo.NodePort)
-}
-
-func TestStateAgentInfoSerialization(t *testing.T) {
-	t.Parallel()
-
-	agentInfo := AgentInfo{
-		TLS: pki.GeneratedPKI{
-			CA:   []byte("ca"),
-			Cert: []byte("cert"),
-			Key:  []byte("key"),
-		},
-		TLSUserProvided: true,
-		MutationPolicy:  MutationPolicyLabeled,
-	}
-
-	s := State{}
-	s.SetAgentInfo(agentInfo)
-
-	data, err := json.Marshal(s)
-	require.NoError(t, err)
-
-	var raw map[string]json.RawMessage
-	require.NoError(t, json.Unmarshal(data, &raw))
-	require.Contains(t, raw, "agentInfo")
-	require.Contains(t, raw, "agentTLS")
-	require.Contains(t, raw, "agentTLSUserProvided")
-	require.Contains(t, raw, "agentMutationPolicy")
-
-	var legacy struct {
-		AgentTLS             pki.GeneratedPKI `json:"agentTLS"`
-		AgentTLSUserProvided bool             `json:"agentTLSUserProvided"`
-		AgentMutationPolicy  MutationPolicy   `json:"agentMutationPolicy"`
-	}
-	require.NoError(t, json.Unmarshal(data, &legacy))
-	require.Equal(t, agentInfo.TLS, legacy.AgentTLS)
-	require.True(t, legacy.AgentTLSUserProvided)
-	require.Equal(t, agentInfo.MutationPolicy, legacy.AgentMutationPolicy)
 }
 
 func TestRegistryInfoKnownPlainHTTP(t *testing.T) {

--- a/src/pkg/state/state_test.go
+++ b/src/pkg/state/state_test.go
@@ -22,7 +22,8 @@ func TestAgentInfoIsConfigured(t *testing.T) {
 
 	require.False(t, (AgentInfo{}).IsConfigured())
 	require.False(t, (AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Key: []byte("key")}}).IsConfigured())
-	require.True(t, (AgentInfo{TLS: pki.GeneratedPKI{Cert: []byte("cert")}}).IsConfigured())
+	require.False(t, (AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Cert: []byte("cert")}}).IsConfigured())
+	require.True(t, (AgentInfo{TLS: pki.GeneratedPKI{CA: []byte("ca"), Cert: []byte("cert"), Key: []byte("key")}}).IsConfigured())
 }
 
 func TestStateReconcile(t *testing.T) {

--- a/src/pkg/template/template.go
+++ b/src/pkg/template/template.go
@@ -106,7 +106,7 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 	if s == nil {
 		return o, nil
 	}
-	s.ReconcileAgentInfo()
+	s.Reconcile()
 
 	registry := map[string]any{
 		"Address":      s.RegistryInfo.Address,

--- a/src/pkg/template/template.go
+++ b/src/pkg/template/template.go
@@ -106,6 +106,7 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 	if s == nil {
 		return o, nil
 	}
+	s.ReconcileAgentInfo()
 
 	registry := map[string]any{
 		"Address":      s.RegistryInfo.Address,
@@ -155,9 +156,9 @@ func (o Objects) WithState(access StateAccess) (Objects, error) {
 
 	if slices.Contains(access.AccessKeys, v1alpha1.StateAccessAgentCerts) {
 		stateMap["Agent"] = map[string]any{
-			"CA":   base64.StdEncoding.EncodeToString(s.AgentTLS.CA),
-			"Cert": base64.StdEncoding.EncodeToString(s.AgentTLS.Cert),
-			"Key":  base64.StdEncoding.EncodeToString(s.AgentTLS.Key),
+			"CA":   base64.StdEncoding.EncodeToString(s.AgentInfo.TLS.CA),
+			"Cert": base64.StdEncoding.EncodeToString(s.AgentInfo.TLS.Cert),
+			"Key":  base64.StdEncoding.EncodeToString(s.AgentInfo.TLS.Key),
 		}
 	}
 

--- a/src/pkg/template/template_test.go
+++ b/src/pkg/template/template_test.go
@@ -1140,10 +1140,12 @@ func testState() *state.State {
 			PayLoadConfigMapAmount: 3,
 			PayLoadShaSum:          "abc123",
 		},
-		AgentTLS: pki.GeneratedPKI{
-			CA:   []byte("ca-data"),
-			Cert: []byte("cert-data"),
-			Key:  []byte("key-data"),
+		AgentInfo: state.AgentInfo{
+			TLS: pki.GeneratedPKI{
+				CA:   []byte("ca-data"),
+				Cert: []byte("cert-data"),
+				Key:  []byte("key-data"),
+			},
 		},
 	}
 }
@@ -1269,9 +1271,9 @@ func TestWithState_AgentCertsGroup(t *testing.T) {
 	require.Contains(t, stateMap, "Agent")
 
 	for tmpl, expectedB64 := range map[string][]byte{
-		`{{ .State.Agent.CA }}`:   s.AgentTLS.CA,
-		`{{ .State.Agent.Cert }}`: s.AgentTLS.Cert,
-		`{{ .State.Agent.Key }}`:  s.AgentTLS.Key,
+		`{{ .State.Agent.CA }}`:   s.AgentInfo.TLS.CA,
+		`{{ .State.Agent.Cert }}`: s.AgentInfo.TLS.Cert,
+		`{{ .State.Agent.Key }}`:  s.AgentInfo.TLS.Key,
 	} {
 		out, err := Apply(ctx, tmpl, objs)
 		require.NoError(t, err, "template %q should render with agentCerts", tmpl)


### PR DESCRIPTION
## Description

move agent information into a sub-struct with backwards compatiability

## Related Issue

Fixes #5190

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
