### PR TITLE
feat: reject extra arguments to destroy

### DIFF
--- a/src/cmd/destroy.go
+++ b/src/cmd/destroy.go
@@ -32,6 +32,7 @@ func newDestroyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "destroy --confirm",
 		Aliases: []string{"d"},
+		Args:    cobra.NoArgs,
 		Short:   lang.CmdDestroyShort,
 		Long:    lang.CmdDestroyLong,
 		RunE:    o.run,

--- a/src/cmd/destroy_test.go
+++ b/src/cmd/destroy_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroyCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		args            []string
+		wantErrContains string
+		wantRun         bool
+	}{
+		{
+			name:    "confirmed destroy",
+			args:    []string{"--confirm"},
+			wantRun: true,
+		},
+		{
+			name:            "positional argument",
+			args:            []string{"podinfo", "--confirm"},
+			wantErrContains: `unknown command "podinfo"`,
+		},
+		{
+			name:            "missing confirmation",
+			args:            []string{},
+			wantErrContains: `required flag(s) "confirm" not set`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newDestroyCommand()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			runCalled := false
+			cmd.RunE = func(_ *cobra.Command, _ []string) error {
+				runCalled = true
+				return nil
+			}
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			if tt.wantErrContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErrContains)
+			}
+			require.Equal(t, tt.wantRun, runCalled)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Return an error when extra arguments are included with `destroy` command to prevent accidental destruction if a user erroneously attempts to use `destroy` to remove a single package. 

Currently, if a user were to run `zarf destroy podinfo --confirm`, incorrectly attempting to remove an installed `podinfo` package, zarf will silently ignore the additional `podinfo` argument and proceed to destroy everything. While this _is_ the intended behavior of running `destroy`, erroring when additional arguments are provided could help to prevent a costly user mistake.

Previous behavior:
```shell
❯ zarf destroy podinfo --confirm
2026-09-03 15:15:33 INF waiting for cluster connection
2026-09-03 15:15:33 INF removing Zarf-installed charts
2026-09-03 15:15:33 INF uninstalling helm chart namespace=zarf name=zarf-d2db14ef40305397791454e883b26fc94ad9615d
2026-09-03 15:15:33 INF uninstalling helm chart namespace=zarf name=zarf-6fd4933a3193a9565e76c479531ec18fbae1b512
2026-09-03 15:15:33 INF uninstalling helm chart namespace=zarf name=zarf-a0e2de5862bbc49ea7f205abbb4da84041fe9c74
2026-09-03 15:15:33 INF uninstalling helm chart namespace=zarf name=zarf-docker-registry
2026-09-03 15:15:35 INF deleting the zarf namespace from this cluster
...
```

Changed behavior:
```shell
❯ zarf destroy podinfo --confirm
2026-09-03 17:02:15 ERR unknown command "podinfo" for "zarf destroy"
```

## Related Issue
N/A

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
