### PR TITLE
chore: update gitea chart to `12.7.0`

### DIFF
--- a/packages/gitea/gitea-values.yaml
+++ b/packages/gitea/gitea-values.yaml
@@ -71,9 +71,6 @@ serviceAccount:
 postgresql-ha:
   enabled: false
 
-redis-cluster:
-  enabled: false
-
 valkey-cluster:
   enabled: false
 

--- a/packages/gitea/zarf.yaml
+++ b/packages/gitea/zarf.yaml
@@ -86,7 +86,7 @@ components:
       - name: gitea
         releaseName: zarf-gitea
         url: oci://registry-1.docker.io/giteacharts/gitea
-        version: 12.3.0
+        version: 12.7.0
         namespace: zarf
         valuesFiles:
           - gitea-values.yaml

--- a/src/test/e2e/06_create_sbom_test.go
+++ b/src/test/e2e/06_create_sbom_test.go
@@ -68,8 +68,8 @@ func TestCreateSBOM(t *testing.T) {
 
 	// Test that we preserve the filepath
 	require.FileExists(t, filepath.Join(outSbomPath, "dos-games", "sbom-viewer-ghcr.io_zarf-dev_doom-game_0.0.1.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-ghcr.io_go-gitea_gitea_1.24.6-rootless.html"))
-	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.24.6-rootless.json"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-ghcr.io_go-gitea_gitea_1.27.3-rootless.html"))
+	require.FileExists(t, filepath.Join(outSbomPath, "init", "ghcr.io_go-gitea_gitea_1.27.3-rootless.json"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "sbom-viewer-zarf-component-k3s.html"))
 	require.FileExists(t, filepath.Join(outSbomPath, "init", "zarf-component-k3s.json"))
 }

--- a/zarf-config.toml
+++ b/zarf-config.toml
@@ -15,4 +15,4 @@ proxy_image = 'alpine/socat'
 proxy_image_tag = '1.8.0.3'
 
 # The image reference to use for the optional git-server Zarf deploys
-gitea_image = 'ghcr.io/go-gitea/gitea:1.24.6-rootless'
+gitea_image = 'ghcr.io/go-gitea/gitea:1.27.3-rootless'


### PR DESCRIPTION
## Description

Updates the Gitea component of the init package:

- helm chart `12.3.0` -> `12.7.0`
- image `ghcr.io/go-gitea/gitea:1.24.6-rootless` -> `1.27.3-rootless` (chart appVersion is 1.27.0, 1.27.3 is the latest patch on that minor)
- removed the `redis-cluster` block from `gitea-values.yaml`. That subchart was replaced by valkey-cluster and no longer exists in 12.7.0, so the value was dead weight.
- updated the SBOM filenames in `06_create_sbom_test.go` (same substitution `hack/cots/update-gitea.sh` does)

One thing worth calling out for review: the chart and image have to move together here. The 12.7.0 init script switched from `environment-to-ini` to `gitea config edit-ini`, and that command doesn't exist in 1.24.x, so the new chart with the old image would fail on startup.

How I tested this:

- rendered the chart with the package values (template placeholders filled in by hand) against both 12.3.0 and 12.7.0 and diffed the output. Only expected differences: version labels, the image tag, and the chart's own init script change mentioned above.
- `zarf package create packages/gitea` builds cleanly, and the SBOM filenames inside the package match what the updated e2e test expects.
- since the issue specifically calls out that upgrades can be tricky, I ran one on a kind cluster: installed 12.3.0 with 1.24.6-rootless using the package values (sqlite backend), created a repo through the Gitea API, then ran `helm upgrade` to 12.7.0 / 1.27.3-rootless. The pod came up healthy, `/api/v1/version` reports 1.27.3, and the repo created before the upgrade survived the migration.

## Related Issue

Fixes #5293

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed

