### PR TITLE
fix(helm): inspect list items for connect strings and namespaces

### DIFF
--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/zarf-dev/zarf/src/pkg/state"
 
@@ -186,23 +187,7 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 	for _, resource := range resources {
 		// parse to unstructured to have access to more data than just the name
 		newContent, rawData, err := processManifestContent(resource.Content, func(obj *unstructured.Unstructured) error {
-			// Add the package label to all resources
-			labels := obj.GetLabels()
-			if labels == nil {
-				labels = map[string]string{}
-			}
-			obj.SetLabels(r.setPackageLabels(labels))
-			// Add the package label to pod templates (for Deployments, StatefulSets, etc.)
-			if err := r.addLabelsToNestedPath(obj, []string{"spec", "template", "metadata", "labels"}); err != nil {
-				return fmt.Errorf("failed to add labels to pod template: %w", err)
-			}
-			// In connected or YOLO mode, add agent ignore labels so the webhook doesn't mutate resources
-			if r.shouldAddAgentIgnoreLabels() {
-				if err := addAgentIgnoreLabels(obj); err != nil {
-					return err
-				}
-			}
-			return nil
+			return eachResource(obj, r.addZarfLabels)
 		})
 		if err != nil {
 			return err
@@ -259,6 +244,50 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 
 		// Finally place this back onto the output buffer
 		fmt.Fprintf(finalManifestsOutput, "---\n# Source: %s\n%s\n", resource.Name, resource.Content)
+	}
+	return nil
+}
+
+// eachResource calls modifyFn once for every resource a rendered manifest document contains.
+// Most documents hold a single resource, but a list kind like ConfigMapList or the generic List
+// holds one per item.
+// The metadata on a list is a ListMeta, which has no labels field, so whatever gets written there
+// is rejected by the API server. Helm flattens a list into its items before applying it anyway,
+// so the items are what we actually want to edit.
+func eachResource(obj *unstructured.Unstructured, modifyFn func(*unstructured.Unstructured) error) error {
+	// IsList only checks for a top level items array, so every kubernetes list kind ending in List
+	// is checked as well to keep a custom resource carrying its own items from looking like a list.
+	if obj.IsList() && strings.HasSuffix(obj.GetKind(), "List") {
+		// EachListItem shares the underlying map with each item, so edits made here end up
+		// in the manifest that gets marshaled back out
+		return obj.EachListItem(func(item runtime.Object) error {
+			itemObj, ok := item.(*unstructured.Unstructured)
+			if !ok {
+				return fmt.Errorf("unexpected item of type %T in %s", item, obj.GetKind())
+			}
+			return eachResource(itemObj, modifyFn)
+		})
+	}
+	return modifyFn(obj)
+}
+
+// addZarfLabels adds the zarf labels to a single resource
+func (r *renderer) addZarfLabels(obj *unstructured.Unstructured) error {
+	// Add the package label to all resources
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	obj.SetLabels(r.setPackageLabels(labels))
+	// Add the package label to pod templates (for Deployments, StatefulSets, etc.)
+	if err := r.addLabelsToNestedPath(obj, []string{"spec", "template", "metadata", "labels"}); err != nil {
+		return fmt.Errorf("failed to add labels to pod template: %w", err)
+	}
+	// In connected or YOLO mode, add agent ignore labels so the webhook doesn't mutate resources
+	if r.shouldAddAgentIgnoreLabels() {
+		if err := addAgentIgnoreLabels(obj); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/zarf-dev/zarf/src/pkg/state"
 
@@ -255,9 +254,9 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 // is rejected by the API server. Helm flattens a list into its items before applying it anyway,
 // so the items are what we actually want to edit.
 func eachResource(obj *unstructured.Unstructured, modifyFn func(*unstructured.Unstructured) error) error {
-	// IsList only checks for a top level items array, so every kubernetes list kind ending in List
-	// is checked as well to keep a custom resource carrying its own items from looking like a list.
-	if obj.IsList() && strings.HasSuffix(obj.GetKind(), "List") {
+	// IsList is the check the resource builder uses to decide what to flatten, so zarf and helm
+	// agree on which documents hold more than one resource
+	if obj.IsList() {
 		// EachListItem shares the underlying map with each item, so edits made here end up
 		// in the manifest that gets marshaled back out
 		return obj.EachListItem(func(item runtime.Object) error {

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -198,8 +198,7 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 			continue
 		}
 
-		switch rawData.GetKind() {
-		case "Namespace":
+		if rawData.GetKind() == "Namespace" {
 			namespace := &corev1.Namespace{}
 			// parse the namespace resource so it can be applied out-of-band by zarf instead of helm to avoid helm ns shenanigans
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawData.UnstructuredContent(), namespace); err != nil {
@@ -212,27 +211,15 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 			}
 			// skip so we can strip namespaces from helm's brain
 			continue
+		}
 
-		case "Service":
-			// Check service resources for the zarf-connect label
-			labels := rawData.GetLabels()
-			if labels == nil {
-				labels = map[string]string{}
-			}
-			annotations := rawData.GetAnnotations()
-			if annotations == nil {
-				annotations = map[string]string{}
-			}
-			if key, keyExists := labels[cluster.ZarfConnectLabelName]; keyExists {
-				// If there is a zarf-connect label
-				l.Debug("match helm service for zarf connection", "service", rawData.GetName(), "connectionKey", key)
-
-				// Add the connectString for processing later in the deployment
-				r.connectStrings[key] = state.ConnectString{
-					Description: annotations[cluster.ZarfConnectAnnotationDescription],
-					URL:         annotations[cluster.ZarfConnectAnnotationURL],
-				}
-			}
+		// a service inside a list is as connectable as one in its own document, so the items are
+		// checked too rather than only the document itself
+		if err := eachResource(rawData, func(obj *unstructured.Unstructured) error {
+			r.recordConnectString(ctx, obj)
+			return nil
+		}); err != nil {
+			return err
 		}
 
 		namespace := rawData.GetNamespace()
@@ -289,6 +276,33 @@ func (r *renderer) addZarfLabels(obj *unstructured.Unstructured) error {
 		}
 	}
 	return nil
+}
+
+// recordConnectString notes the connect string of a service carrying the zarf-connect label, for
+// the deployment to pick up later
+func (r *renderer) recordConnectString(ctx context.Context, obj *unstructured.Unstructured) {
+	if obj.GetKind() != "Service" {
+		return
+	}
+	// Check service resources for the zarf-connect label
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if key, keyExists := labels[cluster.ZarfConnectLabelName]; keyExists {
+		// If there is a zarf-connect label
+		logger.From(ctx).Debug("match helm service for zarf connection", "service", obj.GetName(), "connectionKey", key)
+
+		// Add the connectString for processing later in the deployment
+		r.connectStrings[key] = state.ConnectString{
+			Description: annotations[cluster.ZarfConnectAnnotationDescription],
+			URL:         annotations[cluster.ZarfConnectAnnotationURL],
+		}
+	}
 }
 
 // addLabelsToNestedPath adds package labels to a nested path in an unstructured object

--- a/src/internal/packager/helm/post-render.go
+++ b/src/internal/packager/helm/post-render.go
@@ -213,19 +213,14 @@ func (r *renderer) editHelmResources(ctx context.Context, resources []releaseuti
 			continue
 		}
 
-		// a service inside a list is as connectable as one in its own document, so the items are
-		// checked too rather than only the document itself
+		// connect strings and namespaces are read off each resource, which for a list kind means
+		// the items it holds rather than the list itself
 		if err := eachResource(rawData, func(obj *unstructured.Unstructured) error {
 			r.recordConnectString(ctx, obj)
+			r.trackNamespace(obj)
 			return nil
 		}); err != nil {
 			return err
-		}
-
-		namespace := rawData.GetNamespace()
-		if _, exists := r.namespaces[namespace]; !exists && namespace != "" {
-			// if this is the first time seeing this ns, we need to track that to create it as well
-			r.namespaces[namespace] = cluster.NewZarfManagedNamespace(namespace)
 		}
 
 		// Finally place this back onto the output buffer
@@ -302,6 +297,16 @@ func (r *renderer) recordConnectString(ctx context.Context, obj *unstructured.Un
 			Description: annotations[cluster.ZarfConnectAnnotationDescription],
 			URL:         annotations[cluster.ZarfConnectAnnotationURL],
 		}
+	}
+}
+
+// trackNamespace notes a namespace zarf has to create before helm applies the chart, since helm
+// does not create the namespaces its resources are placed in
+func (r *renderer) trackNamespace(obj *unstructured.Unstructured) {
+	namespace := obj.GetNamespace()
+	if _, exists := r.namespaces[namespace]; !exists && namespace != "" {
+		// if this is the first time seeing this ns, we need to track that to create it as well
+		r.namespaces[namespace] = cluster.NewZarfManagedNamespace(namespace)
 	}
 }
 

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -4,6 +4,8 @@
 package helm
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,8 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/pkg/pki"
 	"github.com/zarf-dev/zarf/src/pkg/state"
+	"github.com/zarf-dev/zarf/src/test/testutil"
+	releaseutil "helm.sh/helm/v4/pkg/release/v1/util"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
@@ -533,4 +539,252 @@ func TestProcessManifestContentEmptyObject(t *testing.T) {
 	require.Equal(t, emptyManifest, outputContent)
 	require.NotNil(t, rawData)
 	require.Empty(t, rawData.Object)
+}
+
+func TestEditHelmResourcesListDocuments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest string
+		assert   func(t *testing.T, doc *unstructured.Unstructured)
+	}{
+		{
+			name: "typed list wrapper is left alone and its items are labeled",
+			manifest: `apiVersion: v1
+kind: ConfigMapList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: repro-one
+    data:
+      hello: world
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: repro-two
+      labels:
+        grafana_dashboard: "1"
+    data:
+      hello: world
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				// ListMeta has no labels field, a list that carries one is rejected by the API server
+				_, found, err := unstructured.NestedMap(doc.Object, "metadata")
+				require.NoError(t, err)
+				require.False(t, found, "list wrapper must not be given metadata")
+
+				items, err := listItems(doc)
+				require.NoError(t, err)
+				require.Len(t, items, 2)
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, items[0].GetLabels())
+				require.Equal(t, map[string]string{
+					"grafana_dashboard": "1",
+					"zarf.dev/package":  "test-pkg",
+				}, items[1].GetLabels(), "existing item labels are kept")
+
+				// nothing else about the item changed
+				data, found, err := unstructured.NestedStringMap(items[0].Object, "data")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, map[string]string{"hello": "world"}, data)
+			},
+		},
+		{
+			name: "generic list labels pod templates of its items",
+			manifest: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nested-deploy
+    spec:
+      template:
+        metadata:
+          labels:
+            app: nested
+        spec:
+          containers:
+            - name: main
+              image: nginx
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				items, err := listItems(doc)
+				require.NoError(t, err)
+				require.Len(t, items, 1)
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, items[0].GetLabels())
+
+				templateLabels, found, err := unstructured.NestedStringMap(items[0].Object, "spec", "template", "metadata", "labels")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, map[string]string{
+					"app":              "nested",
+					"zarf.dev/package": "test-pkg",
+				}, templateLabels)
+			},
+		},
+		{
+			name: "list nested in a list is walked all the way down",
+			manifest: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMapList
+    items:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: deeply-nested
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				outer, err := listItems(doc)
+				require.NoError(t, err)
+				require.Len(t, outer, 1)
+				require.Nil(t, outer[0].GetLabels(), "nested list wrapper must not be given metadata")
+
+				inner, err := listItems(outer[0])
+				require.NoError(t, err)
+				require.Len(t, inner, 1)
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, inner[0].GetLabels())
+			},
+		},
+		{
+			name: "list that rendered no items is left alone",
+			manifest: `apiVersion: v1
+kind: ConfigMapList
+items: []
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				_, found, err := unstructured.NestedMap(doc.Object, "metadata")
+				require.NoError(t, err)
+				require.False(t, found, "empty list wrapper must not be given metadata")
+			},
+		},
+		{
+			name: "list kind whose items is not an array is labeled itself",
+			manifest: `apiVersion: example.com/v1
+kind: ShoppingList
+metadata:
+  name: groceries
+items:
+  milk: 2
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, doc.GetLabels(),
+					"a resource that is not a list wrapper must not be left unlabeled")
+			},
+		},
+		{
+			name: "custom resource with an items field is labeled itself",
+			manifest: `apiVersion: example.com/v1
+kind: Basket
+metadata:
+  name: basket
+items:
+  - apple
+  - banana
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, doc.GetLabels())
+				items, found, err := unstructured.NestedStringSlice(doc.Object, "items")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, []string{"apple", "banana"}, items, "the items must be left alone")
+			},
+		},
+		{
+			name: "regular resource is still labeled",
+			manifest: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plain-cm
+`,
+			assert: func(t *testing.T, doc *unstructured.Unstructured) {
+				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, doc.GetLabels())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc := renderManifest(t, newTestRenderer(), tt.manifest)
+			tt.assert(t, doc)
+		})
+	}
+}
+
+func TestEditHelmResourcesAgentIgnoreLabelsOnListItems(t *testing.T) {
+	t.Parallel()
+
+	manifest := `apiVersion: v1
+kind: List
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nested-deploy
+    spec:
+      template:
+        metadata:
+          labels:
+            app: nested
+`
+
+	r := newTestRenderer()
+	r.connectedDeploy = true
+	r.state = &state.State{
+		AgentInfo: state.AgentInfo{TLS: pki.GeneratedPKI{
+			CA:   []byte("ca"),
+			Cert: []byte("cert"),
+			Key:  []byte("key"),
+		}},
+	}
+	require.True(t, r.shouldAddAgentIgnoreLabels())
+
+	doc := renderManifest(t, r, manifest)
+	items, err := listItems(doc)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	templateLabels, found, err := unstructured.NestedStringMap(items[0].Object, "spec", "template", "metadata", "labels")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "ignore", templateLabels["zarf.dev/agent"])
+}
+
+func newTestRenderer() *renderer {
+	return &renderer{
+		pkgName:        "test-pkg",
+		connectStrings: state.ConnectStrings{},
+		namespaces:     map[string]*corev1.Namespace{},
+	}
+}
+
+// renderManifest puts one manifest document through editHelmResources and hands back what it wrote
+func renderManifest(t *testing.T, r *renderer, manifest string) *unstructured.Unstructured {
+	t.Helper()
+
+	output := bytes.NewBuffer(nil)
+	err := r.editHelmResources(testutil.TestContext(t), []releaseutil.Manifest{{Name: "test-manifest", Content: manifest}}, output)
+	require.NoError(t, err)
+
+	doc := &unstructured.Unstructured{}
+	require.NoError(t, yaml.Unmarshal(output.Bytes(), doc))
+	return doc
+}
+
+func listItems(doc *unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	var items []*unstructured.Unstructured
+	err := doc.EachListItem(func(item runtime.Object) error {
+		itemObj, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected item of type %T", item)
+		}
+		items = append(items, itemObj)
+		return nil
+	})
+	return items, err
 }

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -760,7 +760,7 @@ metadata:
 		{
 			name: "service inside a list",
 			manifest: `apiVersion: v1
-kind: List
+kind: ServiceList
 items:
   - apiVersion: v1
     kind: Service
@@ -787,6 +787,48 @@ items:
 					URL:         "/nested",
 				},
 			}, r.connectStrings)
