### PR TITLE
fix: introduce more randomization in the fuzzers

### DIFF
--- a/src/internal/api/v1alpha1/roundtrip_test.go
+++ b/src/internal/api/v1alpha1/roundtrip_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
+// defaultFuzzIterations specifies number of fuzzing iterations, higher number
+// will quickly raise the time needed to run them. The 20 iterations balances
+// time (currently <60s) with coverage.
+const defaultFuzzIterations = 20
+
 // TestConvertGenericRoundTripLossless asserts that decoding a v1alpha1 package, converting it to
 // the generic representation and back, reproduces the original exactly. layout and zoci load built
 // v1alpha1 packages through this round-trip, so any drift would change packages across build hosts
@@ -158,7 +163,7 @@ func TestConvertGenericRoundTripFuzz(t *testing.T) {
 	t.Parallel()
 
 	rng := rand.New(rand.NewSource(1))
-	for i := range 1000 {
+	for i := range defaultFuzzIterations {
 		var pkg v1alpha1.ZarfPackage
 		testutil.FillValue(reflect.ValueOf(&pkg).Elem(), rng)
 
@@ -180,7 +185,7 @@ func TestConvertV1alpha1V1beta1RoundTripFuzz(t *testing.T) {
 	t.Parallel()
 
 	rng := rand.New(rand.NewSource(1))
-	for i := range 1000 {
+	for i := range defaultFuzzIterations {
 		var pkg v1alpha1.ZarfPackage
 		testutil.FillValue(reflect.ValueOf(&pkg).Elem(), rng)
 		populateValidV1alpha1ChartSources(&pkg, rng, i)

--- a/src/internal/api/v1beta1/roundtrip_test.go
+++ b/src/internal/api/v1beta1/roundtrip_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/zarf-dev/zarf/src/test/testutil"
 )
 
+// defaultFuzzIterations specifies number of fuzzing iterations, higher number
+// will quickly raise the time needed to run them. The 20 iterations balances
+// time (currently <20s) with coverage.
+const defaultFuzzIterations = 20
+
 // TestConvertGenericRoundTripLossless asserts that a v1beta1 package converted to the generic
 // representation and back reproduces the original exactly. layout and zoci load built packages
 // through this round-trip, so any drift would change packages across build hosts.
@@ -194,7 +199,7 @@ func TestConvertGenericRoundTripFuzz(t *testing.T) {
 	t.Parallel()
 
 	rng := rand.New(rand.NewSource(1))
-	for i := range 1000 {
+	for i := range defaultFuzzIterations {
 		var pkg v1beta1.Package
 		testutil.FillValue(reflect.ValueOf(&pkg).Elem(), rng)
 
@@ -253,7 +258,7 @@ func TestConvertV1beta1V1alpha1RoundTripFuzz(t *testing.T) {
 	t.Parallel()
 
 	rng := rand.New(rand.NewSource(1))
-	for i := range 1000 {
+	for i := range defaultFuzzIterations {
 		var pkg v1beta1.Package
 		testutil.FillValue(reflect.ValueOf(&pkg).Elem(), rng)
 		// Valid repository url with only one source so that it can roundtrip

--- a/src/test/testutil/fuzz.go
+++ b/src/test/testutil/fuzz.go
@@ -4,9 +4,24 @@
 package testutil
 
 import (
-	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
+)
+
+const (
+	// maxElements specifies maximum number of elements in array/slice
+	maxElements = 10
+	// maxStringLen specifies maximum string length
+	maxStringLen = 20
+
+	// the following unicode range covers:
+	// - Latin-1 Supplement (0x00A0–0x00FF),
+	// - Latin Extended-A (0x0100–0x017F),
+	// - Latin Extended-B (0x0180–0x024F),
+	// - IPA Extensions (0x0250–0x02AF).
+	unicodeRangeLo = 0x00A0
+	unicodeRangeHi = 0x02AF
 )
 
 // FillValue recursively populates v for round-trip fuzz tests. Struct fields that cannot be set via
@@ -21,9 +36,10 @@ func FillValue(v reflect.Value, rng *rand.Rand) {
 		case 1:
 			v.Set(reflect.New(v.Type().Elem()))
 			return
+		default:
+			v.Set(reflect.New(v.Type().Elem()))
+			FillValue(v.Elem(), rng)
 		}
-		v.Set(reflect.New(v.Type().Elem()))
-		FillValue(v.Elem(), rng)
 	case reflect.Struct:
 		for i := range v.NumField() {
 			if f := v.Field(i); f.CanSet() {
@@ -31,7 +47,7 @@ func FillValue(v reflect.Value, rng *rand.Rand) {
 			}
 		}
 	case reflect.Slice:
-		n := 1 + rng.Intn(2)
+		n := 1 + rng.Intn(maxElements)
 		s := reflect.MakeSlice(v.Type(), n, n)
 		for i := range n {
 			FillValue(s.Index(i), rng)
@@ -39,7 +55,7 @@ func FillValue(v reflect.Value, rng *rand.Rand) {
 		v.Set(s)
 	case reflect.Map:
 		m := reflect.MakeMap(v.Type())
-		for range 1 + rng.Intn(2) {
+		for range 1 + rng.Intn(maxElements) {
 			key := reflect.New(v.Type().Key()).Elem()
 			FillValue(key, rng)
 			val := reflect.New(v.Type().Elem()).Elem()
@@ -48,14 +64,24 @@ func FillValue(v reflect.Value, rng *rand.Rand) {
 		}
 		v.Set(m)
 	case reflect.String:
-		v.SetString(fmt.Sprintf("s%d", rng.Intn(1<<30)))
+		v.SetString(randString(rng, rng.Intn(maxStringLen)))
 	case reflect.Bool:
 		v.SetBool(rng.Intn(2) == 1)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		v.SetInt(int64(1 + rng.Intn(1000)))
+		v.SetInt(int64(rng.Int31()))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v.SetUint(uint64(1 + rng.Intn(1000)))
+		v.SetUint(uint64(rng.Uint32()))
 	case reflect.Float32, reflect.Float64:
-		v.SetFloat(float64(1 + rng.Intn(1000)))
+		v.SetFloat(rng.Float64())
 	}
+}
+
+func randString(rng *rand.Rand, n int) string {
+	var sb strings.Builder
+	span := int(unicodeRangeHi-unicodeRangeLo) + 1
+	for range n {
+		r := unicodeRangeLo + rune(rng.Intn(span))
+		sb.WriteRune(r)
+	}
+	return sb.String()
 }


### PR DESCRIPTION
## Description

This change:
- increases the length randomization for slices up to 10
- increases the length randomization for strings up to 20
- introduces unicode coverage for strings
- switches to using 64-bit randoms for uints, ints and floats
- shortens the number of iterations from 1000 to 20

This is followup to https://github.com/zarf-dev/zarf/pull/5249

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
