### PR TITLE
feat: support listing a deployed package by name

### DIFF
--- a/site/src/content/docs/commands/zarf_package.md
+++ b/site/src/content/docs/commands/zarf_package.md
@@ -36,7 +36,7 @@ Zarf package commands for creating, deploying, and inspecting packages
 * [zarf package create](/commands/zarf_package_create/)	 - Creates a Zarf package from a given directory or the current directory
 * [zarf package deploy](/commands/zarf_package_deploy/)	 - Deploys a Zarf package from a local file or URL (runs offline)
 * [zarf package inspect](/commands/zarf_package_inspect/)	 - Commands for gathering information from a built package
-* [zarf package list](/commands/zarf_package_list/)	 - Lists out all of the packages that have been deployed to the cluster (runs offline)
+* [zarf package list](/commands/zarf_package_list/)	 - Lists packages that have been deployed to the cluster (runs offline)
 * [zarf package mirror-resources](/commands/zarf_package_mirror-resources/)	 - Mirrors a Zarf package's internal resources to specified image registries and git repositories
 * [zarf package publish](/commands/zarf_package_publish/)	 - Publishes a Zarf package to a remote registry
 * [zarf package pull](/commands/zarf_package_pull/)	 - Pulls a Zarf package from a remote registry and save to the local file system

--- a/site/src/content/docs/commands/zarf_package_list.md
+++ b/site/src/content/docs/commands/zarf_package_list.md
@@ -8,16 +8,17 @@ tableOfContents: false
 
 ## zarf package list
 
-Lists out all of the packages that have been deployed to the cluster (runs offline)
+Lists packages that have been deployed to the cluster (runs offline)
 
 ```
-zarf package list [flags]
+zarf package list [PACKAGE_NAME] [flags]
 ```
 
 ### Options
 
 ```
   -h, --help                         help for list
+  -n, --namespace string             [Alpha] Filter by namespace override when listing packages or select it for a named deployed package
   -o, --output-format outputFormat   Prints the output in the specified format. Valid options: table, json, yaml (default table)
 ```
 

--- a/src/cmd/package.go
+++ b/src/cmd/package.go
@@ -1292,9 +1292,10 @@ func (o *packageInspectDefinitionOptions) run(cmd *cobra.Command, args []string)
 }
 
 type packageListOptions struct {
-	outputFormat outputFormat
-	outputWriter io.Writer
-	cluster      *cluster.Cluster
+	outputFormat      outputFormat
+	outputWriter      io.Writer
+	cluster           *cluster.Cluster
+	namespaceOverride string
 }
 
 func newPackageListOptions() *packageListOptions {
@@ -1309,20 +1310,23 @@ func newPackageListCommand() *cobra.Command {
 	o := newPackageListOptions()
 
 	cmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"l", "ls"},
-		Short:   lang.CmdPackageListShort,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Use:               "list [PACKAGE_NAME]",
+		Aliases:           []string{"l", "ls"},
+		Short:             lang.CmdPackageListShort,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: getPackageCompletionArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			err := o.complete(ctx)
 			if err != nil {
 				return err
 			}
-			return o.run(ctx)
+			return o.run(ctx, args)
 		},
 	}
 
 	cmd.Flags().VarP(&o.outputFormat, "output-format", "o", "Prints the output in the specified format. Valid options: table, json, yaml")
+	cmd.Flags().StringVarP(&o.namespaceOverride, "namespace", "n", "", lang.CmdPackageListFlagNamespace)
 
 	return cmd
 }
@@ -1347,10 +1351,10 @@ type packageListInfo struct {
 	Components        []string                  `json:"components"`
 }
 