+		})
+	}
+}
+
+func TestEditHelmResourcesTracksNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest string
+	}{
+		{
+			name: "configmap in its own document",
+			manifest: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elsewhere
+  namespace: another-namespace
+`,
+		},
+		{
+			name: "configmap inside a list",
+			manifest: `apiVersion: v1
+kind: ConfigMapList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: elsewhere
+      namespace: another-namespace
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRenderer()
+			renderManifest(t, r, tt.manifest)
+			// the namespace has to be tracked for zarf to create it before helm applies the chart
+			require.Contains(t, r.namespaces, "another-namespace")
 		})
 	}
 }

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -737,6 +737,75 @@ items:
 	require.Equal(t, "ignore", templateLabels["zarf.dev/agent"])
 }
 
+func TestEditHelmResourcesConnectStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest string
+	}{
+		{
+			name: "service in its own document",
+			manifest: `apiVersion: v1
+kind: Service
+metadata:
+  name: connect-me
+  labels:
+    zarf.dev/connect-name: my-connect
+  annotations:
+    zarf.dev/connect-description: a connectable service
+    zarf.dev/connect-url: /nested
+`,
+		},
+		{
+			name: "service inside a list",
+			manifest: `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: connect-me
+      labels:
+        zarf.dev/connect-name: my-connect
+      annotations:
+        zarf.dev/connect-description: a connectable service
+        zarf.dev/connect-url: /nested
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRenderer()
+			renderManifest(t, r, tt.manifest)
+			require.Equal(t, state.ConnectStrings{
+				"my-connect": {
+					Description: "a connectable service",
+					URL:         "/nested",
+				},
+			}, r.connectStrings)
+		})
+	}
+}
+
+func TestEditHelmResourcesConnectStringsIgnoresUnlabeledService(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	renderManifest(t, r, `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: plain-service
+`)
+	require.Empty(t, r.connectStrings)
+}
+
 func newTestRenderer() *renderer {
 	return &renderer{
 		pkgName:        "test-pkg",

--- a/src/internal/packager/helm/post-render_test.go
+++ b/src/internal/packager/helm/post-render_test.go
@@ -677,24 +677,6 @@ items:
 			},
 		},
 		{
-			name: "custom resource with an items field is labeled itself",
-			manifest: `apiVersion: example.com/v1
-kind: Basket
-metadata:
-  name: basket
-items:
-  - apple
-  - banana
-`,
-			assert: func(t *testing.T, doc *unstructured.Unstructured) {
-				require.Equal(t, map[string]string{"zarf.dev/package": "test-pkg"}, doc.GetLabels())
-				items, found, err := unstructured.NestedStringSlice(doc.Object, "items")
-				require.NoError(t, err)
-				require.True(t, found)
-				require.Equal(t, []string{"apple", "banana"}, items, "the items must be left alone")
-			},
-		},
-		{
 			name: "regular resource is still labeled",
 			manifest: `apiVersion: v1
 kind: ConfigMap

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -320,6 +320,10 @@ func TestHelmListKinds(t *testing.T) {
 	require.NoError(t, err, stdOut, stdErr)
 
 	pkgPath := filepath.Join(tmpdir, fmt.Sprintf("zarf-package-list-kinds-%s-0.1.0.tar.zst", e2e.Arch))
+	t.Cleanup(func() {
+		_, _, err := e2e.Kubectl(t, "delete", "namespace", "list-kinds-elsewhere", "--ignore-not-found", "--grace-period=0")
+		require.NoError(t, err)
+	})
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgPath, "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 
@@ -335,6 +339,11 @@ func TestHelmListKinds(t *testing.T) {
 	kubectlOut, _, err = e2e.Kubectl(t, "-n", "list-kinds", "get", "configmap", "list-two", "-o", "jsonpath={.metadata.labels.chart-owned}")
 	require.NoError(t, err)
 	require.Equal(t, "true", kubectlOut)
+
+	// an item can name a namespace of its own, which zarf has to create before helm applies it
+	kubectlOut, _, err = e2e.Kubectl(t, "-n", "list-kinds-elsewhere", "get", "configmap", "list-elsewhere", "-o", "jsonpath={.metadata.name}")
+	require.NoError(t, err)
+	require.Equal(t, "list-elsewhere", kubectlOut)
 
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "list-kinds", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)

--- a/src/test/e2e/25_helm_test.go
+++ b/src/test/e2e/25_helm_test.go
@@ -309,3 +309,33 @@ func TestHelmHooks(t *testing.T) {
 	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "helm-hooks", "--confirm")
 	require.NoError(t, err, stdOut, stdErr)
 }
+
+func TestHelmListKinds(t *testing.T) {
+	t.Log("E2E: Helm charts that render list kinds")
+
+	tmpdir := t.TempDir()
+	packagePath := filepath.Join("src", "test", "packages", "25-list-kinds")
+
+	stdOut, stdErr, err := e2e.Zarf(t, "package", "create", packagePath, "-o", tmpdir, "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+
+	pkgPath := filepath.Join(tmpdir, fmt.Sprintf("zarf-package-list-kinds-%s-0.1.0.tar.zst", e2e.Arch))
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "deploy", pkgPath, "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+
+	// the configmaps only exist if helm accepted the list documents, and they only carry the
+	// package label if zarf labeled the items rather than the list wrapping them
+	kubectlOut, _, err := e2e.Kubectl(t, "-n", "list-kinds", "get", "configmaps", "-l", "zarf.dev/package=list-kinds", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	require.Contains(t, kubectlOut, "list-one")
+	require.Contains(t, kubectlOut, "list-two")
+	require.Contains(t, kubectlOut, "generic-list-config")
+
+	// labels the chart set on an item are kept alongside the ones zarf adds
+	kubectlOut, _, err = e2e.Kubectl(t, "-n", "list-kinds", "get", "configmap", "list-two", "-o", "jsonpath={.metadata.labels.chart-owned}")
+	require.NoError(t, err)
+	require.Equal(t, "true", kubectlOut)
+
+	stdOut, stdErr, err = e2e.Zarf(t, "package", "remove", "list-kinds", "--confirm")
+	require.NoError(t, err, stdOut, stdErr)
+}

--- a/src/test/packages/25-list-kinds/chart/Chart.yaml
+++ b/src/test/packages/25-list-kinds/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: list-kinds
+description: A chart that renders its resources inside list kinds
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/src/test/packages/25-list-kinds/chart/templates/configmaps.yaml
+++ b/src/test/packages/25-list-kinds/chart/templates/configmaps.yaml
@@ -17,3 +17,16 @@ items:
         chart-owned: "true"
     data:
       message: "second item of a ConfigMapList"
+---
+apiVersion: v1
+kind: ConfigMapList
+items:
+  # zarf has to create this namespace before helm applies the item, which it can only do if it
+  # reads the namespace off the items rather than off the list
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: list-elsewhere
+      namespace: list-kinds-elsewhere
+    data:
+      message: "an item pointing at a namespace nothing else creates"

--- a/src/test/packages/25-list-kinds/chart/templates/configmaps.yaml
+++ b/src/test/packages/25-list-kinds/chart/templates/configmaps.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMapList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: list-one
+      namespace: {{ .Release.Namespace }}
+    data:
+      message: "first item of a ConfigMapList"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: list-two
+      namespace: {{ .Release.Namespace }}
+      labels:
+        chart-owned: "true"
+    data:
+      message: "second item of a ConfigMapList"

--- a/src/test/packages/25-list-kinds/chart/templates/generic-list.yaml
+++ b/src/test/packages/25-list-kinds/chart/templates/generic-list.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: generic-list-config
+      namespace: {{ .Release.Namespace }}
+    data:
+      message: "item of a generic List"

--- a/src/test/packages/25-list-kinds/zarf.yaml
+++ b/src/test/packages/25-list-kinds/zarf.yaml
@@ -1,0 +1,13 @@
+kind: ZarfPackageConfig
+metadata:
+  name: list-kinds
+  version: 0.1.0
+
+components:
+  - name: list-kinds
+    required: true
+    charts:
+      - name: list-kinds
+        version: 0.1.0
+        namespace: list-kinds
+        localPath: chart


### PR DESCRIPTION
> [!NOTE]
> Depends on #5344. That PR's two commits are included in the diff below until it merges;
> only the last commit belongs to this one.

## Description

Zarf inspected only the top-level manifest document, so resources inside a typed list were invisible to two checks. A `Service` carrying `zarf.dev/connect-name` never registered a connect string, and a namespace named only by list items was never tracked. The second is a hard failure, since Zarf creates namespaces before Helm applies:

```
server-side apply failed for object list-kinds-elsewhere/list-elsewhere
/v1, Kind=ConfigMap: namespaces "list-kinds-elsewhere" not found
```

Both now run through the `eachResource` helper from #5344, which walks a list's items. Neither is new behaviour; it's what a resource in its own document already gets, including namespace adoption under `takeOwnership`.

The Namespace kind case stays document-level. It works by dropping the whole document so Zarf can create the namespace out of band, and there's no per-item equivalent of that.

### Not included

Namespace tracking has the same blind spot: `rawData.GetNamespace()` reads the wrapper's
`ListMeta` and returns `""`, so a namespace referenced only by list items is never tracked. That
one isn't as simple, because `r.namespaces` feeds `adoptAndUpdateNamespaces`, which creates
namespaces and adopts existing ones under `takeOwnership`, so fixing it changes who owns those
namespaces.

## Related Issue

Relates to #5343

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/zarf-dev/zarf/blob/main/CONTRIBUTING.md#developer-workflow) followed
