### PR TITLE
feat: debug log container runtime for diagnostics - warn on cri-o

### DIFF
--- a/src/pkg/packager/deploy.go
+++ b/src/pkg/packager/deploy.go
@@ -438,6 +438,11 @@ func (d *deployer) deployInitComponent(ctx context.Context, pkgLayout *layout.Pa
 		if err := d.c.SaveState(ctx, d.s); err != nil {
 			return nil, err
 		}
+
+		switch d.s.RegistryInfo.RegistryMode {
+		case state.RegistryModeNodePort, state.RegistryModeProxy:
+			logBootstrapRuntimeDiagnostics(ctx, d.c, state.LocalhostRegistryAddress(d.s.IPFamily, d.s.InjectorInfo.Port))
+		}
 	}
 
 	// Skip image checksum if component is agent.

--- a/src/pkg/packager/deploy_diagnostics.go
+++ b/src/pkg/packager/deploy_diagnostics.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var crioBootstrapMinimumVersion = semver.MustParse("1.35.0")
+
+func logBootstrapRuntimeDiagnostics(ctx context.Context, c *cluster.Cluster, injectorAddress string) {
+	l := logger.From(ctx)
+	nodes, err := c.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		l.Debug("unable to inspect node container runtimes for CRI-O bootstrap compatibility", "error", err)
+		return
+	}
+
+	sort.Slice(nodes.Items, func(i, j int) bool {
+		return nodes.Items[i].Name < nodes.Items[j].Name
+	})
+
+	logDetectedContainerRuntimes(ctx, nodes.Items)
+	warnCRIOBootstrapCompatibility(ctx, nodes.Items, injectorAddress)
+}
+
+func logDetectedContainerRuntimes(ctx context.Context, nodes []corev1.Node) {
+	l := logger.From(ctx)
+	if !l.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+
+	runtimes := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		runtimeVersion := node.Status.NodeInfo.ContainerRuntimeVersion
+		if runtimeVersion != "" {
+			runtimes = append(runtimes, fmt.Sprintf("%s (%s)", node.Name, runtimeVersion))
+		}
+	}
+	l.Debug("detected node container runtimes", "runtimes", strings.Join(runtimes, ", "))
+}
+
+func warnCRIOBootstrapCompatibility(ctx context.Context, nodes []corev1.Node, injectorAddress string) {
+	matching := make([]string, 0)
+	for _, node := range nodes {
+		runtimeVersion := node.Status.NodeInfo.ContainerRuntimeVersion
+		versionString, isCRIO := strings.CutPrefix(runtimeVersion, "cri-o://")
+		if !isCRIO {
+			continue
+		}
+		version, err := semver.NewVersion(versionString)
+		if err == nil && !version.LessThan(crioBootstrapMinimumVersion) {
+			matching = append(matching, fmt.Sprintf("%s (%s)", node.Name, runtimeVersion))
+		}
+	}
+	if len(matching) == 0 {
+		return
+	}
+
+	logger.From(ctx).Warn(fmt.Sprintf(
+		"CRI-O 1.35+ detected on nodes %s. Zarf's temporary bootstrap injector at %s serves HTTP, while affected CRI-O registry policies may attempt HTTPS. If bootstrap image pulls fail, configure this endpoint in the node runtime's registries.conf or use an external registry.",
+		strings.Join(matching, ", "), injectorAddress,
+	))
+}

--- a/src/pkg/packager/deploy_diagnostics_test.go
+++ b/src/pkg/packager/deploy_diagnostics_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021-Present The Zarf Authors
+
+package packager
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestLogBootstrapRuntimeDiagnostics(t *testing.T) {
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		listError   bool
+		wantWarning bool
+	}{
+		{
+			name: "warns only for qualifying CRI-O while logging all runtimes",
+			objects: []runtime.Object{
+				testRuntimeNode("worker-crio", "cri-o://1.35.6-5.rhaos4.22.git41f610b.el9"),
+				testRuntimeNode("worker-containerd", "containerd://2.2.0"),
+				testRuntimeNode("worker-old", "cri-o://1.34.9"),
+			},
+			wantWarning: true,
+		},
+		{
+			name: "logs inventory without warning for nonmatching runtimes",
+			objects: []runtime.Object{
+				testRuntimeNode("worker-containerd", "containerd://2.2.0"),
+				testRuntimeNode("worker-malformed", "cri-o://not-a-version"),
+			},
+		},
+		{
+			name:      "logs lookup failures without warning",
+			listError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			l, err := logger.New(logger.Config{
+				Level:       logger.Debug,
+				Format:      logger.FormatJSON,
+				Destination: logger.Destination(&output),
+			})
+			require.NoError(t, err)
+
+			cs := fake.NewClientset(tt.objects...)
+			if tt.listError {
+				cs.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("nodes forbidden")
+				})
+			}
+
+			logBootstrapRuntimeDiagnostics(logger.WithContext(context.Background(), l), &cluster.Cluster{Clientset: cs}, "127.0.0.1:31999")
+
+			logs := output.String()
+			if tt.listError {
+				require.Contains(t, logs, "unable to inspect node container runtimes")
+				require.NotContains(t, logs, "CRI-O 1.35+ detected")
+				return
+			}
+			require.Contains(t, logs, "detected node container runtimes")
+			require.Contains(t, logs, "worker-containerd")
+			require.Contains(t, logs, "containerd://2.2.0")
+			if tt.wantWarning {
+				require.Contains(t, logs, "CRI-O 1.35+ detected")
+				require.Contains(t, logs, "worker-crio")
+				require.Contains(t, logs, "127.0.0.1:31999")
+				require.Contains(t, logs, "use an external registry")
+			} else {
+				require.Contains(t, logs, "worker-malformed")
+				require.Contains(t, logs, "cri-o://not-a-version")
+				require.NotContains(t, logs, "CRI-O 1.35+ detected")
+			}
+		})
+	}
+}
+
+func testRuntimeNode(name, runtimeVersion string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{ContainerRuntimeVersion: runtimeVersion}},
+	}
+}


### PR DESCRIPTION
## Description

See associated issue for more information on incompatibility - this adds a diagnostic for container runtime on nodes with a warning for the known versions of cri-o. 

There may be room for expanding diagnostics further so I went this direction while implementing the warning. Any future incompatibility problems would benefit from this information. 

Does not increase the surface area of the init command RBAC but deemed this something we perform as a preflight warning based on most isolated location with all required information for the activity. 

## Related Issue

Relates to #5325

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
