### PR TITLE
fix(values): infer integer and unknown schema types

### DIFF
--- a/src/pkg/value/generate.go
+++ b/src/pkg/value/generate.go
@@ -5,6 +5,7 @@ package value
 
 import (
 	"fmt"
+	"math"
 )
 
 // GenerateJSONSchema infers a JSON schema from the structure and scalar types in values.
@@ -31,6 +32,10 @@ func ReconcileJSONSchema(existing, inferred map[string]any, deleteNotFound bool)
 	typeVal, hasType := inferred["type"]
 	if hasType {
 		existing["type"] = typeVal
+	} else if deleteNotFound {
+		delete(existing, "type")
+		delete(existing, "properties")
+		delete(existing, "items")
 	}
 
 	if schemaTypeIncludes(typeVal, "object") {
@@ -396,8 +401,12 @@ func inferSchemaType(v any) any {
 	switch val := v.(type) {
 	case string:
 		return map[string]any{"type": "string"}
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
-		return map[string]any{"type": "number"}
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return map[string]any{"type": "integer"}
+	case float32:
+		return inferFloatSchema(float64(val))
+	case float64:
+		return inferFloatSchema(val)
 	case bool:
 		return map[string]any{"type": "boolean"}
 	case map[string]any:
@@ -415,6 +424,13 @@ func inferSchemaType(v any) any {
 		}
 		return map[string]any{"type": "array"}
 	default:
-		return map[string]any{"type": "string"}
+		return map[string]any{}
 	}
+}
+
+func inferFloatSchema(val float64) map[string]any {
+	if math.Trunc(val) == val {
+		return map[string]any{"type": "integer"}
+	}
+	return map[string]any{"type": "number"}
 }

--- a/src/pkg/value/generate_test.go
+++ b/src/pkg/value/generate_test.go
@@ -13,10 +13,12 @@ import (
 func TestGenerateJSONSchema(t *testing.T) {
 	t.Run("infers nested types", func(t *testing.T) {
 		vals := Values{
-			"name":     "zarf",
-			"replicas": uint64(3),
-			"enabled":  true,
-			"ports":    []any{uint64(80)},
+			"name":        "zarf",
+			"replicas":    float64(3),
+			"threshold":   0.75,
+			"enabled":     true,
+			"ports":       []any{uint64(80)},
+			"annotations": nil,
 			"image": map[string]any{
 				"tag": "v1.2.3",
 			},
@@ -36,7 +38,11 @@ func TestGenerateJSONSchema(t *testing.T) {
 
 		replicas, ok := props["replicas"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "number", replicas["type"])
+		assert.Equal(t, "integer", replicas["type"])
+
+		threshold, ok := props["threshold"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "number", threshold["type"])
 
 		enabled, ok := props["enabled"].(map[string]any)
 		require.True(t, ok)
@@ -47,7 +53,11 @@ func TestGenerateJSONSchema(t *testing.T) {
 		assert.Equal(t, "array", ports["type"])
 		items, ok := ports["items"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "number", items["type"])
+		assert.Equal(t, "integer", items["type"])
+
+		annotations, ok := props["annotations"].(map[string]any)
+		require.True(t, ok)
+		assert.Empty(t, annotations)
 
 		image, ok := props["image"].(map[string]any)
 		require.True(t, ok)
@@ -58,6 +68,26 @@ func TestGenerateJSONSchema(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "string", tag["type"])
 	})
+}
+
+func TestReconcileJSONSchemaUnknownType(t *testing.T) {
+	existing := map[string]any{
+		"type":        "object",
+		"description": "preserve this",
+		"properties":  map[string]any{"name": map[string]any{"type": "string"}},
+		"items":       map[string]any{"type": "string"},
+	}
+
+	preserved := ReconcileJSONSchema(existing, map[string]any{}, false)
+	assert.Equal(t, "object", preserved["type"])
+	assert.Contains(t, preserved, "properties")
+	assert.Contains(t, preserved, "items")
+
+	pruned := ReconcileJSONSchema(existing, map[string]any{}, true)
+	assert.NotContains(t, pruned, "type")
+	assert.NotContains(t, pruned, "properties")
+	assert.NotContains(t, pruned, "items")
+	assert.Equal(t, "preserve this", pruned["description"])
 }
 
 func TestMergeJSONSchemaAtPathPreservesNullableObjects(t *testing.T) {

--- a/src/test/e2e/14_zarf_package_generate_test.go
+++ b/src/test/e2e/14_zarf_package_generate_test.go
@@ -71,8 +71,7 @@ func TestZarfDevGenerate(t *testing.T) {
 
 		aReplicas, ok := appProps["replicas"].(map[string]any)
 		require.True(t, ok)
-		// .app.replicas should take the type 'number' from the parent values.yaml
-		require.Equal(t, "number", aReplicas["type"])
+		require.Equal(t, "integer", aReplicas["type"])
 		// .app.replicas should take the description from the parent values.schema.json
 		require.Equal(t, "Replica count", aReplicas["description"])
 
@@ -90,8 +89,7 @@ func TestZarfDevGenerate(t *testing.T) {
 
 		bReplicas, ok := backendProps["replicaCount"].(map[string]any)
 		require.True(t, ok)
-		// .backend.replicas should take the type 'number' from the child values.yaml
-		require.Equal(t, "number", bReplicas["type"])
+		require.Equal(t, "integer", bReplicas["type"])
 		// .backend.replicas should take the description from the child values.schema.json
 		require.Equal(t, "Replica count", bReplicas["description"])
 
@@ -102,7 +100,7 @@ func TestZarfDevGenerate(t *testing.T) {
 		require.True(t, ok)
 		bPort, ok := bServiceProps["port"].(map[string]any)
 		require.True(t, ok)
-		require.Equal(t, "number", bPort["type"])
+		require.Equal(t, "integer", bPort["type"])
 
 		// .network should be pulled in from the parent's mapped chart
 		network, ok := props["network"].(map[string]any)
@@ -111,7 +109,7 @@ func TestZarfDevGenerate(t *testing.T) {
 		require.True(t, ok)
 		port, ok := networkProps["port"].(map[string]any)
 		require.True(t, ok)
-		require.Equal(t, "number", port["type"])
+		require.Equal(t, "integer", port["type"])
 
 		configMap, ok := props["configMap"].(map[string]any)
 		require.True(t, ok)
@@ -127,6 +125,11 @@ func TestZarfDevGenerate(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, "string", additionalProperties["type"])
 		}
+
+		fallback, ok := props["fallback"].(map[string]any)
+		require.True(t, ok)
+		require.NotContains(t, fallback, "type")
+		require.Equal(t, "Value without an inferred type", fallback["description"])
 
 		// .backend.image should be dropped because it is excluded from the chart mapping.
 		_, hasExcludedImage := backendProps["image"]

--- a/src/test/packages/14-generate-schema/chart/values.yaml
+++ b/src/test/packages/14-generate-schema/chart/values.yaml
@@ -8,3 +8,5 @@ image:
 configMap:
   annotations:
   labels:
+
+fallback:

--- a/src/test/packages/14-generate-schema/values.schema.json
+++ b/src/test/packages/14-generate-schema/values.schema.json
@@ -16,6 +16,10 @@
         }
       }
     },
+    "fallback": {
+      "type": "string",
+      "description": "Value without an inferred type"
+    },
     "oldField": {
       "type": "string",
       "description": "Should be removed"

--- a/src/test/packages/14-generate-schema/zarf.yaml
+++ b/src/test/packages/14-generate-schema/zarf.yaml
@@ -26,6 +26,8 @@ components:
             targetPath: ".configMap.annotations"
           - sourcePath: ".configMap.labels"
             targetPath: ".configMap.labels"
+          - sourcePath: ".fallback"
+            targetPath: ".fallback"
   
   - name: backend-chart
     required: true


### PR DESCRIPTION
## Description
Improves fallback schema inference for charts without native schemas. Unknown/null values remain unconstrained, integral values infer as integer, and `--delete-not-found` removes stale structural types. Includes unit and E2E coverage.

Changes:
  - Infer unknown/null values as {} instead of string.
  - Infer integral values as integer; retain number for fractional values.
  - Remove stale structural constraints for unknown values with `--delete-not-found`.
  - Update unit and generate-schema E2E coverage.

## Related Issue

Fixes #5332 

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