-func (o *packageListOptions) run(ctx context.Context) error {
-	deployedZarfPackages, err := o.cluster.GetDeployedZarfPackages(ctx)
-	if err != nil && len(deployedZarfPackages) == 0 {
-		return fmt.Errorf("unable to get the packages deployed to the cluster: %w", err)
+func (o *packageListOptions) run(ctx context.Context, args []string) error {
+	deployedZarfPackages, err := o.getDeployedPackages(ctx, args)
+	if err != nil {
+		return err
 	}
 
 	var packageList []packageListInfo
@@ -1394,6 +1398,31 @@ func (o *packageListOptions) run(ctx context.Context) error {
 		return fmt.Errorf("unsupported output format: %s", o.outputFormat)
 	}
 	return nil
+}
+
+func (o *packageListOptions) getDeployedPackages(ctx context.Context, args []string) ([]state.DeployedPackage, error) {
+	if len(args) == 0 {
+		deployedZarfPackages, err := o.cluster.GetDeployedZarfPackages(ctx)
+		if err != nil && len(deployedZarfPackages) == 0 {
+			return nil, fmt.Errorf("unable to get the packages deployed to the cluster: %w", err)
+		}
+		if o.namespaceOverride != "" {
+			filteredPackages := make([]state.DeployedPackage, 0, len(deployedZarfPackages))
+			for _, deployedPackage := range deployedZarfPackages {
+				if deployedPackage.NamespaceOverride == o.namespaceOverride {
+					filteredPackages = append(filteredPackages, deployedPackage)
+				}
+			}
+			return filteredPackages, nil
+		}
+		return deployedZarfPackages, nil
+	}
+
+	deployedPackage, err := o.cluster.GetDeployedPackage(ctx, args[0], state.WithPackageNamespaceOverride(o.namespaceOverride))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get package %q deployed to the cluster: %w", args[0], err)
+	}
+	return []state.DeployedPackage{*deployedPackage}, nil
 }
 
 type packageRemoveOptions struct {

--- a/src/cmd/package_test.go
+++ b/src/cmd/package_test.go
@@ -118,7 +118,7 @@ func TestPackageList(t *testing.T) {
 				outputWriter: buf,
 				cluster:      c,
 			}
-			err := listOpts.run(ctx)
+			err := listOpts.run(ctx, nil)
 			require.NoError(t, err)
 			b, err := os.ReadFile(filepath.Join("testdata", "package-list", tt.file))
 			require.NoError(t, err)
@@ -130,6 +130,140 @@ func TestPackageList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPackageListFiltersByNamespaceOverride(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := &cluster.Cluster{Clientset: fake.NewClientset()}
+	packages := []state.DeployedPackage{
+		{
+			Name: "package1",
+		},
+		{
+			Name:              "package2",
+			NamespaceOverride: "test2",
+		},
+	}
+
+	for _, p := range packages {
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.GetSecretName(),
+				Namespace: state.ZarfNamespaceName,
+				Labels:    map[string]string{state.ZarfPackageInfoLabel: p.Name},
+			},
+			Data: map[string][]byte{"data": b},
+		}
+		_, err = c.Clientset.CoreV1().Secrets(state.ZarfNamespaceName).Create(ctx, &secret, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	buf := new(bytes.Buffer)
+	listOpts := packageListOptions{
+		outputFormat:      outputJSON,
+		outputWriter:      buf,
+		cluster:           c,
+		namespaceOverride: "test2",
+	}
+	require.NoError(t, listOpts.run(ctx, nil))
+	require.JSONEq(t, `[
+  {
+    "package": "package2",
+    "namespaceOverride": "test2",
+    "version": "",
+    "connectivity": "airgap",
+    "components": null
+  }
+]`, buf.String())
+}
+
+func TestPackageListCommandAcceptsOptionalPackageName(t *testing.T) {
+	t.Parallel()
+
+	cmd := newPackageListCommand()
+
+	require.Equal(t, "list [PACKAGE_NAME]", cmd.Use)
+	require.NotNil(t, cmd.Args)
+	require.Equal(t, "n", cmd.Flag("namespace").Shorthand)
+	require.NoError(t, cmd.Args(cmd, []string{"package1"}))
+	require.Error(t, cmd.Args(cmd, []string{"package1", "package2"}))
+}
+
+func TestPackageListNamedPackage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := &cluster.Cluster{Clientset: fake.NewClientset()}
+	packages := []state.DeployedPackage{
+		{
+			Name: "package1",
+			Data: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Version: "0.42.0"},
+			},
+			DeployedComponents: []state.DeployedComponent{{Name: "component1"}},
+		},
+		{
+			Name:              "package2",
+			NamespaceOverride: "test2",
+			Data: v1alpha1.ZarfPackage{
+				Metadata: v1alpha1.ZarfMetadata{Version: "1.0.0"},
+			},
+			DeployedComponents: []state.DeployedComponent{{Name: "component2"}},
+		},
+	}
+
+	for _, p := range packages {
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.GetSecretName(),
+				Namespace: state.ZarfNamespaceName,
+				Labels:    map[string]string{state.ZarfPackageInfoLabel: p.Name},
+			},
+			Data: map[string][]byte{"data": b},
+		}
+		_, err = c.Clientset.CoreV1().Secrets(state.ZarfNamespaceName).Create(ctx, &secret, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	buf := new(bytes.Buffer)
+	listOpts := packageListOptions{
+		outputFormat: outputJSON,
+		outputWriter: buf,
+		cluster:      c,
+	}
+	require.NoError(t, listOpts.run(ctx, []string{"package1"}))
+	require.JSONEq(t, `[
+  {
+    "package": "package1",
+    "namespaceOverride": "",
+    "version": "0.42.0",
+    "connectivity": "airgap",
+    "components": ["component1"]
+  }
+]`, buf.String())
+
+	buf.Reset()
+	listOpts.namespaceOverride = "test2"
+	require.NoError(t, listOpts.run(ctx, []string{"package2"}))
+	require.JSONEq(t, `[
+  {
+    "package": "package2",
+    "namespaceOverride": "test2",
+    "version": "1.0.0",
+    "connectivity": "airgap",
+    "components": ["component2"]
+  }
+]`, buf.String())
+
+	listOpts.namespaceOverride = ""
+	require.Error(t, listOpts.run(ctx, []string{"package2"}))
+	require.Error(t, listOpts.run(ctx, []string{"missing"}))
 }
 
 func TestPackageInspectManifests(t *testing.T) {

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -284,7 +284,8 @@ $ zarf package mirror-resources zarf-package-my-app-amd64-1.0.0.tar.zst --repos 
 
 	CmdPackageInspectShort = "Commands for gathering information from a built package"
 
-	CmdPackageListShort         = "Lists out all of the packages that have been deployed to the cluster (runs offline)"
+	CmdPackageListShort         = "Lists packages that have been deployed to the cluster (runs offline)"
+	CmdPackageListFlagNamespace = "[Alpha] Filter by namespace override when listing packages or select it for a named deployed package"
 	CmdPackageListNoPackageWarn = "Unable to get the packages deployed to the cluster"
 
 	CmdPackageCreateFlagConfirm               = "Confirm package creation without prompting"


### PR DESCRIPTION
## Description

Adds an optional package name argument to `zarf package list`.

- `zarf package list` continues to list all deployed packages.
- `zarf package list <PACKAGE_NAME>` retrieves and displays a single deployed package.
- JSON and YAML output retain the existing list-shaped format.
- Adds argument validation and package-name completion.
- Updates the generated command documentation.

## Related Issue

Fixes #5220

## Checklist before merging

- [ x ] Test, docs, adr added or updated as needed
- [ x ] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
