### PR TITLE
feat(cluster): support random registry pod selection

### DIFF
--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -155,7 +155,7 @@ func (c *Cluster) ConnectToZarfRegistryEndpoint(ctx context.Context, registryInf
 	var tunnel *Tunnel
 	if registryInfo.IsInternal() {
 		// Establish a registry tunnel to send the images to the zarf registry
-		if tunnel, err = c.NewTunnel(state.ZarfNamespaceName, SvcResource, ZarfRegistryName, "", 0, ZarfRegistryPort, withServicePodSelector(selectRandomServicePod)); err != nil {
+		if tunnel, err = c.NewTunnel(state.ZarfNamespaceName, SvcResource, ZarfRegistryName, "", 0, ZarfRegistryPort); err != nil {
 			return "", tunnel, err
 		}
 	} else if dns.IsServiceURL(registryInfo.Address) {
@@ -322,18 +322,6 @@ const (
 // TunnelOption is a function that configures a tunnel
 type TunnelOption func(*Tunnel)
 
-type servicePodSelector func([]corev1.Pod) corev1.Pod
-
-func withServicePodSelector(selector servicePodSelector) TunnelOption {
-	return func(t *Tunnel) {
-		t.servicePodSelector = selector
-	}
-}
-
-func selectRandomServicePod(pods []corev1.Pod) corev1.Pod {
-	return pods[rand.IntN(len(pods))]
-}
-
 // WithListenAddress will set the listen address for the tunnel
 func WithListenAddress(addr []string) TunnelOption {
 	return func(t *Tunnel) {
@@ -343,19 +331,18 @@ func WithListenAddress(addr []string) TunnelOption {
 
 // Tunnel is the main struct that configures and manages port forwarding tunnels to Kubernetes resources.
 type Tunnel struct {
-	clientset          kubernetes.Interface
-	restConfig         *rest.Config
-	localPort          int
-	remotePort         int
-	namespace          string
-	resourceType       string
-	resourceName       string
-	urlSuffix          string
-	listenAddress      []string
-	servicePodSelector servicePodSelector
-	stopChan           chan struct{}
-	readyChan          chan struct{}
-	errChan            chan error
+	clientset     kubernetes.Interface
+	restConfig    *rest.Config
+	localPort     int
+	remotePort    int
+	namespace     string
+	resourceType  string
+	resourceName  string
+	urlSuffix     string
+	listenAddress []string
+	stopChan      chan struct{}
+	readyChan     chan struct{}
+	errChan       chan error
 }
 
 // NewTunnel will create a new Tunnel struct.
@@ -592,25 +579,17 @@ func (tunnel *Tunnel) getAttachablePodForService(ctx context.Context) (string, e
 	// status.phase=Running alone isn't enough: a pod stays "Running" throughout its
 	// graceful termination (e.g. mid-rollout), so without also checking these, a
 	// port-forward can bind to a pod that's already on its way out.
-	if tunnel.servicePodSelector == nil {
-		for _, pod := range podList.Items {
-			if pod.DeletionTimestamp == nil && podutils.IsPodReady(&pod) {
-				return pod.Name, nil
-			}
-		}
-		return "", fmt.Errorf("no ready pods found for service %s", tunnel.resourceName)
-	}
-
 	readyPods := make([]corev1.Pod, 0, len(podList.Items))
 	for _, pod := range podList.Items {
-		if pod.DeletionTimestamp == nil && podutils.IsPodReady(&pod) {
-			readyPods = append(readyPods, pod)
+		if pod.DeletionTimestamp != nil || !podutils.IsPodReady(&pod) {
+			continue
 		}
+		readyPods = append(readyPods, pod)
 	}
 	if len(readyPods) == 0 {
 		return "", fmt.Errorf("no ready pods found for service %s", tunnel.resourceName)
 	}
-	return tunnel.servicePodSelector(readyPods).Name, nil
+	return readyPods[rand.IntN(len(readyPods))].Name, nil
 }
 
 // Inspired by https://github.com/kubernetes/kubernetes/blob/1ee1ff97fb7f9755a44d29bee0c80d2ccbed68dc/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go#L139-L156

--- a/src/pkg/cluster/tunnel.go
+++ b/src/pkg/cluster/tunnel.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strings"
@@ -154,7 +155,7 @@ func (c *Cluster) ConnectToZarfRegistryEndpoint(ctx context.Context, registryInf
 	var tunnel *Tunnel
 	if registryInfo.IsInternal() {
 		// Establish a registry tunnel to send the images to the zarf registry
-		if tunnel, err = c.NewTunnel(state.ZarfNamespaceName, SvcResource, ZarfRegistryName, "", 0, ZarfRegistryPort); err != nil {
+		if tunnel, err = c.NewTunnel(state.ZarfNamespaceName, SvcResource, ZarfRegistryName, "", 0, ZarfRegistryPort, withServicePodSelector(selectRandomServicePod)); err != nil {
 			return "", tunnel, err
 		}
 	} else if dns.IsServiceURL(registryInfo.Address) {
@@ -321,6 +322,18 @@ const (
 // TunnelOption is a function that configures a tunnel
 type TunnelOption func(*Tunnel)
 
+type servicePodSelector func([]corev1.Pod) corev1.Pod
+
+func withServicePodSelector(selector servicePodSelector) TunnelOption {
+	return func(t *Tunnel) {
+		t.servicePodSelector = selector
+	}
+}
+
+func selectRandomServicePod(pods []corev1.Pod) corev1.Pod {
+	return pods[rand.IntN(len(pods))]
+}
+
 // WithListenAddress will set the listen address for the tunnel
 func WithListenAddress(addr []string) TunnelOption {
 	return func(t *Tunnel) {
@@ -330,18 +343,19 @@ func WithListenAddress(addr []string) TunnelOption {
 
 // Tunnel is the main struct that configures and manages port forwarding tunnels to Kubernetes resources.
 type Tunnel struct {
-	clientset     kubernetes.Interface
-	restConfig    *rest.Config
-	localPort     int
-	remotePort    int
-	namespace     string
-	resourceType  string
-	resourceName  string
-	urlSuffix     string
-	listenAddress []string
-	stopChan      chan struct{}
-	readyChan     chan struct{}
-	errChan       chan error
+	clientset          kubernetes.Interface
+	restConfig         *rest.Config
+	localPort          int
+	remotePort         int
+	namespace          string
+	resourceType       string
+	resourceName       string
+	urlSuffix          string
+	listenAddress      []string
+	servicePodSelector servicePodSelector
+	stopChan           chan struct{}
+	readyChan          chan struct{}
+	errChan            chan error
 }
 
 // NewTunnel will create a new Tunnel struct.
@@ -578,12 +592,25 @@ func (tunnel *Tunnel) getAttachablePodForService(ctx context.Context) (string, e
 	// status.phase=Running alone isn't enough: a pod stays "Running" throughout its
 	// graceful termination (e.g. mid-rollout), so without also checking these, a
 	// port-forward can bind to a pod that's already on its way out.
+	if tunnel.servicePodSelector == nil {
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp == nil && podutils.IsPodReady(&pod) {
+				return pod.Name, nil
+			}
+		}
+		return "", fmt.Errorf("no ready pods found for service %s", tunnel.resourceName)
+	}
+
+	readyPods := make([]corev1.Pod, 0, len(podList.Items))
 	for _, pod := range podList.Items {
 		if pod.DeletionTimestamp == nil && podutils.IsPodReady(&pod) {
-			return pod.Name, nil
+			readyPods = append(readyPods, pod)
 		}
 	}
-	return "", fmt.Errorf("no ready pods found for service %s", tunnel.resourceName)
+	if len(readyPods) == 0 {
+		return "", fmt.Errorf("no ready pods found for service %s", tunnel.resourceName)
+	}
+	return tunnel.servicePodSelector(readyPods).Name, nil
 }
 
 // Inspired by https://github.com/kubernetes/kubernetes/blob/1ee1ff97fb7f9755a44d29bee0c80d2ccbed68dc/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go#L139-L156

--- a/src/pkg/cluster/tunnel_test.go
+++ b/src/pkg/cluster/tunnel_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/state"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestListConnections(t *testing.T) {
@@ -222,14 +224,46 @@ func TestGetAttachablePodForService(t *testing.T) {
 	now := metav1.Now()
 
 	tests := []struct {
-		name        string
-		pods        []corev1.Pod
-		expectedErr string
-		expectedPod string
+		name               string
+		pods               []corev1.Pod
+		servicePodSelector servicePodSelector
+		expectedErr        string
+		expectedPod        string
 	}{
 		{
 			name:        "no pods",
 			expectedErr: "no pods found for service web",
+		},
+		{
+			name: "uses first ready pod without a selector",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-first", Labels: map[string]string{"app": "web"}},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-final", Labels: map[string]string{"app": "web"}},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
+				},
+			},
+			expectedPod: "web-ready-first",
+		},
+		{
+			name: "uses configured selector across ready pods",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-first", Labels: map[string]string{"app": "web"}},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-final", Labels: map[string]string{"app": "web"}},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
+				},
+			},
+			servicePodSelector: func(pods []corev1.Pod) corev1.Pod {
+				return pods[len(pods)-1]
+			},
+			expectedPod: "web-ready-final",
 		},
 		{
 			name: "only a terminating pod",
@@ -274,6 +308,9 @@ func TestGetAttachablePodForService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			clientset := fake.NewClientset()
+			clientset.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &corev1.PodList{Items: tt.pods}, nil
+			})
 			svc := corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web"},
 				Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
@@ -285,7 +322,7 @@ func TestGetAttachablePodForService(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			tunnel := &Tunnel{clientset: clientset, namespace: "app-ns", resourceName: "web"}
+			tunnel := &Tunnel{clientset: clientset, namespace: "app-ns", resourceName: "web", servicePodSelector: tt.servicePodSelector}
 			podName, err := tunnel.getAttachablePodForService(context.Background())
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)

--- a/src/pkg/cluster/tunnel_test.go
+++ b/src/pkg/cluster/tunnel_test.go
@@ -224,18 +224,17 @@ func TestGetAttachablePodForService(t *testing.T) {
 	now := metav1.Now()
 
 	tests := []struct {
-		name               string
-		pods               []corev1.Pod
-		servicePodSelector servicePodSelector
-		expectedErr        string
-		expectedPod        string
+		name         string
+		pods         []corev1.Pod
+		expectedErr  string
+		expectedPods []string
 	}{
 		{
 			name:        "no pods",
 			expectedErr: "no pods found for service web",
 		},
 		{
-			name: "uses first ready pod without a selector",
+			name: "selects a ready pod",
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-first", Labels: map[string]string{"app": "web"}},
@@ -246,24 +245,7 @@ func TestGetAttachablePodForService(t *testing.T) {
 					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
 				},
 			},
-			expectedPod: "web-ready-first",
-		},
-		{
-			name: "uses configured selector across ready pods",
-			pods: []corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-first", Labels: map[string]string{"app": "web"}},
-					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "web-ready-final", Labels: map[string]string{"app": "web"}},
-					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
-				},
-			},
-			servicePodSelector: func(pods []corev1.Pod) corev1.Pod {
-				return pods[len(pods)-1]
-			},
-			expectedPod: "web-ready-final",
+			expectedPods: []string{"web-ready-first", "web-ready-final"},
 		},
 		{
 			name: "only a terminating pod",
@@ -301,7 +283,7 @@ func TestGetAttachablePodForService(t *testing.T) {
 					Status:     corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{readyCondition}},
 				},
 			},
-			expectedPod: "web-ready",
+			expectedPods: []string{"web-ready"},
 		},
 	}
 	for _, tt := range tests {
@@ -322,14 +304,14 @@ func TestGetAttachablePodForService(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			tunnel := &Tunnel{clientset: clientset, namespace: "app-ns", resourceName: "web", servicePodSelector: tt.servicePodSelector}
+			tunnel := &Tunnel{clientset: clientset, namespace: "app-ns", resourceName: "web"}
 			podName, err := tunnel.getAttachablePodForService(context.Background())
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedPod, podName)
+			require.Contains(t, tt.expectedPods, podName)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Randomizes internal-registry tunnel pod selection so image pushes are distributed across ready registry replicas instead of always targeting the first pod returned by Kubernetes. Adds an optional service-pod selector to tunnels, preserves existing selection behavior elsewhere.
## Related Issue

Fixes #5313


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
