### PR TITLE
feat: add oci source auto-prefixing

### DIFF
--- a/site/src/content/docs/commands/zarf_package_deploy.md
+++ b/site/src/content/docs/commands/zarf_package_deploy.md
@@ -26,7 +26,7 @@ zarf package deploy [ PACKAGE_SOURCE ] [flags]
 # Deploy a local package tarball
 $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst --confirm
 
-# Deploy a package from an OCI registry (requires oci:// scheme)
+# Deploy a package from an OCI registry (oci:// prefix optional)
 $ zarf package deploy oci://ghcr.io/my-org/my-package:1.0.0 --confirm
 
 # Deploy a package from an HTTPS URL (--shasum required for integrity verification)

--- a/site/src/content/docs/commands/zarf_package_inspect_definition.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_definition.md
@@ -21,7 +21,7 @@ zarf package inspect definition [ PACKAGE_SOURCE ] [flags]
 # Inspect the zarf.yaml of a local package tarball
 $ zarf package inspect definition zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Inspect the zarf.yaml of a package in an OCI registry (requires oci:// scheme)
+# Inspect the zarf.yaml of a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect definition oci://ghcr.io/my-org/my-package:1.0.0
 
 # Inspect the zarf.yaml of a package deployed to a cluster

--- a/site/src/content/docs/commands/zarf_package_inspect_digest.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_digest.md
@@ -25,7 +25,7 @@ zarf package inspect digest [ PACKAGE_SOURCE ] [flags]
 # Get the digest of a local package tarball
 $ zarf package inspect digest zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Get the digest of a package in an OCI registry (requires oci:// scheme; resolved directly from the registry)
+# Get the digest of a package in an OCI registry (oci:// prefix optional; resolved directly from the registry)
 $ zarf package inspect digest oci://ghcr.io/my-org/my-package:1.0.0
 
 # Get the stored digest of a package already deployed to a cluster

--- a/site/src/content/docs/commands/zarf_package_inspect_documentation.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_documentation.md
@@ -21,7 +21,7 @@ zarf package inspect documentation [ PACKAGE_SOURCE ] [flags]
 # Extract documentation from a local package tarball
 $ zarf package inspect documentation zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Extract documentation from a package in an OCI registry (requires oci:// scheme)
+# Extract documentation from a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
 
 ```

--- a/site/src/content/docs/commands/zarf_package_inspect_images.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_images.md
@@ -21,7 +21,7 @@ zarf package inspect images [ PACKAGE_SOURCE ] [flags]
 # List images in a local package tarball
 $ zarf package inspect images zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# List images in a package from an OCI registry (requires oci:// scheme)
+# List images in a package from an OCI registry (oci:// prefix optional)
 $ zarf package inspect images oci://ghcr.io/my-org/my-package:1.0.0
 
 # List images in a package already deployed to a cluster

--- a/site/src/content/docs/commands/zarf_package_inspect_manifests.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_manifests.md
@@ -21,7 +21,7 @@ zarf package inspect manifests [ PACKAGE ] [flags]
 # Show templated manifests for a local package tarball
 $ zarf package inspect manifests zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Show manifests for a package in an OCI registry (requires oci:// scheme)
+# Show manifests for a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
 
 ```

--- a/site/src/content/docs/commands/zarf_package_inspect_sbom.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_sbom.md
@@ -21,7 +21,7 @@ zarf package inspect sbom [ PACKAGE ] [flags]
 # Extract the SBOM from a local package tarball
 $ zarf package inspect sbom zarf-package-my-app-amd64-1.0.0.tar.zst --output ./sbom
 
-# Extract the SBOM from a package in an OCI registry (requires oci:// scheme)
+# Extract the SBOM from a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbom
 
 ```

--- a/site/src/content/docs/commands/zarf_package_inspect_values-files.md
+++ b/site/src/content/docs/commands/zarf_package_inspect_values-files.md
@@ -25,7 +25,7 @@ zarf package inspect values-files [ PACKAGE ] [flags]
 # Show values files for a local package tarball
 $ zarf package inspect values-files zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Show values files for a package in an OCI registry (requires oci:// scheme)
+# Show values files for a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
 
 ```

--- a/site/src/content/docs/commands/zarf_package_mirror-resources.md
+++ b/site/src/content/docs/commands/zarf_package_mirror-resources.md
@@ -26,7 +26,7 @@ zarf package mirror-resources [ PACKAGE_SOURCE ] [flags]
 # Mirror a local package to internal Zarf resources (uses Zarf state if available)
 $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Mirror a package from an OCI registry (requires oci:// scheme)
+# Mirror a package from an OCI registry (oci:// prefix optional)
 $ zarf package mirror-resources oci://ghcr.io/my-org/my-package:1.0.0
 
 # Mirror a local package to external resources

--- a/site/src/content/docs/commands/zarf_package_publish.md
+++ b/site/src/content/docs/commands/zarf_package_publish.md
@@ -24,7 +24,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
 # Publish a skeleton package (pre-'create' directory) to a remote registry
 $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
 
-# Copy a package from one OCI registry to another (requires oci:// scheme on source)
+# Copy a package from one OCI registry to another (oci:// prefix optional on source)
 $ zarf package publish oci://source-registry.com/my-namespace/my-package:1.0.0 oci://my-registry.com/my-namespace
 
 # Publish a package with a specific tag different from the package metadata.version

--- a/site/src/content/docs/commands/zarf_package_remove.md
+++ b/site/src/content/docs/commands/zarf_package_remove.md
@@ -28,7 +28,7 @@ $ zarf package remove my-package --confirm
 # Remove using a local package tarball (package name is read from the tarball)
 $ zarf package remove zarf-package-my-app-amd64-1.0.0.tar.zst --confirm
 
-# Remove using a package from an OCI registry (requires oci:// scheme)
+# Remove using a package from an OCI registry (oci:// prefix optional)
 $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
 
 ```

--- a/site/src/content/docs/commands/zarf_package_verify.md
+++ b/site/src/content/docs/commands/zarf_package_verify.md
@@ -25,7 +25,7 @@ zarf package verify PACKAGE_SOURCE [flags]
 # Verify a signed local package tarball
 $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst --key ./public-key.pub
 
-# Verify a package in an OCI registry (requires oci:// scheme)
+# Verify a package in an OCI registry (oci:// prefix optional)
 $ zarf package verify oci://ghcr.io/my-org/my-package:1.0.0 --key ./public-key.pub
 
 # Verify an unsigned package (checksums only)

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1548,7 +1548,7 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	v := getViper()
 	isSkeletonPackage := helpers.IsDir(packageSource)
 	if !isSkeletonPackage {
-		packageSource = packager.NormalizeOCISource(packageSource)
+		packageSource = zoci.NormalizeOCISource(packageSource)
 	}
 
 	if !helpers.IsOCIURL(args[1]) {
@@ -1805,7 +1805,7 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	l := logger.From(ctx)
-	packageSource := packager.NormalizeOCISource(args[0])
+	packageSource := zoci.NormalizeOCISource(args[0])
 
 	if !o.keyless && o.signingKeyPath == "" {
 		return errors.New("--signing-key is required (or pass --keyless for Sigstore keyless flow)")

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1546,6 +1546,10 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	l := logger.From(ctx)
 	v := getViper()
+	isSkeletonPackage := helpers.IsDir(packageSource)
+	if !isSkeletonPackage {
+		packageSource = packager.NormalizeOCISource(packageSource)
+	}
 
 	if !helpers.IsOCIURL(args[1]) {
 		return errors.New("registry must be prefixed with 'oci://'")
@@ -1568,7 +1572,7 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Skeleton package - call PublishSkeleton
-	if helpers.IsDir(packageSource) {
+	if isSkeletonPackage {
 		skeletonOpts := packager.PublishSkeletonOptions{
 			OCIConcurrency:       o.ociConcurrency,
 			SigningKeyPath:       o.signingKeyPath,
@@ -1801,7 +1805,7 @@ func newPackageSignCommand(v *viper.Viper) *cobra.Command {
 func (o *packageSignOptions) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	l := logger.From(ctx)
-	packageSource := args[0]
+	packageSource := packager.NormalizeOCISource(args[0])
 
 	if !o.keyless && o.signingKeyPath == "" {
 		return errors.New("--signing-key is required (or pass --keyless for Sigstore keyless flow)")

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1543,6 +1543,7 @@ func newPackagePublishCommand(v *viper.Viper) *cobra.Command {
 
 func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 	packageSource := args[0]
+	packageDestination := zoci.NormalizeOCISource(args[1])
 	ctx := cmd.Context()
 	l := logger.From(ctx)
 	v := getViper()
@@ -1551,12 +1552,12 @@ func (o *packagePublishOptions) run(cmd *cobra.Command, args []string) error {
 		packageSource = zoci.NormalizeOCISource(packageSource)
 	}
 
-	if !helpers.IsOCIURL(args[1]) {
-		return errors.New("registry must be prefixed with 'oci://'")
+	if !helpers.IsOCIURL(packageDestination) {
+		return errors.New("registry must be a valid OCI reference")
 	}
 
 	// Destination Repository
-	parts := strings.Split(strings.TrimPrefix(args[1], helpers.OCIURLPrefix), "/")
+	parts := strings.Split(strings.TrimPrefix(packageDestination, helpers.OCIURLPrefix), "/")
 	dstRef := registry.Reference{
 		Registry:   parts[0],
 		Repository: strings.Join(parts[1:], "/"),

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -240,7 +240,7 @@ $ zarf init --git-push-password={PASSWORD} --git-push-username={USERNAME} --git-
 # Deploy a local package tarball
 $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst --confirm
 
-# Deploy a package from an OCI registry (requires oci:// scheme)
+# Deploy a package from an OCI registry (oci:// prefix optional)
 $ zarf package deploy oci://ghcr.io/my-org/my-package:1.0.0 --confirm
 
 # Deploy a package from an HTTPS URL (--shasum required for integrity verification)
@@ -257,7 +257,7 @@ $ zarf package deploy zarf-package-my-app-amd64-1.0.0.tar.zst.part000 --confirm
 # Mirror a local package to internal Zarf resources (uses Zarf state if available)
 $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Mirror a package from an OCI registry (requires oci:// scheme)
+# Mirror a package from an OCI registry (oci:// prefix optional)
 $ zarf package mirror-resources oci://ghcr.io/my-org/my-package:1.0.0
 
 # Mirror a local package to external resources
@@ -329,7 +329,7 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
 # Get the digest of a local package tarball
 $ zarf package inspect digest zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Get the digest of a package in an OCI registry (requires oci:// scheme; resolved directly from the registry)
+# Get the digest of a package in an OCI registry (oci:// prefix optional; resolved directly from the registry)
 $ zarf package inspect digest oci://ghcr.io/my-org/my-package:1.0.0
 
 # Get the stored digest of a package already deployed to a cluster
@@ -340,7 +340,7 @@ $ zarf package inspect digest my-package
 # Inspect the zarf.yaml of a local package tarball
 $ zarf package inspect definition zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Inspect the zarf.yaml of a package in an OCI registry (requires oci:// scheme)
+# Inspect the zarf.yaml of a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect definition oci://ghcr.io/my-org/my-package:1.0.0
 
 # Inspect the zarf.yaml of a package deployed to a cluster
@@ -351,7 +351,7 @@ $ zarf package inspect definition my-package
 # List images in a local package tarball
 $ zarf package inspect images zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# List images in a package from an OCI registry (requires oci:// scheme)
+# List images in a package from an OCI registry (oci:// prefix optional)
 $ zarf package inspect images oci://ghcr.io/my-org/my-package:1.0.0
 
 # List images in a package already deployed to a cluster
@@ -362,7 +362,7 @@ $ zarf package inspect images my-package
 # Extract the SBOM from a local package tarball
 $ zarf package inspect sbom zarf-package-my-app-amd64-1.0.0.tar.zst --output ./sbom
 
-# Extract the SBOM from a package in an OCI registry (requires oci:// scheme)
+# Extract the SBOM from a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbom
 `
 
@@ -370,7 +370,7 @@ $ zarf package inspect sbom oci://ghcr.io/my-org/my-package:1.0.0 --output ./sbo
 # Show templated manifests for a local package tarball
 $ zarf package inspect manifests zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Show manifests for a package in an OCI registry (requires oci:// scheme)
+# Show manifests for a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
 `
 
@@ -378,7 +378,7 @@ $ zarf package inspect manifests oci://ghcr.io/my-org/my-package:1.0.0
 # Show values files for a local package tarball
 $ zarf package inspect values-files zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Show values files for a package in an OCI registry (requires oci:// scheme)
+# Show values files for a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
 `
 
@@ -386,7 +386,7 @@ $ zarf package inspect values-files oci://ghcr.io/my-org/my-package:1.0.0
 # Extract documentation from a local package tarball
 $ zarf package inspect documentation zarf-package-my-app-amd64-1.0.0.tar.zst
 
-# Extract documentation from a package in an OCI registry (requires oci:// scheme)
+# Extract documentation from a package in an OCI registry (oci:// prefix optional)
 $ zarf package inspect documentation oci://ghcr.io/my-org/my-package:1.0.0
 `
 
@@ -403,7 +403,7 @@ $ zarf package remove my-package --confirm
 # Remove using a local package tarball (package name is read from the tarball)
 $ zarf package remove zarf-package-my-app-amd64-1.0.0.tar.zst --confirm
 
-# Remove using a package from an OCI registry (requires oci:// scheme)
+# Remove using a package from an OCI registry (oci:// prefix optional)
 $ zarf package remove oci://ghcr.io/my-org/my-package:1.0.0 --confirm
 `
 	CmdPackageRemoveFlagConfirm     = "Confirms the removal action"
@@ -419,7 +419,7 @@ $ zarf package publish zarf-package-my-app-amd64-1.0.0.tar.zst oci://my-registry
 # Publish a skeleton package (pre-'create' directory) to a remote registry
 $ zarf package publish ./path/to/dir oci://my-registry.com/my-namespace
 
-# Copy a package from one OCI registry to another (requires oci:// scheme on source)
+# Copy a package from one OCI registry to another (oci:// prefix optional on source)
 $ zarf package publish oci://source-registry.com/my-namespace/my-package:1.0.0 oci://my-registry.com/my-namespace
 
 # Publish a package with a specific tag different from the package metadata.version
@@ -472,7 +472,7 @@ $ zarf package sign zarf-package-demo-amd64-1.0.0.tar.zst --signing-key awskms:/
 # Verify a signed local package tarball
 $ zarf package verify zarf-package-demo-amd64-1.0.0.tar.zst --key ./public-key.pub
 
-# Verify a package in an OCI registry (requires oci:// scheme)
+# Verify a package in an OCI registry (oci:// prefix optional)
 $ zarf package verify oci://ghcr.io/my-org/my-package:1.0.0 --key ./public-key.pub
 
 # Verify an unsigned package (checksums only)

--- a/src/pkg/packager/digest.go
+++ b/src/pkg/packager/digest.go
@@ -39,7 +39,7 @@ type PackageDigestOptions struct {
 // package contents, producing the same digest that would result from publishing with
 // PushPackage.
 func PackageDigest(ctx context.Context, source string, opts PackageDigestOptions) (string, error) {
-	source = NormalizeOCISource(source)
+	source = zoci.NormalizeOCISource(source)
 	srcType, err := identifySource(source)
 	if err != nil {
 		return "", err

--- a/src/pkg/packager/digest.go
+++ b/src/pkg/packager/digest.go
@@ -39,7 +39,7 @@ type PackageDigestOptions struct {
 // package contents, producing the same digest that would result from publishing with
 // PushPackage.
 func PackageDigest(ctx context.Context, source string, opts PackageDigestOptions) (string, error) {
-	source = normalizeOCISource(source)
+	source = NormalizeOCISource(source)
 	srcType, err := identifySource(source)
 	if err != nil {
 		return "", err

--- a/src/pkg/packager/digest.go
+++ b/src/pkg/packager/digest.go
@@ -39,6 +39,7 @@ type PackageDigestOptions struct {
 // package contents, producing the same digest that would result from publishing with
 // PushPackage.
 func PackageDigest(ctx context.Context, source string, opts PackageDigestOptions) (string, error) {
+	source = normalizeOCISource(source)
 	srcType, err := identifySource(source)
 	if err != nil {
 		return "", err

--- a/src/pkg/packager/digest_test.go
+++ b/src/pkg/packager/digest_test.go
@@ -57,9 +57,7 @@ func TestPackageDigestOCI(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// PackageDigest expects an oci:// URL so identifySource classifies it correctly.
-	ociURL := fmt.Sprintf("oci://%s", packageRef.String())
-	digest, err := PackageDigest(ctx, ociURL, PackageDigestOptions{
+	digest, err := PackageDigest(ctx, packageRef.String(), PackageDigestOptions{
 		Architecture:  pkgLayout.AsV1alpha1().Build.Architecture,
 		RemoteOptions: defaultTestRemoteOptions(),
 	})

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
+	"oras.land/oras-go/v2/registry"
 
 	"github.com/zarf-dev/zarf/src/api"
 	"github.com/zarf-dev/zarf/src/config"
@@ -207,7 +208,7 @@ func identifySource(src string) (string, error) {
 	return "", fmt.Errorf("unknown source %s. Did you forget the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
 }
 
-// normalizeOCISource adds the OCI scheme to unambiguous registry references.
+// normalizeOCISource adds the OCI scheme to valid registry references.
 func normalizeOCISource(source string) string {
 	if helpers.IsOCIURL(source) || strings.Contains(source, "://") {
 		return source
@@ -216,11 +217,7 @@ func normalizeOCISource(source string) string {
 		return source
 	}
 
-	registry, repository, found := strings.Cut(source, "/")
-	if !found || repository == "" {
-		return source
-	}
-	if registry == "localhost" || strings.Contains(registry, ".") || strings.Contains(registry, ":") || strings.HasPrefix(registry, "[") {
+	if _, err := registry.ParseReference(source); err == nil {
 		return helpers.OCIURLPrefix + source
 	}
 	return source

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -56,6 +56,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 	if source == "" {
 		return nil, fmt.Errorf("must provide a package source")
 	}
+	source = normalizeOCISource(source)
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
@@ -206,11 +207,31 @@ func identifySource(src string) (string, error) {
 	return "", fmt.Errorf("unknown source %s. Did you forget the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
 }
 
+// normalizeOCISource adds the OCI scheme to unambiguous registry references.
+func normalizeOCISource(source string) string {
+	if helpers.IsOCIURL(source) || strings.Contains(source, "://") {
+		return source
+	}
+	if strings.HasSuffix(source, ".tar.zst") || strings.HasSuffix(source, ".tar") || strings.Contains(source, ".part000") {
+		return source
+	}
+
+	registry, repository, found := strings.Cut(source, "/")
+	if !found || repository == "" {
+		return source
+	}
+	if registry == "localhost" || strings.Contains(registry, ".") || strings.Contains(registry, ":") || strings.HasPrefix(registry, "[") {
+		return helpers.OCIURLPrefix + source
+	}
+	return source
+}
+
 // GetPackageFromSourceOrCluster retrieves a package definition from a source or cluster.
 func GetPackageFromSourceOrCluster(ctx context.Context, cluster *cluster.Cluster, src string, namespaceOverride string, opts LoadOptions) (_ api.PackageDefinition, err error) {
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
+	src = normalizeOCISource(src)
 	srcType, err := identifySource(src)
 	if err != nil {
 		return api.PackageDefinition{}, err

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -57,7 +57,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 	if source == "" {
 		return nil, fmt.Errorf("must provide a package source")
 	}
-	source = normalizeOCISource(source)
+	source = NormalizeOCISource(source)
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
@@ -208,8 +208,8 @@ func identifySource(src string) (string, error) {
 	return "", fmt.Errorf("unknown source %s. Did you forget the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
 }
 
-// normalizeOCISource adds the OCI scheme to valid registry references.
-func normalizeOCISource(source string) string {
+// NormalizeOCISource adds the OCI scheme to valid registry references.
+func NormalizeOCISource(source string) string {
 	if helpers.IsOCIURL(source) || strings.Contains(source, "://") {
 		return source
 	}
@@ -228,7 +228,7 @@ func GetPackageFromSourceOrCluster(ctx context.Context, cluster *cluster.Cluster
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
-	src = normalizeOCISource(src)
+	src = NormalizeOCISource(src)
 	srcType, err := identifySource(src)
 	if err != nil {
 		return api.PackageDefinition{}, err

--- a/src/pkg/packager/load.go
+++ b/src/pkg/packager/load.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
-	"oras.land/oras-go/v2/registry"
 
 	"github.com/zarf-dev/zarf/src/api"
 	"github.com/zarf-dev/zarf/src/config"
@@ -57,7 +56,7 @@ func LoadPackage(ctx context.Context, source string, opts LoadOptions) (_ *layou
 	if source == "" {
 		return nil, fmt.Errorf("must provide a package source")
 	}
-	source = NormalizeOCISource(source)
+	source = zoci.NormalizeOCISource(source)
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
@@ -208,27 +207,12 @@ func identifySource(src string) (string, error) {
 	return "", fmt.Errorf("unknown source %s. Did you forget the scheme (e.g. (oci://) or file extension (e.g. .tar.zst)?", src)
 }
 
-// NormalizeOCISource adds the OCI scheme to valid registry references.
-func NormalizeOCISource(source string) string {
-	if helpers.IsOCIURL(source) || strings.Contains(source, "://") {
-		return source
-	}
-	if strings.HasSuffix(source, ".tar.zst") || strings.HasSuffix(source, ".tar") || strings.Contains(source, ".part000") {
-		return source
-	}
-
-	if _, err := registry.ParseReference(source); err == nil {
-		return helpers.OCIURLPrefix + source
-	}
-	return source
-}
-
 // GetPackageFromSourceOrCluster retrieves a package definition from a source or cluster.
 func GetPackageFromSourceOrCluster(ctx context.Context, cluster *cluster.Cluster, src string, namespaceOverride string, opts LoadOptions) (_ api.PackageDefinition, err error) {
 	if opts.Filter == nil {
 		opts.Filter = filters.Empty()
 	}
-	src = NormalizeOCISource(src)
+	src = zoci.NormalizeOCISource(src)
 	srcType, err := identifySource(src)
 	if err != nil {
 		return api.PackageDefinition{}, err

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -219,6 +219,59 @@ func TestIdentifySource(t *testing.T) {
 	}
 }
 
+func TestNormalizeOCISource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name:     "registry domain",
+			source:   "ghcr.io/zarf-dev/packages/init:v0.84.0",
+			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+		},
+		{
+			name:     "localhost registry",
+			source:   "localhost:5000/packages/init:v0.84.0",
+			expected: "oci://localhost:5000/packages/init:v0.84.0",
+		},
+		{
+			name:     "IPv6 registry",
+			source:   "[::1]:5000/packages/init:v0.84.0",
+			expected: "oci://[::1]:5000/packages/init:v0.84.0",
+		},
+		{
+			name:     "explicit OCI URL",
+			source:   "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+		},
+		{
+			name:     "cluster package name",
+			source:   "my-package",
+			expected: "my-package",
+		},
+		{
+			name:     "local tarball",
+			source:   "packages/init.tar.zst",
+			expected: "packages/init.tar.zst",
+		},
+		{
+			name:     "ambiguous path",
+			source:   "packages/init:v0.84.0",
+			expected: "packages/init:v0.84.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, normalizeOCISource(tt.source))
+		})
+	}
+}
+
 func TestPackageFromSourceOrCluster(t *testing.T) {
 	t.Parallel()
 

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -258,9 +258,14 @@ func TestNormalizeOCISource(t *testing.T) {
 			expected: "packages/init.tar.zst",
 		},
 		{
-			name:     "ambiguous path",
+			name:     "short registry hostname",
 			source:   "packages/init:v0.84.0",
-			expected: "packages/init:v0.84.0",
+			expected: "oci://packages/init:v0.84.0",
+		},
+		{
+			name:     "invalid OCI reference",
+			source:   "packages/Init:v0.84.0",
+			expected: "packages/Init:v0.84.0",
 		},
 	}
 

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -219,69 +219,6 @@ func TestIdentifySource(t *testing.T) {
 	}
 }
 
-func TestNormalizeOCISource(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		source   string
-		expected string
-	}{
-		{
-			name:     "registry domain",
-			source:   "ghcr.io/zarf-dev/packages/init:v0.84.0",
-			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
-		},
-		{
-			name:     "localhost registry",
-			source:   "localhost:5000/packages/init:v0.84.0",
-			expected: "oci://localhost:5000/packages/init:v0.84.0",
-		},
-		{
-			name:     "IPv6 registry",
-			source:   "[::1]:5000/packages/init:v0.84.0",
-			expected: "oci://[::1]:5000/packages/init:v0.84.0",
-		},
-		{
-			name:     "explicit OCI URL",
-			source:   "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
-			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
-		},
-		{
-			name:     "cluster package name",
-			source:   "my-package",
-			expected: "my-package",
-		},
-		{
-			name:     "local tarball",
-			source:   "packages/init.tar.zst",
-			expected: "packages/init.tar.zst",
-		},
-		{
-			name:     "short registry hostname",
-			source:   "packages/init:v0.84.0",
-			expected: "oci://packages/init:v0.84.0",
-		},
-		{
-			name:     "local registry",
-			source:   "localhost:5000/packages/init:v0.84.0",
-			expected: "oci://localhost:5000/packages/init:v0.84.0",
-		},
-		{
-			name:     "invalid OCI reference",
-			source:   "packages/Init:v0.84.0",
-			expected: "packages/Init:v0.84.0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.expected, NormalizeOCISource(tt.source))
-		})
-	}
-}
-
 func TestPackageFromSourceOrCluster(t *testing.T) {
 	t.Parallel()
 

--- a/src/pkg/packager/load_test.go
+++ b/src/pkg/packager/load_test.go
@@ -263,6 +263,11 @@ func TestNormalizeOCISource(t *testing.T) {
 			expected: "oci://packages/init:v0.84.0",
 		},
 		{
+			name:     "local registry",
+			source:   "localhost:5000/packages/init:v0.84.0",
+			expected: "oci://localhost:5000/packages/init:v0.84.0",
+		},
+		{
 			name:     "invalid OCI reference",
 			source:   "packages/Init:v0.84.0",
 			expected: "packages/Init:v0.84.0",
@@ -272,7 +277,7 @@ func TestNormalizeOCISource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.expected, normalizeOCISource(tt.source))
+			require.Equal(t, tt.expected, NormalizeOCISource(tt.source))
 		})
 	}
 }

--- a/src/pkg/packager/publish_test.go
+++ b/src/pkg/packager/publish_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
@@ -539,7 +538,7 @@ func TestSignOCITransportNegotiation(t *testing.T) {
 		PlainHTTP:             true,
 		InsecureSkipTLSVerify: true,
 	}
-	packagePath, err := Pull(ctx, helpers.OCIURLPrefix+sourceRef.String(), t.TempDir(), PullOptions{
+	packagePath, err := Pull(ctx, sourceRef.String(), t.TempDir(), PullOptions{
 		Architecture:  layoutExpected.AsV1alpha1().Build.Architecture,
 		RemoteOptions: remoteOptions,
 		CachePath:     t.TempDir(),

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -56,7 +56,7 @@ type PullOptions struct {
 func Pull(ctx context.Context, source, destination string, opts PullOptions) (_ string, err error) {
 	l := logger.From(ctx)
 	start := time.Now()
-	source = NormalizeOCISource(source)
+	source = zoci.NormalizeOCISource(source)
 
 	// ensure architecture is set
 	arch := config.GetArch(opts.Architecture)

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -56,7 +56,7 @@ type PullOptions struct {
 func Pull(ctx context.Context, source, destination string, opts PullOptions) (_ string, err error) {
 	l := logger.From(ctx)
 	start := time.Now()
-	source = normalizeOCISource(source)
+	source = NormalizeOCISource(source)
 
 	// ensure architecture is set
 	arch := config.GetArch(opts.Architecture)

--- a/src/pkg/packager/pull.go
+++ b/src/pkg/packager/pull.go
@@ -56,6 +56,7 @@ type PullOptions struct {
 func Pull(ctx context.Context, source, destination string, opts PullOptions) (_ string, err error) {
 	l := logger.From(ctx)
 	start := time.Now()
+	source = normalizeOCISource(source)
 
 	// ensure architecture is set
 	arch := config.GetArch(opts.Architecture)

--- a/src/pkg/zoci/utils.go
+++ b/src/pkg/zoci/utils.go
@@ -14,6 +14,21 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+// NormalizeOCISource adds the OCI scheme to valid registry references.
+func NormalizeOCISource(source string) string {
+	if helpers.IsOCIURL(source) || strings.Contains(source, "://") {
+		return source
+	}
+	if strings.HasSuffix(source, ".tar.zst") || strings.HasSuffix(source, ".tar") || strings.Contains(source, ".part000") {
+		return source
+	}
+
+	if _, err := registry.ParseReference(source); err == nil {
+		return helpers.OCIURLPrefix + source
+	}
+	return source
+}
+
 // ReferenceFromMetadata returns a reference for the given metadata.
 func ReferenceFromMetadata(registryLocation string, pkg v1alpha1.ZarfPackage) (registry.Reference, error) {
 	return ReferenceFromMetadataWithOptions(registryLocation, pkg, ReferenceFromMetadataOptions{})

--- a/src/pkg/zoci/utils_test.go
+++ b/src/pkg/zoci/utils_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package zoci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeOCISource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name:     "registry domain",
+			source:   "ghcr.io/zarf-dev/packages/init:v0.84.0",
+			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+		},
+		{
+			name:     "localhost registry",
+			source:   "localhost:5000/packages/init:v0.84.0",
+			expected: "oci://localhost:5000/packages/init:v0.84.0",
+		},
+		{
+			name:     "IPv6 registry",
+			source:   "[::1]:5000/packages/init:v0.84.0",
+			expected: "oci://[::1]:5000/packages/init:v0.84.0",
+		},
+		{
+			name:     "explicit OCI URL",
+			source:   "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+			expected: "oci://ghcr.io/zarf-dev/packages/init:v0.84.0",
+		},
+		{
+			name:     "cluster package name",
+			source:   "my-package",
+			expected: "my-package",
+		},
+		{
+			name:     "local tarball",
+			source:   "packages/init.tar.zst",
+			expected: "packages/init.tar.zst",
+		},
+		{
+			name:     "short registry hostname",
+			source:   "packages/init:v0.84.0",
+			expected: "oci://packages/init:v0.84.0",
+		},
+		{
+			name:     "invalid OCI reference",
+			source:   "packages/Init:v0.84.0",
+			expected: "packages/Init:v0.84.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, NormalizeOCISource(tt.source))
+		})
+	}
+}

--- a/src/test/e2e/11_oci_pull_inspect_test.go
+++ b/src/test/e2e/11_oci_pull_inspect_test.go
@@ -49,6 +49,7 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	suite.NoError(err, stdOut, stdErr)
 
 	simplePackageRef := fmt.Sprintf("oci://%s/simple-package:0.0.1", ref)
+	unprefixedPackageRef := fmt.Sprintf("%s/simple-package:0.0.1", ref)
 	// fail to pull the package without providing the public key
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "--verify=always")
 	suite.Error(err, stdOut, stdErr)
@@ -57,6 +58,12 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	suite.NoError(err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", simplePackageRef, "--plain-http", "-o", outputPath)
+	suite.NoError(err, stdOut, stdErr)
+
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "pull", unprefixedPackageRef, "--plain-http", "-o", outputPath)
+	suite.NoError(err, stdOut, stdErr)
+
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", unprefixedPackageRef, "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", simplePackageRef, "--plain-http", "--verify=always")
@@ -84,6 +91,10 @@ func (suite *PullInspectTestSuite) Test_0_Pull() {
 	ociDigest := strings.TrimSpace(stdOut)
 	suite.Equal(tarballDigest, ociDigest,
 		"inspect digest should return the same value for the tarball and the OCI source it was published from")
+
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "digest", unprefixedPackageRef, "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
+	suite.Equal(ociDigest, strings.TrimSpace(stdOut))
 }
 
 func (suite *PullInspectTestSuite) Test_1_Init_Loads_OCI_Over_Plain_HTTP() {

--- a/src/test/e2e/12_package_signing_test.go
+++ b/src/test/e2e/12_package_signing_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
 func TestPackageSigning(t *testing.T) {
@@ -85,5 +86,20 @@ func TestPackageSigning(t *testing.T) {
 		_, stdErr, err = e2e.Zarf(t, "package", "verify", testPath, "--key", filepath.Join("src", "test", "packages", "zarf-test.pub"))
 		require.Error(t, err)
 		require.Contains(t, stdErr, "verification material was provided but the package is not signed")
+	})
+
+	t.Run("Signing an OCI package without its source prefix", func(t *testing.T) {
+		registryURL := testutil.SetupInMemoryRegistryDynamic(testutil.TestContext(t), t)
+		source := registryURL + "/implicit-sign-source/simple-package:0.0.1"
+
+		// Create directly in the registry, then sign without the optional oci:// source prefix.
+		stdOut, stdErr, err := e2e.Zarf(t, "package", "create", filepath.Join("src", "test", "packages", "11-simple-package"), "-o", "oci://"+registryURL+"/implicit-sign-source", "--plain-http")
+		require.NoError(t, err, stdOut, stdErr)
+
+		stdOut, stdErr, err = e2e.Zarf(t, "package", "sign", source, "--signing-key", filepath.Join("src", "test", "packages", "zarf-test.prv-key"), "--plain-http")
+		require.NoError(t, err, stdOut, stdErr)
+
+		stdOut, stdErr, err = e2e.Zarf(t, "package", "verify", source, "--key", filepath.Join("src", "test", "packages", "zarf-test.pub"), "--plain-http")
+		require.NoError(t, err, stdOut, stdErr)
 	})
 }

--- a/src/test/e2e/50_oci_publish_deploy_test.go
+++ b/src/test/e2e/50_oci_publish_deploy_test.go
@@ -80,6 +80,22 @@ func (suite *PublishDeploySuiteTestSuite) Test_0_Publish() {
 	// Inspect the published package.
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", "oci://"+ref+"/helm-charts:0.0.1", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
+
+	// Copy an OCI package without its optional oci:// source prefix. The source tag must be preserved.
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", ref+"/helm-charts:0.0.1", "oci://"+ref+"/implicit-source", "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", "oci://"+ref+"/implicit-source/helm-charts:0.0.1", "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
+
+	// Sign an OCI package without its optional oci:// source prefix. With no output flag,
+	// the command must publish the signed package back to the source registry namespace.
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", chartPackagePath, "-o", "oci://"+ref+"/implicit-sign-source", "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
+	implicitSignSource := ref + "/implicit-sign-source/package-flavors:1.0.0"
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "sign", implicitSignSource, privateKeyFlag, "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "verify", implicitSignSource, publicKeyFlag, "--plain-http")
+	suite.NoError(err, stdOut, stdErr)
 }
 
 func (suite *PublishDeploySuiteTestSuite) Test_1_Deploy() {

--- a/src/test/e2e/50_oci_publish_deploy_test.go
+++ b/src/test/e2e/50_oci_publish_deploy_test.go
@@ -81,20 +81,10 @@ func (suite *PublishDeploySuiteTestSuite) Test_0_Publish() {
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", "oci://"+ref+"/helm-charts:0.0.1", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 
-	// Copy an OCI package without its optional oci:// source prefix. The source tag must be preserved.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", ref+"/helm-charts:0.0.1", "oci://"+ref+"/implicit-source", "--plain-http")
+	// Copy an OCI package without its optional oci:// source or destination prefix. The source tag must be preserved.
+	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "publish", ref+"/helm-charts:0.0.1", ref+"/implicit-source", "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "inspect", "definition", "oci://"+ref+"/implicit-source/helm-charts:0.0.1", "--plain-http")
-	suite.NoError(err, stdOut, stdErr)
-
-	// Sign an OCI package without its optional oci:// source prefix. With no output flag,
-	// the command must publish the signed package back to the source registry namespace.
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "create", chartPackagePath, "-o", "oci://"+ref+"/implicit-sign-source", "--plain-http")
-	suite.NoError(err, stdOut, stdErr)
-	implicitSignSource := ref + "/implicit-sign-source/package-flavors:1.0.0"
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "sign", implicitSignSource, privateKeyFlag, "--plain-http")
-	suite.NoError(err, stdOut, stdErr)
-	stdOut, stdErr, err = e2e.Zarf(suite.T(), "package", "verify", implicitSignSource, publicKeyFlag, "--plain-http")
 	suite.NoError(err, stdOut, stdErr)
 }
 


### PR DESCRIPTION
## Description

Adds a `normalizeOCISource` function that auto-prefixes known OCI packages with the explicit `oci://` prefix. This seemed like the least intrusive path to handle the linked issue.

## Related Issue

Fixes https://github.com/zarf-dev/zarf/issues/5271

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
